### PR TITLE
Fix: Updates the the link to the Visual Testing addon  documentation

### DIFF
--- a/src/components/FooterMenu.tsx
+++ b/src/components/FooterMenu.tsx
@@ -22,7 +22,7 @@ export const FooterMenu = ({ setAccessToken }: FooterMenuProps) => {
           id: "learn",
           title: "Learn about this addon",
           icon: "question",
-          href: "https://www.chromatic.com/docs/test",
+          href: "https://www.chromatic.com/docs/visual-testing-addon",
         },
       ]}
     >


### PR DESCRIPTION
With this small pull request, the URL that is currently linked to the documentation was fixed to reference to its right place, as we have the starter documentation available.

I'm aware that this component may be subject to changes in the near future, but at least we have it referenced and available.



