### PR TITLE
Switch to a new progress event for build status

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@storybook/csf-tools": "7.4.0-alpha.2",
     "@storybook/design-system": "^7.15.15",
-    "chromatic": "6.24.0",
+    "chromatic": "6.25.0-canary.0",
     "date-fns": "^2.30.0",
     "pluralize": "^8.0.0",
     "urql": "^4.0.3",

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -7,8 +7,8 @@ import React, { useCallback, useState } from "react";
 
 import {
   ADDON_ID,
-  BUILD_ANNOUNCED,
-  BUILD_STARTED,
+  BUILD_PROGRESS,
+  BuildProgressPayload,
   DEV_BUILD_ID_KEY,
   GIT_INFO,
   GitInfoPayload,
@@ -60,10 +60,14 @@ export const Panel = ({ active, api }: PanelProps) => {
   const emit = useChannel(
     {
       [START_BUILD]: () => setIsStarting(true),
-      [BUILD_STARTED]: () => setIsStarting(false),
-      [BUILD_ANNOUNCED]: (buildId: string) => {
-        setLastBuildId(buildId);
-        localStorage.setItem(DEV_BUILD_ID_KEY, buildId);
+      [BUILD_PROGRESS]: ({ step, id }: BuildProgressPayload) => {
+        if (step === "build") {
+          setLastBuildId(id);
+          localStorage.setItem(DEV_BUILD_ID_KEY, id);
+        }
+        if (step === "snapshot" || step === "complete") {
+          setIsStarting(false);
+        }
       },
       [GIT_INFO]: (info: GitInfoPayload) => {
         setGitInfo(info);

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -11,7 +11,7 @@ export const Tool = () => {
   const emit = useChannel(
     {
       [START_BUILD]: () => setIsStarting(true),
-      [BUILD_PROGRESS]: ({ step, id }: BuildProgressPayload) => {
+      [BUILD_PROGRESS]: ({ step }: BuildProgressPayload) => {
         if (step === "snapshot" || step === "complete") {
           setIsStarting(false);
         }

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -3,7 +3,7 @@ import { useChannel } from "@storybook/manager-api";
 import React, { useState } from "react";
 
 import { ProgressIcon } from "./components/icons/ProgressIcon";
-import { BUILD_STARTED, START_BUILD, TOOL_ID } from "./constants";
+import { BUILD_PROGRESS, BuildProgressPayload, START_BUILD, TOOL_ID } from "./constants";
 
 export const Tool = () => {
   const [isStarting, setIsStarting] = useState(false);
@@ -11,7 +11,11 @@ export const Tool = () => {
   const emit = useChannel(
     {
       [START_BUILD]: () => setIsStarting(true),
-      [BUILD_STARTED]: () => setIsStarting(false),
+      [BUILD_PROGRESS]: ({ step, id }: BuildProgressPayload) => {
+        if (step === "snapshot" || step === "complete") {
+          setIsStarting(false);
+        }
+      },
     },
     []
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,9 +16,20 @@ export const DEV_BUILD_ID_KEY = `${ADDON_ID}/dev-build-id`;
 
 export const GIT_INFO = `${ADDON_ID}/gitInfo`;
 export type GitInfoPayload = Omit<GitInfo, "committedAt" | "committerEmail" | "committerName">;
+
 export const START_BUILD = `${ADDON_ID}/startBuild`;
-export const BUILD_ANNOUNCED = `${ADDON_ID}/buildAnnounced`;
-export const BUILD_STARTED = `${ADDON_ID}/buildStarted`;
+export const BUILD_PROGRESS = `${ADDON_ID}/buildProgress`;
+export type BuildProgressPayload = {
+  // Possibly this should be a type exported by the CLI -- these correspond to tasks
+  /** The step of the build process we have reached */
+  step: "initialize" | "build" | "upload" | "verify" | "snapshot" | "complete";
+  /** The id of the build, available after the initialize step */
+  id?: string;
+  /** progress pertains to the current step, and may not be set */
+  progress?: number;
+  /** total pertains to the current step, and may not be set */
+  total?: number;
+};
 
 export const UPDATE_PROJECT = `${ADDON_ID}/updateProject`;
 export type UpdateProjectPayload = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ async function serverChannel(
             step = newStep;
             channel.emit(BUILD_PROGRESS, {
               step,
-              id: ctx.announcedBuild.id,
+              id: ctx.announcedBuild?.id,
             } satisfies BuildProgressPayload);
           }
         },

--- a/src/screens/VisualTests/BuildStatus.stories.ts
+++ b/src/screens/VisualTests/BuildStatus.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { withFigmaDesign } from "../../utils/withFigmaDesign";
+import { BuildStatus } from "./BuildStatus";
+
+const meta = {
+  component: BuildStatus,
+} satisfies Meta<typeof BuildStatus>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    // build: passedBuild,
+  },
+  parameters: withFigmaDesign(
+    "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=508-525764&t=18c1zI1SMe76dWYk-4"
+  ),
+};

--- a/src/screens/VisualTests/BuildStatus.tsx
+++ b/src/screens/VisualTests/BuildStatus.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export function BuildStatus({}) {
+  return <div>Build Status</div>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5453,10 +5453,10 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromatic@6.24.0:
-  version "6.24.0"
-  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-6.24.0.tgz#007561facf1c3d444195cf640195dbb19c2cc4e1"
-  integrity sha512-i09yqXa5P1qsNntohW8SN3MYWitdz8j6FazOGrN7v2nEvPauP50vTKFYKxBXq68kp904ede/06D4TZdkfp55sw==
+chromatic@6.25.0-canary.0:
+  version "6.25.0-canary.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-6.25.0-canary.0.tgz#1121c5afcf335a2b5ee1fbe5c709b0f42dbbd1d3"
+  integrity sha512-oiytax7ozb/b4bFLTRuDQ60uUxpmT7W/O4yjm49YhYfpXFbKsDMDyyLjJZnE3ntMJxyhF5uSehuZFnS0CXaemw==
 
 ci-info@^3.2.0:
   version "3.8.0"


### PR DESCRIPTION
Using the new `onTaskProgress` option, switch to a more full featured `BUILD_PROGRESS` event https://github.com/chromaui/chromatic-cli/pull/805.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.42--canary.55.36a4f81.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.42--canary.55.36a4f81.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.42--canary.55.36a4f81.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
