### PR TITLE
Add very basic install instructions with details on how to work around jackspeak issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,86 +2,36 @@
 
 Visual Testing addon with Chromatic
 
-### Development scripts
+## Installation
 
-- `pnpm run start` runs babel in watch mode and starts Storybook
-- `pnpm run build` build and package your addon code
+Add the `@chromaui/visual-tests` addon, and add it to `main.js`:
 
-## What's included?
-
-![Demo](https://user-images.githubusercontent.com/42671/107857205-e7044380-6dfa-11eb-8718-ad02e3ba1a3f.gif)
-
-The addon code lives in `src`. It demonstrates all core addon related concepts. The three [UI paradigms](https://storybook.js.org/docs/react/addons/addon-types#ui-based-addons)
-
-- `src/Tool.tsx`
-- `src/Panel.tsx`
-- `src/Tab.tsx`
-
-Which, along with the addon itself, are registered in `src/manager.ts`.
-
-Managing State and interacting with a story:
-
-- `src/withGlobals.ts` & `src/Tool.tsx` demonstrates how to use `useGlobals` to manage global state and modify the contents of a Story.
-- `src/withRoundTrip.ts` & `src/Panel.tsx` demonstrates two-way communication using channels.
-- `src/Tab.tsx` demonstrates how to use `useParameter` to access the current story's parameters.
-
-Your addon might use one or more of these patterns. Feel free to delete unused code. Update `src/manager.ts` and `src/preview.ts` accordingly.
-
-Lastly, configure you addon name in `src/constants.ts`.
-
-### Metadata
-
-Storybook addons are listed in the [catalog](https://storybook.js.org/addons) and distributed via npm. The catalog is populated by querying npm's registry for Storybook-specific metadata in `package.json`. This project has been configured with sample data. Learn more about available options in the [Addon metadata docs](https://storybook.js.org/docs/react/addons/addon-catalog#addon-metadata).
-
-## Release Management
-
-### Setup
-
-This project is configured to use [auto](https://github.com/intuit/auto) for release management. It generates a changelog and pushes it to both GitHub and npm. Therefore, you need to configure access to both:
-
-- [`NPM_TOKEN`](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-access-tokens) Create a token with both _Read and Publish_ permissions.
-- [`GH_TOKEN`](https://github.com/settings/tokens) Create a token with the `repo` scope.
-
-Then open your `package.json` and edit the following fields:
-
-- `name`
-- `author`
-- `repository`
-
-#### Local
-
-To use `auto` locally create a `.env` file at the root of your project and add your tokens to it:
-
-```bash
-GH_TOKEN=<value you just got from GitHub>
-NPM_TOKEN=<value you just got from npm>
+```
+yarn add --dev @chromaui/visual-tests
 ```
 
-Lastly, **create labels on GitHub**. You’ll use these labels in the future when making changes to the package.
-
-```bash
-npx auto create-labels
+```
+// main.js:
+"addons": ["@chromaui/visual-tests"]
 ```
 
-If you check on GitHub, you’ll now see a set of labels that `auto` would like you to use. Use these to tag future pull requests.
+### Troubleshooting
 
-#### GitHub Actions
+If you see:
 
-This template comes with GitHub actions already set up to publish your addon anytime someone pushes to your repository.
+```
+var stringWidth = require('string-width')
+                  ^
 
-Go to `Settings > Secrets`, click `New repository secret`, and add your `NPM_TOKEN`.
-
-### Creating a release
-
-To create a release locally you can run the following command, otherwise the GitHub action will make the release for you.
-
-```sh
-pnpm run release
+Error [ERR_REQUIRE_ESM]: require() of ES Module /Users
 ```
 
-That will:
+In Yarn 1 starting up your Storybook after installation, you can [workaround with](https://github.com/storybookjs/storybook/issues/22431#issuecomment-1630086092):
 
-- Build and package the addon code
-- Bump the version
-- Push a release to GitHub and npm
-- Push a changelog to GitHub
+```
+ "resolutions": {
+    "jackspeak": "2.1.1"
+  }
+```
+
+Alternatively, you could use a different package manager (yarn 3, npm, pnpm).


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.4-canary.12.d2ccc49.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.4-canary.12.d2ccc49.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.4-canary.12.d2ccc49.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
