### PR TITLE
Don't force node@18 for package consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/chromaui/storybook-visual-tests"
+    "url": "https://github.com/chromaui/addon-visual-tests"
   },
   "license": "MIT",
   "author": "Chromatic <tom@chromatic.com>",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Visual Testing addon with Chromatic",
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=16.0.0",
     "yarn": ">=1.22.18"
   },
   "keywords": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 export const { CHROMATIC_BASE_URL } = process.env;
 
-export const ADDON_ID = "chromaui/storybook-visual-tests";
+export const ADDON_ID = "chromaui/addon-visual-tests";
 export const TOOL_ID = `${ADDON_ID}/tool`;
 export const PANEL_ID = `${ADDON_ID}/panel`;
 export const ACCESS_TOKEN_KEY = `${ADDON_ID}/access-token/${CHROMATIC_BASE_URL}`;


### PR DESCRIPTION
<img width="733" alt="image" src="https://github.com/chromaui/addon-visual-tests/assets/132554/98faad09-38a3-412d-b206-78bcd589395d">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.11--canary.19.0c08673.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.11--canary.19.0c08673.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.11--canary.19.0c08673.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
