### PR TITLE
Stricter linting and improved DX

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"],
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "editor.formatOnSave": true,
+  "eslint.rules.customizations": [
+    { "rule": "*", "severity": "warn" }
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib",
+}

--- a/package.json
+++ b/package.json
@@ -42,16 +42,15 @@
     "*.d.ts"
   ],
   "scripts": {
-    "chromatic": "chromatic -t 9b39ff142a7f",
     "build": "tsup",
     "build:staging": "CHROMATIC_BASE_URL=https://www.staging-chromatic.com tsup",
     "build:watch": "pnpm run build --watch",
-    "lint": "eslint src",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "run-p build:watch 'storybook --quiet'",
+    "build-storybook": "storybook build",
+    "chromatic": "chromatic -t 9b39ff142a7f",
+    "lint": "eslint src --max-warnings 0 --report-unused-disable-directives",
     "release": "pnpm run build && auto shipit",
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "start": "run-p build:watch 'storybook --quiet'",
+    "storybook": "storybook dev -p 6006"
   },
   "dependencies": {
     "@storybook/design-system": "^7.15.11",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,11 @@ async function serverChannel(channel: Channel, { projectToken }: { projectToken:
       },
       options: {
         onTaskComplete(ctx: any) {
+          // eslint-disable-next-line no-console
           console.log(`Completed task '${ctx.title}'`);
           if (ctx.announcedBuild && !sent) {
             const { id, number, app } = ctx.announcedBuild;
+            // eslint-disable-next-line no-console
             console.log("emitting", BUILD_STARTED);
             channel.emit(BUILD_STARTED, {
               id,

--- a/src/utils/useSignIn.ts
+++ b/src/utils/useSignIn.ts
@@ -57,6 +57,7 @@ const pollForAccessToken = async (options: {
       onFailure(data);
     }
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error(err);
   }
 };
@@ -107,8 +108,10 @@ const signInWithRetry = async (options: {
     onSuccess,
     onFailure(authResp: any) {
       if (betaUserAccessDenied(authResp)) {
+        // eslint-disable-next-line no-alert
         alert("You must be a beta user to use this addon at this time.");
       } else {
+        // eslint-disable-next-line no-console
         console.warn(authResp);
         onFailure();
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "esModuleInterop": true,
     "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
     "incremental": false,
     "isolatedModules": true,
     "jsx": "react",


### PR DESCRIPTION
This follows (some) advice from a [great talk](https://www.youtube.com/watch?v=sSJBeWPIipQ) on configuring ESLint for a TS React project.

Warnings are configured to break the build, so we don't get sloppy and ignore them.
Unused eslint-disable directives are reported so they behave similar to `@ts-expect-error`, which means we'll know when such a directive can be removed.
VSCode is configured with recommended extensions and sensible format/fix settings, and to highlight lint errors as warnings (yellow squigglies) to disambiguate from type errors.