### PR TITLE
Send mainPath and configDir on update success/failure

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -80,15 +80,16 @@ export const Panel = ({ active, api }: PanelProps) => {
     },
     [api]
   );
-  const [
+  const {
     projectId,
     projectToken,
     configDir,
+    mainPath,
     updateProject,
     projectUpdatingFailed,
     projectIdUpdated,
     clearProjectIdUpdated,
-  ] = useProjectId();
+  } = useProjectId();
 
   // Render a hidden element when the addon panel is not active.
   // Storybook's AddonPanel component does the same but it's not styleable so we don't use it.
@@ -109,6 +110,7 @@ export const Panel = ({ active, api }: PanelProps) => {
       <LinkingProjectFailed
         projectId={projectId}
         projectToken={projectToken}
+        mainPath={mainPath}
         configDir={configDir}
       />
     );
@@ -119,6 +121,7 @@ export const Panel = ({ active, api }: PanelProps) => {
       <Provider key={PANEL_ID} value={client}>
         <LinkedProject
           projectId={projectId}
+          mainPath={mainPath}
           goToNext={clearProjectIdUpdated}
           setAccessToken={setAccessToken}
         />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,12 @@ export type UpdateProjectPayload = {
 };
 
 export const PROJECT_UPDATED = `${ADDON_ID}/projectUpdated`;
+export type ProjectUpdatedPayload = {
+  mainPath: string;
+  configDir: string;
+};
 export const PROJECT_UPDATING_FAILED = `${ADDON_ID}/projectUpdatingFailed`;
 export type ProjectUpdatingFailedPayload = {
+  mainPath?: string;
   configDir: string;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import type { Channel } from "@storybook/channels";
 // eslint-disable-next-line import/no-unresolved
 import { getGitInfo, GitInfo, run } from "chromatic/node";
-import { relative } from "path";
+import { basename, relative } from "path";
 
 import {
   BUILD_ANNOUNCED,
@@ -102,13 +102,13 @@ async function serverChannel(
         mainPath = await findConfig(configDir, "main");
         await updateMain({ mainPath, projectId, projectToken });
         channel.emit(PROJECT_UPDATED, {
-          mainPath,
+          mainPath: basename(mainPath),
           configDir: relativeConfigDir,
         } satisfies ProjectUpdatedPayload);
       } catch (err) {
         console.warn(`Failed to update your main configuration:\n\n ${err}`);
         channel.emit(PROJECT_UPDATING_FAILED, {
-          mainPath,
+          mainPath: basename(mainPath),
           configDir: relativeConfigDir,
         } satisfies ProjectUpdatingFailedPayload);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ async function serverChannel(
       } catch (err) {
         console.warn(`Failed to update your main configuration:\n\n ${err}`);
         channel.emit(PROJECT_UPDATING_FAILED, {
-          mainPath: basename(mainPath),
+          mainPath: mainPath && basename(mainPath),
           configDir: relativeConfigDir,
         } satisfies ProjectUpdatingFailedPayload);
       }

--- a/src/screens/LinkProject/LinkProject.stories.ts
+++ b/src/screens/LinkProject/LinkProject.stories.ts
@@ -2,13 +2,11 @@ import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
 import { findByTestId } from "@storybook/testing-library";
 import { graphql } from "msw";
-import React from "react";
 
-import { ProjectQueryQuery, SelectProjectsQueryQuery } from "../../gql/graphql";
+import { SelectProjectsQueryQuery } from "../../gql/graphql";
 import { storyWrapper } from "../../utils/graphQLClient";
 import { playAll } from "../../utils/playAll";
 import { withFigmaDesign } from "../../utils/withFigmaDesign";
-import { LinkedProject } from "./LinkedProject";
 import { LinkProject } from "./LinkProject";
 
 const meta = {
@@ -238,35 +236,6 @@ export const SelectProjectManyProjects: Story = {
     await rightDiv.scroll({ top: rightDiv.scrollHeight });
     await leftDiv.scroll({ top: leftDiv.scrollHeight });
   }),
-};
-export const Linked: Story = {
-  render: () => (
-    <LinkedProject
-      projectId="789"
-      goToNext={action("goToNext")}
-      setAccessToken={action("setAccessToken")}
-    />
-  ),
-  parameters: {
-    ...withGraphQLQuery("ProjectQuery", (req, res, ctx) =>
-      res(
-        ctx.data({
-          project: {
-            id: "789",
-            name: "acme",
-            webUrl: "https://www.chromatic.com/builds?appId=789",
-            lastBuild: {
-              branch: "main",
-              number: 123,
-            },
-          },
-        } satisfies ProjectQueryQuery)
-      )
-    ),
-    ...withFigmaDesign(
-      "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=508-317094&t=435fylbu7gUQNEgq-4"
-    ),
-  },
 };
 
 export const EmptyNoAccounts: Story = {

--- a/src/screens/LinkProject/LinkedProject.stories.ts
+++ b/src/screens/LinkProject/LinkedProject.stories.ts
@@ -1,0 +1,49 @@
+import { action } from "@storybook/addon-actions";
+import type { Meta, StoryObj } from "@storybook/react";
+import { graphql } from "msw";
+
+import { ProjectQueryQuery } from "../../gql/graphql";
+import { storyWrapper } from "../../utils/graphQLClient";
+import { withFigmaDesign } from "../../utils/withFigmaDesign";
+import { LinkedProject } from "./LinkedProject";
+
+const withGraphQLQuery = (...args: Parameters<typeof graphql.query>) => ({
+  msw: {
+    handlers: [graphql.query(...args)],
+  },
+});
+
+const meta = {
+  component: LinkedProject,
+  args: {
+    projectId: "Project:abc123",
+    goToNext: action("goToNext"),
+    setAccessToken: action("setAccessToken"),
+  },
+  decorators: [storyWrapper],
+  parameters: {
+    ...withGraphQLQuery("ProjectQuery", (req, res, ctx) =>
+      res(
+        ctx.data({
+          project: {
+            id: "789",
+            name: "acme",
+            webUrl: "https://www.chromatic.com/builds?appId=789",
+            lastBuild: {
+              branch: "main",
+              number: 123,
+            },
+          },
+        } satisfies ProjectQueryQuery)
+      )
+    ),
+    ...withFigmaDesign(
+      "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=508-317094&t=435fylbu7gUQNEgq-4"
+    ),
+  },
+} satisfies Meta<typeof LinkedProject>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/screens/LinkProject/LinkedProject.stories.ts
+++ b/src/screens/LinkProject/LinkedProject.stories.ts
@@ -17,6 +17,7 @@ const meta = {
   component: LinkedProject,
   args: {
     projectId: "Project:abc123",
+    mainPath: "main.ts",
     goToNext: action("goToNext"),
     setAccessToken: action("setAccessToken"),
   },

--- a/src/screens/LinkProject/LinkedProject.tsx
+++ b/src/screens/LinkProject/LinkedProject.tsx
@@ -37,10 +37,12 @@ const ProjectQuery = graphql(/* GraphQL */ `
 
 export const LinkedProject = ({
   projectId,
+  mainPath,
   goToNext,
   setAccessToken,
 }: {
   projectId: string;
+  mainPath: string;
   goToNext: () => void;
   setAccessToken: (accessToken: string | null) => void;
 }) => {
@@ -62,8 +64,8 @@ export const LinkedProject = ({
                 <Heading>Project linked!</Heading>
                 <Text style={{ maxWidth: 380 }}>
                   The <code>projectId</code> for {data.project.name} has been added to this
-                  Storybook&apos;s <code>main.js</code>. This will be used to sync with Chromatic.
-                  Please commit this change to continue using this addon.
+                  Storybook&apos;s <code>{mainPath}</code>. This will be used to sync with
+                  Chromatic. Please commit this change to continue using this addon.
                 </Text>
                 <Button secondary onClick={() => goToNext()}>
                   Catch a UI change

--- a/src/screens/LinkProject/LinkingProjectFailed.stories.ts
+++ b/src/screens/LinkProject/LinkingProjectFailed.stories.ts
@@ -15,3 +15,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const WithMainPath: Story = {
+  args: {
+    mainPath: "main.ts",
+  },
+};

--- a/src/screens/LinkProject/LinkingProjectFailed.tsx
+++ b/src/screens/LinkProject/LinkingProjectFailed.tsx
@@ -11,6 +11,7 @@ type LinkingProjectFailedProps = {
   projectId: string;
   projectToken: string;
   configDir: string;
+  mainPath?: string;
 };
 
 const addonName = "@chromaui/addon-visual-tests";
@@ -20,6 +21,7 @@ export function LinkingProjectFailed({
   projectId,
   projectToken,
   configDir,
+  mainPath,
 }: LinkingProjectFailedProps) {
   return (
     <Sections>
@@ -32,7 +34,7 @@ export function LinkingProjectFailed({
           </CenterText>
           <Code>
             {dedent`
-            // ${configDir}/main.js|ts|tsx
+            // ${configDir}/${mainPath ?? `main.js|ts|tsx`}
 
             module.exports = {
               // ...,

--- a/src/utils/updateMain.ts
+++ b/src/utils/updateMain.ts
@@ -1,18 +1,16 @@
 import { readConfig, writeConfig } from "@storybook/csf-tools";
 
 import { CHROMATIC_ADDON_NAME } from "../constants";
-import { findConfig } from "./storybook.config.utils";
 
 export async function updateMain({
   projectId,
   projectToken,
-  configDir,
+  mainPath,
 }: {
   projectId: string;
   projectToken: string;
-  configDir: string;
+  mainPath: string;
 }) {
-  const mainPath = await findConfig(configDir, "main");
   const MainConfig = await readConfig(mainPath);
 
   const addonsConfig = MainConfig.getFieldValue(["addons"]);

--- a/src/utils/useProjectId.ts
+++ b/src/utils/useProjectId.ts
@@ -4,6 +4,7 @@ import React from "react";
 import {
   PROJECT_UPDATED,
   PROJECT_UPDATING_FAILED,
+  ProjectUpdatedPayload,
   ProjectUpdatingFailedPayload,
   UPDATE_PROJECT,
   UpdateProjectPayload,
@@ -11,25 +12,23 @@ import {
 
 const { CHROMATIC_PROJECT_ID } = process.env;
 
-export const useProjectId = (): [
-  projectId: string,
-  projectToken: string,
-  configDir: string,
-  updateProject: (projectId: string, projectToken?: string) => void,
-  projectUpdatingFailed: boolean,
-  projectIdUpdated: boolean,
-  clearProjectIdUpdated: () => void
-] => {
+export const useProjectId = () => {
   const [projectId, setProjectId] = React.useState<string | null>(CHROMATIC_PROJECT_ID);
   const [projectToken, setProjectToken] = React.useState<string | null>();
   const [projectIdUpdated, setProjectIdUpdated] = React.useState(false);
   const [projectUpdatingFailed, setProjectUpdatingFailed] = React.useState(false);
+  const [mainPath, setMainPath] = React.useState<string | null>();
   const [configDir, setConfigDir] = React.useState<string | null>();
 
   const emit = useChannel({
-    [PROJECT_UPDATED]: () => setProjectIdUpdated(true),
+    [PROJECT_UPDATED]: (payload: ProjectUpdatedPayload) => {
+      setProjectIdUpdated(true);
+      setMainPath(payload.mainPath);
+      setConfigDir(payload.configDir);
+    },
     [PROJECT_UPDATING_FAILED]: (payload: ProjectUpdatingFailedPayload) => {
       setProjectUpdatingFailed(true);
+      setMainPath(payload.mainPath);
       setConfigDir(payload.configDir);
     },
   });
@@ -42,13 +41,14 @@ export const useProjectId = (): [
     setProjectId(newProjectId);
     setProjectToken(newProjectToken);
   };
-  return [
+  return {
     projectId,
     projectToken,
     configDir,
+    mainPath,
     updateProject,
     projectUpdatingFailed,
     projectIdUpdated,
-    () => setProjectIdUpdated(false),
-  ];
+    clearProjectIdUpdated: () => setProjectIdUpdated(false),
+  };
 };


### PR DESCRIPTION
Telescoping on https://github.com/chromaui/addon-visual-tests/pull/41

Send the `main.js` location and `configDir` up on success/failure so we can incorporate it into the UIs.

To QA:

1. Clear the selected options from `main.ts`: https://github.com/chromaui/addon-visual-tests/blob/1f7b002a58d160c755bb363e686b62cc64de9c42/.storybook/main.ts#L40

2. Make `findConfig` error, select a project, check you see generic instructions (no specific main location)

3. Make `updateMain` error, select a project, check you see instructions that include `main.ts`

4. Make it all work, select a project, check you see a message that includes `main.ts`.