### PR TITLE
attempt: clear the build id to remove it from query if gitInfo changes

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -65,6 +65,8 @@ export const Panel = ({ active }: PanelProps) => {
       },
       [GIT_INFO]: (info: GitInfo) => {
         setGitInfo(info);
+        // Reset the build ID when the Git info changes.
+        localStorage.removeItem(DEV_BUILD_ID_KEY);
         logger.debug("Updated Git info:", info);
       },
     },


### PR DESCRIPTION
This is not a fix for the issue so I didn't link it to the ticket. This attempted to remove the item from localstorage, which caused the text to change to "Waiting for build on ..." when I switched to main, but there were further issues. Opening draft to share in thread.