### PR TITLE
Implement UI for 'project linked' screen

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -7,4 +7,5 @@ export const Container = styled.div(({ theme }) => ({
   alignItems: "center",
   justifyContent: "center",
   height: "100%",
+  padding: 10,
 }));

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -2,7 +2,7 @@ import { color, styled } from "@storybook/theming";
 
 export const Text = styled.p({
   color: color.mediumdark,
-  margin: 8,
+  margin: "8px 0",
   lineHeight: "18px",
   textAlign: "center",
   textWrap: "balance",

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -44,6 +44,12 @@ export const Text = styled.div(({ theme }) => ({
   b: {
     color: theme.color.defaultText,
   },
+  code: {
+    fontSize: theme.typography.size.s1,
+    border: `1px solid ${theme.color.border}`,
+    borderRadius: 3,
+    padding: "0 3px",
+  },
   small: {
     fontSize: theme.typography.size.s1,
   },

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -382,6 +382,7 @@ export type CompletedBuildTestsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<CompletedBuildTestsOrder>;
+  statuses?: InputMaybe<Array<TestStatus>>;
   storyId?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -683,6 +684,7 @@ export type PreparedBuildTestsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<PreparedBuildTestsOrder>;
+  statuses?: InputMaybe<Array<TestStatus>>;
   storyId?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -956,6 +958,7 @@ export type StartedBuildTestsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<StartedBuildTestsOrder>;
+  statuses?: InputMaybe<Array<TestStatus>>;
   storyId?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/src/screens/LinkProject/LinkProject.stories.tsx
+++ b/src/screens/LinkProject/LinkProject.stories.tsx
@@ -97,7 +97,7 @@ export const Linked: Story = {
   ),
   parameters: {
     ...withFigmaDesign(
-      "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=330-472759&t=3EAIRe8423CpOQWY-4"
+      "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=508-317094&t=435fylbu7gUQNEgq-4"
     ),
   },
 };

--- a/src/screens/LinkProject/LinkedProject.tsx
+++ b/src/screens/LinkProject/LinkedProject.tsx
@@ -1,4 +1,5 @@
-import { Icon } from "@storybook/design-system";
+import { Icons, Link } from "@storybook/components";
+import { styled } from "@storybook/theming";
 import React from "react";
 import { useQuery } from "urql";
 
@@ -10,6 +11,15 @@ import { Bar, Col, Section, Sections, Text } from "../../components/layout";
 import { Stack } from "../../components/Stack";
 import { graphql } from "../../gql";
 import { ProjectQueryQuery } from "../../gql/graphql";
+
+const CheckIcon = styled(Icons)(({ theme }) => ({
+  width: 40,
+  height: 40,
+  padding: 10,
+  background: theme.color.positive,
+  borderRadius: "100%",
+  color: "white",
+}));
 
 const ProjectQuery = graphql(/* GraphQL */ `
   query ProjectQuery($projectId: ID!) {
@@ -48,34 +58,20 @@ export const LinkedProject = ({
             {error && <p>{error.message}</p>}
             {data?.project && (
               <Stack>
-                <Icon icon="check" />
+                <CheckIcon icon="check" />
                 <Heading>Project linked!</Heading>
-                <p>
-                  We added project ID to main.js. The {data.project.name} app ID will be used to
+                <Text style={{ maxWidth: 380 }}>
+                  Your Storybook&apos;s <code>main.js</code> has been updated to include the{" "}
+                  <code>projectId</code> of {data.project.name}. This project will be used to
                   reference prior tests. Please commit this change to continue using this addon.
-                </p>
+                </Text>
                 <Button secondary onClick={() => goToNext()}>
-                  Next
+                  Catch a UI change
                 </Button>
-                <p>
-                  What is the app ID for?{" "}
-                  <a href="https://www.chromatic.com/docs/cli">Learn More »</a>
-                </p>
-                {data?.project && (
-                  <div>
-                    <Heading>Selected project</Heading>
-                    <Text>Baselines will be used with this project.</Text>
-                    <b>
-                      <a href={data.project.webUrl}>{data.project.name}</a>
-                    </b>
-                  </div>
-                )}
-                {data.project.lastBuild && (
-                  <p>
-                    Last build: {data.project.lastBuild.number} on branch{" "}
-                    {data.project.lastBuild.branch}
-                  </p>
-                )}
+                <Text>
+                  Why do we need a project ID?{" "}
+                  <Link href="https://www.chromatic.com/docs/cli">Learn More »</Link>
+                </Text>
               </Stack>
             )}
           </Stack>
@@ -83,8 +79,15 @@ export const LinkedProject = ({
       </Section>
       <Section>
         <Bar>
-          <Col push />
           <Col>
+            {data?.project?.lastBuild && (
+              <Text style={{ marginLeft: 5 }}>
+                Last build: {data.project.lastBuild.number} on branch{" "}
+                {data.project.lastBuild.branch}
+              </Text>
+            )}
+          </Col>
+          <Col push>
             <FooterMenu setAccessToken={setAccessToken} />
           </Col>
         </Bar>

--- a/src/screens/LinkProject/LinkedProject.tsx
+++ b/src/screens/LinkProject/LinkedProject.tsx
@@ -61,9 +61,9 @@ export const LinkedProject = ({
                 <CheckIcon icon="check" />
                 <Heading>Project linked!</Heading>
                 <Text style={{ maxWidth: 380 }}>
-                  Your Storybook&apos;s <code>main.js</code> has been updated to include the{" "}
-                  <code>projectId</code> of {data.project.name}. This project will be used to
-                  reference prior tests. Please commit this change to continue using this addon.
+                  The <code>projectId</code> for {data.project.name} has been added to this
+                  Storybook&apos;s <code>main.js</code>. This will be used to sync with Chromatic.
+                  Please commit this change to continue using this addon.
                 </Text>
                 <Button secondary onClick={() => goToNext()}>
                   Catch a UI change


### PR DESCRIPTION
This updates the temporary mockup to look as designed. I did tweak the copy a bit.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.30--canary.42.7e80cf4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.30--canary.42.7e80cf4.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.30--canary.42.7e80cf4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
