### PR TITLE
Remove/hide render settings and warnings screens for now

### DIFF
--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -305,26 +305,26 @@ export const InfrastructureError: Story = {
   },
 };
 
-export const RenderSettings: Story = {
-  parameters: {
-    ...withFigmaDesign(
-      "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=508-525764&t=18c1zI1SMe76dWYk-4"
-    ),
-  },
-  play: playAll(async ({ canvasElement }) => {
-    const button = await findByRole(canvasElement, "button", { name: "Show render settings" });
-    await fireEvent.click(button);
-  }),
-};
+// export const RenderSettings: Story = {
+//   parameters: {
+//     ...withFigmaDesign(
+//       "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=508-525764&t=18c1zI1SMe76dWYk-4"
+//     ),
+//   },
+//   play: playAll(async ({ canvasElement }) => {
+//     const button = await findByRole(canvasElement, "button", { name: "Show render settings" });
+//     await fireEvent.click(button);
+//   }),
+// };
 
-export const Warnings: Story = {
-  parameters: {
-    ...withFigmaDesign(
-      "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=516-672810&t=18c1zI1SMe76dWYk-4"
-    ),
-  },
-  play: playAll(async ({ canvasElement }) => {
-    const button = await findByRole(canvasElement, "button", { name: "Show warnings" });
-    await fireEvent.click(button);
-  }),
-};
+// export const Warnings: Story = {
+//   parameters: {
+//     ...withFigmaDesign(
+//       "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=516-672810&t=18c1zI1SMe76dWYk-4"
+//     ),
+//   },
+//   play: playAll(async ({ canvasElement }) => {
+//     const button = await findByRole(canvasElement, "button", { name: "Show warnings" });
+//     await fireEvent.click(button);
+//   }),
+// };

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -1,5 +1,4 @@
 import { Icons, Loader } from "@storybook/components";
-import { Icon } from "@storybook/design-system";
 // eslint-disable-next-line import/no-unresolved
 import { GitInfo } from "chromatic/node";
 import React, { useCallback, useEffect, useState } from "react";
@@ -325,7 +324,7 @@ export const VisualTests = ({
           <Col>
             <Text style={{ marginLeft: 5 }}>Latest snapshot on {build.branch}</Text>
           </Col>
-          <Col push>
+          {/* <Col push>
             <IconButton
               active={settingsVisible}
               aria-label={`${settingsVisible ? "Hide" : "Show"} render settings`}
@@ -334,7 +333,7 @@ export const VisualTests = ({
                 setWarningsVisible(false);
               }}
             >
-              <Icon icon="controls" />
+              <Icons icon="controls" />
             </IconButton>
           </Col>
           <Col>
@@ -347,10 +346,10 @@ export const VisualTests = ({
               }}
               status="warning"
             >
-              <Icon icon="alert" />2
+              <Icons icon="alert" />2
             </IconButton>
-          </Col>
-          <Col>
+          </Col> */}
+          <Col push>
             <FooterMenu setAccessToken={setAccessToken} />
           </Col>
         </Bar>


### PR DESCRIPTION
This just comments out the toggles so there's no way to enable these screens. I also commented out the stories because they wouldn't show their respective screens anymore (they rely on the toggle being available).