### PR TITLE
First pass at server compatible addon state

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -1,7 +1,6 @@
 import { Spinner } from "@storybook/design-system";
 import type { API } from "@storybook/manager-api";
-import { useChannel, useStorybookApi, useStorybookState } from "@storybook/manager-api";
-// eslint-disable-next-line import/no-unresolved
+import { useChannel, useStorybookState } from "@storybook/manager-api";
 import React, { useCallback, useState } from "react";
 
 import {
@@ -29,23 +28,6 @@ interface PanelProps {
   api: API;
 }
 
-const {
-  GIT_USER_EMAIL,
-  GIT_USER_EMAIL_HASH,
-  GIT_BRANCH,
-  GIT_SLUG,
-  GIT_COMMIT,
-  GIT_UNCOMMITTED_HASH,
-} = process.env;
-const initialGitInfo: GitInfoPayload = {
-  userEmail: GIT_USER_EMAIL,
-  userEmailHash: GIT_USER_EMAIL_HASH,
-  branch: GIT_BRANCH,
-  commit: GIT_COMMIT,
-  slug: GIT_SLUG,
-  uncommittedHash: GIT_UNCOMMITTED_HASH,
-};
-
 const storedBuildId = localStorage.getItem(DEV_BUILD_ID_KEY);
 
 export const Panel = ({ active, api }: PanelProps) => {
@@ -55,7 +37,6 @@ export const Panel = ({ active, api }: PanelProps) => {
   const [isStarting, setIsStarting] = useState(false);
   const [lastBuildId, setLastBuildId] = useState(storedBuildId);
   const [gitInfo] = useAddonState<GitInfoPayload>(GIT_INFO);
-  console.log({ gitInfo });
 
   const emit = useChannel(
     {
@@ -76,6 +57,7 @@ export const Panel = ({ active, api }: PanelProps) => {
     [api]
   );
   const {
+    loading: projectInfoLoading,
     projectId,
     projectToken,
     configDir,
@@ -92,6 +74,11 @@ export const Panel = ({ active, api }: PanelProps) => {
 
   // Render the Authentication flow if the user is not signed in.
   if (!accessToken) return <Authentication key={PANEL_ID} setAccessToken={setAccessToken} />;
+
+  // Momentarily wait on addonState (should be very fast)
+  if (projectInfoLoading || !gitInfo) {
+    return <Spinner />;
+  }
 
   if (!projectId)
     return (
@@ -122,10 +109,6 @@ export const Panel = ({ active, api }: PanelProps) => {
         />
       </Provider>
     );
-  }
-
-  if (!gitInfo) {
-    return <Spinner />;
   }
 
   return (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,23 +16,16 @@ export const DEV_BUILD_ID_KEY = `${ADDON_ID}/dev-build-id`;
 
 export const GIT_INFO = `${ADDON_ID}/gitInfo`;
 export type GitInfoPayload = Omit<GitInfo, "committedAt" | "committerEmail" | "committerName">;
+
+export const PROJECT_INFO = `${ADDON_ID}/projectInfo`;
+export type ProjectInfoPayload = {
+  projectId?: string;
+  projectToken?: string;
+  written?: boolean;
+  configDir?: string;
+  mainPath?: string;
+};
+
 export const START_BUILD = `${ADDON_ID}/startBuild`;
 export const BUILD_ANNOUNCED = `${ADDON_ID}/buildAnnounced`;
 export const BUILD_STARTED = `${ADDON_ID}/buildStarted`;
-
-export const UPDATE_PROJECT = `${ADDON_ID}/updateProject`;
-export type UpdateProjectPayload = {
-  projectId: string;
-  projectToken: string;
-};
-
-export const PROJECT_UPDATED = `${ADDON_ID}/projectUpdated`;
-export type ProjectUpdatedPayload = {
-  mainPath: string;
-  configDir: string;
-};
-export const PROJECT_UPDATING_FAILED = `${ADDON_ID}/projectUpdatingFailed`;
-export type ProjectUpdatingFailedPayload = {
-  mainPath?: string;
-  configDir: string;
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,14 +11,8 @@ import {
   GIT_INFO,
   GitInfoPayload,
   PROJECT_INFO,
-  PROJECT_UPDATED,
-  PROJECT_UPDATING_FAILED,
   ProjectInfoPayload,
-  ProjectUpdatedPayload,
-  ProjectUpdatingFailedPayload,
   START_BUILD,
-  UPDATE_PROJECT,
-  UpdateProjectPayload,
 } from "./constants";
 import { useAddonState } from "./useAddonState/server";
 import { findConfig } from "./utils/storybook.config.utils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   UPDATE_PROJECT,
   UpdateProjectPayload,
 } from "./constants";
+import { useAddonState } from "./useAddonState/server";
 import { updateMain } from "./utils/updateMain";
 
 /**
@@ -119,7 +120,11 @@ async function serverChannel(
     }
   );
 
-  observeGitInfo(5000, (info) => channel.emit(GIT_INFO, info as GitInfoPayload));
+  const gitInfoState = useAddonState<GitInfoPayload>(channel, GIT_INFO);
+
+  observeGitInfo(5000, (info) => {
+    gitInfoState.value = info;
+  });
 
   return channel;
 }
@@ -133,17 +138,10 @@ const config = {
   ) => {
     if (configType === "PRODUCTION") return env;
 
-    const { userEmail, userEmailHash, branch, commit, slug, uncommittedHash } = await getGitInfo();
     return {
       ...env,
       CHROMATIC_BASE_URL,
       CHROMATIC_PROJECT_ID: projectId || "",
-      GIT_USER_EMAIL: userEmail,
-      GIT_USER_EMAIL_HASH: userEmailHash,
-      GIT_BRANCH: branch,
-      GIT_COMMIT: commit,
-      GIT_SLUG: slug,
-      GIT_UNCOMMITTED_HASH: uncommittedHash,
     };
   },
 };

--- a/src/useAddonState/common.ts
+++ b/src/useAddonState/common.ts
@@ -1,0 +1,10 @@
+export const getValue = `experimental_useAddonState_setValue`;
+export type GetValuePayload = {
+  key: string;
+};
+
+export const setValue = `experimental_useAddonState_setValue`;
+export type SetValuePayload = {
+  key: string;
+  value: any;
+};

--- a/src/useAddonState/common.ts
+++ b/src/useAddonState/common.ts
@@ -1,4 +1,4 @@
-export const getValue = `experimental_useAddonState_setValue`;
+export const getValue = `experimental_useAddonState_getValue`;
 export type GetValuePayload = {
   key: string;
 };

--- a/src/useAddonState/manager.ts
+++ b/src/useAddonState/manager.ts
@@ -48,7 +48,7 @@ export function useAddonState<T>(key: string) {
   ensureListening(api);
 
   return [
-    apiGetAddonState(api, key),
+    apiGetAddonState<T>(api, key),
     useCallback((value: T) => apiSetAddonState(api, key, value), [api, key]),
-  ];
+  ] as const;
 }

--- a/src/useAddonState/manager.ts
+++ b/src/useAddonState/manager.ts
@@ -1,0 +1,54 @@
+import type { API } from "@storybook/manager-api";
+import { useStorybookApi } from "@storybook/manager-api";
+import { useCallback } from "react";
+
+import { getValue, GetValuePayload, setValue, SetValuePayload } from "./common";
+
+const requestedKeys = new Set<string>();
+let listening = false;
+function ensureListening(api: API) {
+  if (listening) return;
+
+  api.on(getValue, ({ key }: GetValuePayload) => {
+    const apiKey = `experimental_${key}`;
+    const value = api.getAddonState(apiKey);
+    if (value !== undefined) api.emit(setValue, { key, value } satisfies SetValuePayload);
+  });
+
+  api.on(setValue, ({ key, value }: SetValuePayload) => {
+    const apiKey = `experimental_${key}`;
+    api.setAddonState(apiKey, value);
+  });
+
+  listening = true;
+}
+
+function apiGetAddonState<T>(api: API, key: string) {
+  const apiKey = `experimental_${key}`;
+
+  // Ask the universe for the value of the key if we've never seen it before
+  if (!requestedKeys.has(key)) {
+    api.emit(getValue, { key } satisfies GetValuePayload);
+    requestedKeys.add(key);
+  }
+
+  return api.getAddonState(apiKey) as T | undefined;
+}
+function apiSetAddonState<T>(api: API, key: string, value: T) {
+  const apiKey = `experimental_${key}`;
+  api.setAddonState(apiKey, value);
+
+  api.emit(setValue, { key, value } satisfies SetValuePayload);
+}
+
+export function useAddonState<T>(key: string) {
+  const api = useStorybookApi();
+
+  // This should probably just always be happening
+  ensureListening(api);
+
+  return [
+    apiGetAddonState(api, key),
+    useCallback((value: T) => apiSetAddonState(api, key, value), [api, key]),
+  ];
+}

--- a/src/useAddonState/preview.ts
+++ b/src/useAddonState/preview.ts
@@ -1,0 +1,1 @@
+// TODO -- we don't actually need it for the addon

--- a/src/useAddonState/server.test.ts
+++ b/src/useAddonState/server.test.ts
@@ -1,0 +1,72 @@
+import { getValue, setValue } from "./common";
+import { resetAddonState, useAddonState } from "./server";
+
+class MockChannel {
+  private listeners: Record<string, ((data: any) => void)[]> = {};
+
+  on(event: string, cb: (data: any) => void) {
+    this.listeners[event] = [...(this.listeners[event] ?? []), cb];
+  }
+
+  emit = jest.fn((event: string, payload: any) =>
+    (this.listeners[event] || []).forEach((l) => l(payload))
+  );
+}
+
+beforeEach(() => resetAddonState());
+
+it("returns null on first call", () => {
+  const fooState = useAddonState(new MockChannel(), "foo");
+
+  expect(fooState.value).toBeUndefined();
+});
+
+it("emits getValue when reading", () => {
+  const channel = new MockChannel();
+  const fooState = useAddonState(channel, "foo");
+
+  expect(fooState.value).toBeUndefined();
+
+  expect(channel.emit).toHaveBeenCalledWith(getValue, { key: "foo" });
+});
+
+it("returns current value if received", () => {
+  const channel = new MockChannel();
+  const fooState = useAddonState(channel, "foo");
+
+  expect(fooState.value).toBeUndefined();
+
+  channel.emit(setValue, { key: "foo", value: "bar" });
+  expect(fooState.value).toBe("bar");
+});
+
+it("returns value after setting", () => {
+  const fooState = useAddonState(new MockChannel(), "foo");
+
+  fooState.value = "bar";
+
+  expect(fooState.value).toEqual("bar");
+});
+
+it("emits setValue when setting", () => {
+  const channel = new MockChannel();
+  const fooState = useAddonState(channel, "foo");
+
+  fooState.value = "bar";
+
+  expect(channel.emit).toHaveBeenCalledWith(setValue, { key: "foo", value: "bar" });
+});
+
+it("emits setValue after receiving getValue", () => {
+  const channel = new MockChannel();
+  const fooState = useAddonState(channel, "foo");
+
+  fooState.value = "bar";
+
+  expect(channel.emit).toHaveBeenCalledWith(setValue, { key: "foo", value: "bar" });
+
+  channel.emit.mockClear();
+  channel.emit(getValue, { key: "foo" });
+
+  expect(channel.emit).toHaveBeenCalledWith(setValue, { key: "foo", value: "bar" });
+});

--- a/src/useAddonState/server.ts
+++ b/src/useAddonState/server.ts
@@ -1,0 +1,78 @@
+import type { Channel } from "@storybook/channels";
+
+import { getValue, GetValuePayload, setValue, SetValuePayload } from "./common";
+
+class AddonState {
+  private values: Record<string, any> = {};
+
+  private listeners: Record<string, ((value: any) => null)[]> = {};
+
+  get(key: string) {
+    return this.values[key]
+  }
+
+  set(key: string, value: any) {
+    this.values[key] = value;
+    (this.listeners[key] || []).forEach(l => l(value))
+  }
+
+  listen<T>(key: string, cb: (value: T) => null) {
+    this.listeners[key] = [...this.listeners[key] || [], cb];
+  }
+}
+
+const addonState = new AddonState();
+
+
+let listening = false;
+function ensureListening(channel: Channel) {
+  if (listening) return;
+
+  channel.on(getValue, ({ key }: GetValuePayload) => {
+    const value = addonState.get(key);
+    if (value !== undefined) channel.emit(setValue, { key, value } satisfies SetValuePayload);
+  });
+
+  channel.on(setValue, ({ key, value }: SetValuePayload) => {
+    addonState.set(key, value);
+  });
+
+  listening = true;
+}
+
+const requestedKeys = new Set<string>();
+function apiGetAddonState<T>(channel: Channel, key: string) {
+  // Ask the universe for the value of the key if we've never seen it before
+  if (!requestedKeys.has(key)) {
+    channel.emit(getValue, { key } satisfies GetValuePayload);
+    requestedKeys.add(key);
+  }
+
+  return addonState.get(key) as T | undefined;
+}
+
+function apiSetAddonState<T>(channel: Channel, key: string, value: T) {
+  addonState.set(key, value);
+  
+  channel.emit(setValue, { key, value } as SetValuePayload);
+}
+
+export function useAddonState<T>(channel: Channel, key: string) {
+  ensureListening(channel);
+
+  return {
+    get value() {
+      return apiGetAddonState(channel, key),
+    },
+
+    set value(newValue: T) {
+      apiSetAddonState(channel, key, newValue)
+    },
+
+    on(event:string, callback: (value:T) => null) {
+      if (event !== 'change') throw new Error('unsupported event');
+
+      addonState.listen(key, callback)
+    }
+  };
+}

--- a/src/useAddonState/server.ts
+++ b/src/useAddonState/server.ts
@@ -8,21 +8,20 @@ class AddonState {
   private listeners: Record<string, ((value: any) => null)[]> = {};
 
   get(key: string) {
-    return this.values[key]
+    return this.values[key];
   }
 
   set(key: string, value: any) {
     this.values[key] = value;
-    (this.listeners[key] || []).forEach(l => l(value))
+    (this.listeners[key] || []).forEach((l) => l(value));
   }
 
   listen<T>(key: string, cb: (value: T) => null) {
-    this.listeners[key] = [...this.listeners[key] || [], cb];
+    this.listeners[key] = [...(this.listeners[key] || []), cb];
   }
 }
 
 const addonState = new AddonState();
-
 
 let listening = false;
 function ensureListening(channel: Channel) {
@@ -53,7 +52,7 @@ function apiGetAddonState<T>(channel: Channel, key: string) {
 
 function apiSetAddonState<T>(channel: Channel, key: string, value: T) {
   addonState.set(key, value);
-  
+
   channel.emit(setValue, { key, value } as SetValuePayload);
 }
 
@@ -62,17 +61,17 @@ export function useAddonState<T>(channel: Channel, key: string) {
 
   return {
     get value() {
-      return apiGetAddonState(channel, key),
+      return apiGetAddonState(channel, key);
     },
 
     set value(newValue: T) {
-      apiSetAddonState(channel, key, newValue)
+      apiSetAddonState(channel, key, newValue);
     },
 
-    on(event:string, callback: (value:T) => null) {
-      if (event !== 'change') throw new Error('unsupported event');
+    on(event: string, callback: (value: T) => null) {
+      if (event !== "change") throw new Error("unsupported event");
 
-      addonState.listen(key, callback)
-    }
+      addonState.listen(key, callback);
+    },
   };
 }

--- a/src/useAddonState/server.ts
+++ b/src/useAddonState/server.ts
@@ -5,7 +5,7 @@ import { getValue, GetValuePayload, setValue, SetValuePayload } from "./common";
 class AddonState {
   private values: Record<string, any> = {};
 
-  private listeners: Record<string, ((value: any) => null)[]> = {};
+  private listeners: Record<string, ((value: any) => unknown)[]> = {};
 
   get(key: string) {
     return this.values[key];
@@ -16,7 +16,7 @@ class AddonState {
     (this.listeners[key] || []).forEach((l) => l(value));
   }
 
-  listen<T>(key: string, cb: (value: T) => null) {
+  listen<T>(key: string, cb: (value: T) => unknown) {
     this.listeners[key] = [...(this.listeners[key] || []), cb];
   }
 
@@ -79,7 +79,7 @@ export function useAddonState<T>(channel: Pick<Channel, "emit" | "on">, key: str
       apiSetAddonState(channel, key, newValue);
     },
 
-    on(event: string, callback: (value: T) => null) {
+    on(event: string, callback: (value: T) => unknown) {
       if (event !== "change") throw new Error("unsupported event");
 
       addonState.listen(key, callback);


### PR DESCRIPTION
Fixes AP-3557, AP-3544

Prototype `useAddonState` that is server-compatible, and use for state-based manager-server communication (git info, and project info).

To QA:

**Git state**

1. Check the right branch is selected on startup
2. Change branch / commit, check it is reflected in the UI immediately
3. Refresh browser, check it displays the updated branch/commit.

**Project Info**

1. Comment out the [addon's options in main.ts](https://github.com/chromaui/addon-visual-tests/blob/c686270c7f22b9996f50faafd20094350a4b63f6/.storybook/main.ts#L42)
4. Run, pick a project, check you see instructions (as writing failed), check you can keep going
5. Comment out the options and set name: "../src/dev.ts"
6. Run, pick a project, check you see success screen, check project id/token were written, check you can keep going.
7. Start SB with options already in there, check everything works.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.51--canary.64.8673acc.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.51--canary.64.8673acc.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.51--canary.64.8673acc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
