### PR TITLE
Ensure we actually typecheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,8 @@ jobs:
       - name: Lint
         run: yarn lint
 
+      - name: Typecheck
+        run: yarn typecheck
+
       - name: Test
         run: yarn test

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "start": "run-p build:watch 'storybook --quiet'",
     "prerelease": "zx scripts/prepublish-checks.mjs",
     "storybook": "CHROMATIC_ADDON_NAME='../dist/index.js' storybook dev -p 6006",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noemit"
   },
   "dependencies": {
     "@storybook/csf-tools": "^7.3.0",

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -2,7 +2,8 @@ import { Badge as BaseBadge } from "@storybook/components";
 import { styled } from "@storybook/theming";
 import { ReactNode } from "react";
 
-export const Badge: typeof BaseBadge = styled(BaseBadge)<{ children?: ReactNode }>({
+// NOTE: The `Badge` exported by `@storybook/components` incorrectly isn't typed to accept children
+export const Badge = styled(BaseBadge)<{ children?: ReactNode }>({
   padding: "4px 8px",
   margin: "0 6px",
 });

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -2,8 +2,10 @@ import { Badge as BaseBadge } from "@storybook/components";
 import { styled } from "@storybook/theming";
 import { ReactNode } from "react";
 
+type BadgeProps = React.ComponentProps<typeof BaseBadge>;
+
 // NOTE: The `Badge` exported by `@storybook/components` incorrectly isn't typed to accept children
-export const Badge = styled(BaseBadge)<{ children?: ReactNode }>({
+export const Badge: React.FC<BadgeProps & { children?: ReactNode }> = styled(BaseBadge)({
   padding: "4px 8px",
   margin: "0 6px",
 });

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -556,6 +556,13 @@ export type Image = {
   imageWidth: Scalars['Int']['output'];
 };
 
+export type LocalBuildsSpecifierInput = {
+  /** If set, only return builds with isLocalBuild set to this value */
+  isLocalBuild?: InputMaybe<Scalars['Boolean']['input']>;
+  /** If set, return all global builds, and only local builds from this email hash */
+  localBuildEmailHash?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   bulkCreateFigmaMetadata: Array<FigmaMetadata>;
@@ -753,6 +760,7 @@ export type ProjectBranchNamesArgs = {
 export type ProjectLastBuildArgs = {
   branches?: InputMaybe<Array<Scalars['String']['input']>>;
   defaultBranch?: InputMaybe<Scalars['Boolean']['input']>;
+  localBuilds?: InputMaybe<LocalBuildsSpecifierInput>;
   results?: InputMaybe<Array<BuildResult>>;
   slug?: InputMaybe<Scalars['String']['input']>;
   statuses?: InputMaybe<Array<BuildStatus>>;

--- a/src/screens/LinkProject/LinkProject.stories.tsx
+++ b/src/screens/LinkProject/LinkProject.stories.tsx
@@ -88,7 +88,13 @@ export const SelectProject: Story = {
 };
 
 export const Linked: Story = {
-  render: () => <LinkedProject projectId="789" goToNext={action("goToNext")} />,
+  render: () => (
+    <LinkedProject
+      projectId="789"
+      goToNext={action("goToNext")}
+      setAccessToken={action("setAccessToken")}
+    />
+  ),
   parameters: {
     ...withFigmaDesign(
       "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=330-472759&t=3EAIRe8423CpOQWY-4"

--- a/src/screens/VisualTests/BuildInfo.stories.ts
+++ b/src/screens/VisualTests/BuildInfo.stories.ts
@@ -9,7 +9,8 @@ const meta = {
   component: BuildInfo,
   args: {
     isOutdated: false,
-    runDevBuild: action("runDevBuild"),
+    startDevBuild: action("startDevBuild"),
+    isStarting: false,
   },
 } satisfies Meta<typeof BuildInfo>;
 

--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -151,9 +151,9 @@ const meta = {
     },
     storyId: "button--primary",
     projectId: "Project:id123",
-    runDevBuild: action("runDevBuild"),
+    startDevBuild: action("startDevBuild"),
+    isStarting: false,
     setAccessToken: action("setAccessToken"),
-    setIsRunning: action("setIsRunning"),
     updateBuildStatus: action("updateBuildStatus"),
   },
 } satisfies Meta<typeof VisualTests>;


### PR DESCRIPTION
I noticed there were a few broken types in the code base. I guess that'll happen when nothing actually breaks if they break.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.23--canary.35.dd82bf8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.23--canary.35.dd82bf8.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.23--canary.35.dd82bf8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
