### PR TITLE
add code to read the projectId over event

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,8 @@ export const START_BUILD = `${ADDON_ID}/startBuild`;
 export const BUILD_STARTED = `${ADDON_ID}/buildStarted`;
 
 export const UPDATE_PROJECT = `${ADDON_ID}/updateProject`;
+export const READ_PROJECT = `${ADDON_ID}/readProject`;
+export const RESPOND_PROJECT = `${ADDON_ID}/respondProject`;
 export type UpdateProjectPayload = {
   projectId: string;
   projectToken: string;

--- a/src/utils/useProjectId.ts
+++ b/src/utils/useProjectId.ts
@@ -1,7 +1,7 @@
 import { useChannel } from "@storybook/manager-api";
-import React from "react";
+import React, { useEffect } from "react";
 
-import { UPDATE_PROJECT, UpdateProjectPayload } from "../constants";
+import { READ_PROJECT, RESPOND_PROJECT, UPDATE_PROJECT, UpdateProjectPayload } from "../constants";
 
 const { CHROMATIC_PROJECT_ID } = process.env;
 
@@ -14,7 +14,15 @@ export const useProjectId = (): [
   const [projectId, setProjectId] = React.useState<string | null>(CHROMATIC_PROJECT_ID);
   const [projectIdChanged, setProjectIdChanged] = React.useState(false);
 
-  const emit = useChannel({});
+  const emit = useChannel({
+    [RESPOND_PROJECT]: (payload: { projectId: string }) => {
+      setProjectId(payload.projectId);
+      setProjectIdChanged(true);
+    },
+  });
+  useEffect(() => {
+    emit(READ_PROJECT);
+  }, []);
 
   const updateProject = (newProjectId: string, projectToken: string) => {
     emit(UPDATE_PROJECT, { projectId: newProjectId, projectToken } as UpdateProjectPayload);


### PR DESCRIPTION
@tmeasday sort of a POC how I'd do it.

I did not run the code, so might not work fully
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.4-canary.15.4c0149a.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.4-canary.15.4c0149a.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.4-canary.15.4c0149a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
