### PR TITLE
Store last build ID by branch name

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -35,7 +35,7 @@ const initialGitInfo: GitInfo = {
 
 logger.debug("Initial Git info:", initialGitInfo);
 
-const storedBuildId = localStorage.getItem(DEV_BUILD_ID_KEY);
+const storedBuildId = localStorage.getItem(`${DEV_BUILD_ID_KEY}:${GIT_BRANCH}`);
 
 export const Panel = ({ active }: PanelProps) => {
   const api = useStorybookApi();
@@ -52,11 +52,14 @@ export const Panel = ({ active }: PanelProps) => {
       [BUILD_STARTED]: () => setIsStarting(false),
       [BUILD_ANNOUNCED]: (buildId: string) => {
         setLastBuildId(buildId);
-        localStorage.setItem(DEV_BUILD_ID_KEY, buildId);
+        localStorage.setItem(`${DEV_BUILD_ID_KEY}:${gitInfo.branch}`, buildId);
       },
-      [GIT_INFO]: (info: GitInfo) => {
-        setGitInfo(info);
+      [GIT_INFO]: (info: GitInfo, prevInfo: GitInfo) => {
         logger.debug("Updated Git info:", info);
+        setGitInfo(info);
+        if (info.branch !== prevInfo.branch) {
+          setLastBuildId(localStorage.getItem(`${DEV_BUILD_ID_KEY}:${info.branch}`));
+        }
       },
     },
     []

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ async function serverChannel(
     }
   );
 
-  observeGitInfo(5000, (info) => channel.emit(GIT_INFO, info));
+  observeGitInfo(5000, (info, prevInfo) => channel.emit(GIT_INFO, info, prevInfo));
 
   return channel;
 }


### PR DESCRIPTION
This should ensure we show the last local build for the _current_ branch rather than the last local build for _any_ branch.