### PR TITLE
Read configDir and use for `main.js` location

### DIFF
--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -556,6 +556,13 @@ export type Image = {
   imageWidth: Scalars['Int']['output'];
 };
 
+export type LocalBuildsSpecifierInput = {
+  /** If set, only return builds with isLocalBuild set to this value */
+  isLocalBuild?: InputMaybe<Scalars['Boolean']['input']>;
+  /** If set, return all global builds, and only local builds from this email hash */
+  localBuildEmailHash?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   bulkCreateFigmaMetadata: Array<FigmaMetadata>;
@@ -753,6 +760,7 @@ export type ProjectBranchNamesArgs = {
 export type ProjectLastBuildArgs = {
   branches?: InputMaybe<Array<Scalars['String']['input']>>;
   defaultBranch?: InputMaybe<Scalars['Boolean']['input']>;
+  localBuilds?: InputMaybe<LocalBuildsSpecifierInput>;
   results?: InputMaybe<Array<BuildResult>>;
   slug?: InputMaybe<Scalars['String']['input']>;
   statuses?: InputMaybe<Array<BuildStatus>>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ const observeGitInfo = async (
 
 async function serverChannel(
   channel: Channel,
-  { projectToken: initialProjectToken }: { projectToken: string }
+  { configDir, projectToken: initialProjectToken }: { configDir: string; projectToken: string }
 ) {
   let projectToken = initialProjectToken;
   channel.on(START_BUILD, async () => {
@@ -81,7 +81,7 @@ async function serverChannel(
     async ({ projectId, projectToken: updatedProjectToken }: UpdateProjectPayload) => {
       projectToken = updatedProjectToken;
 
-      const mainPath = await findConfig("main");
+      const mainPath = await findConfig(configDir, "main");
       const MainConfig = await readConfig(mainPath);
 
       const addonsConfig = MainConfig.getFieldValue(["addons"]);

--- a/src/utils/storybook.config.utils.ts
+++ b/src/utils/storybook.config.utils.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { join } from "node:path";
 
 const SUPPORTED_EXTENSIONS = ["js", "ts", "tsx", "jsx"] as const;
 
@@ -8,8 +9,8 @@ const pathExists = (f: string) =>
     () => false
   );
 
-export const findConfig = async (prefix: string) => {
-  const filenames = SUPPORTED_EXTENSIONS.map((ext) => `.storybook/${prefix}.${ext}`);
+export const findConfig = async (configDir: string, prefix: string) => {
+  const filenames = SUPPORTED_EXTENSIONS.map((ext) => join(configDir, `${prefix}.${ext}`));
   const exists = await Promise.all(filenames.map(pathExists));
 
   const idx = exists.findIndex((e) => e);


### PR DESCRIPTION
To QA:

1. `cd src`
2. Remove existing config from `main.js`
3. `CHROMATIC_ADDON_NAME='../dist/index.js' ../node_modules/.bin/storybook dev -c ../.storybook -p 6006`
4. Select a project, check `main.js` has id/token

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.25--canary.39.7d57e7f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.25--canary.39.7d57e7f.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.25--canary.39.7d57e7f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
