### PR TITLE
Fix status title and viewport/browser selector for accepted stories

### DIFF
--- a/src/components/BrowserSelector.stories.ts
+++ b/src/components/BrowserSelector.stories.ts
@@ -7,6 +7,7 @@ import { BrowserSelector } from "./BrowserSelector";
 const meta = {
   component: BrowserSelector,
   args: {
+    isAccepted: false,
     onSelectBrowser: action("onSelectBrowser"),
   },
 } satisfies Meta<typeof BrowserSelector>;
@@ -27,7 +28,6 @@ const browserSafari = {
 
 export const WithSingleBrowserChanged: Story = {
   args: {
-    testStatus: TestStatus.Pending,
     selectedBrowser: browserChrome,
     browserResults: [
       {
@@ -40,7 +40,7 @@ export const WithSingleBrowserChanged: Story = {
 
 export const WithSingleBrowserAccepted: Story = {
   args: {
-    testStatus: TestStatus.Accepted,
+    isAccepted: true,
     selectedBrowser: browserChrome,
     browserResults: [
       {
@@ -53,7 +53,6 @@ export const WithSingleBrowserAccepted: Story = {
 
 export const WithSingleBrowserEqual: Story = {
   args: {
-    testStatus: TestStatus.Passed,
     selectedBrowser: browserChrome,
     browserResults: [
       {
@@ -66,7 +65,6 @@ export const WithSingleBrowserEqual: Story = {
 
 export const WithSingleBrowserError: Story = {
   args: {
-    testStatus: TestStatus.Broken,
     selectedBrowser: browserChrome,
     browserResults: [
       {
@@ -79,7 +77,6 @@ export const WithSingleBrowserError: Story = {
 
 export const WithManyBrowsersEqual: Story = {
   args: {
-    testStatus: TestStatus.Passed,
     selectedBrowser: browserChrome,
     browserResults: [
       {
@@ -96,7 +93,6 @@ export const WithManyBrowsersEqual: Story = {
 
 export const WithManyBrowsersSecondSelected: Story = {
   args: {
-    testStatus: TestStatus.Passed,
     selectedBrowser: browserSafari,
     browserResults: [
       {
@@ -113,7 +109,6 @@ export const WithManyBrowsersSecondSelected: Story = {
 
 export const WithManyBrowsersVaried: Story = {
   args: {
-    testStatus: TestStatus.Pending,
     selectedBrowser: browserChrome,
     browserResults: [
       {

--- a/src/components/BrowserSelector.stories.ts
+++ b/src/components/BrowserSelector.stories.ts
@@ -1,7 +1,7 @@
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Browser, ComparisonResult } from "../gql/graphql";
+import { Browser, ComparisonResult, TestStatus } from "../gql/graphql";
 import { BrowserSelector } from "./BrowserSelector";
 
 const meta = {
@@ -27,6 +27,20 @@ const browserSafari = {
 
 export const WithSingleBrowserChanged: Story = {
   args: {
+    testStatus: TestStatus.Pending,
+    selectedBrowser: browserChrome,
+    browserResults: [
+      {
+        browser: browserChrome,
+        result: ComparisonResult.Changed,
+      },
+    ],
+  },
+};
+
+export const WithSingleBrowserAccepted: Story = {
+  args: {
+    testStatus: TestStatus.Accepted,
     selectedBrowser: browserChrome,
     browserResults: [
       {
@@ -39,6 +53,7 @@ export const WithSingleBrowserChanged: Story = {
 
 export const WithSingleBrowserEqual: Story = {
   args: {
+    testStatus: TestStatus.Passed,
     selectedBrowser: browserChrome,
     browserResults: [
       {
@@ -51,6 +66,7 @@ export const WithSingleBrowserEqual: Story = {
 
 export const WithSingleBrowserError: Story = {
   args: {
+    testStatus: TestStatus.Broken,
     selectedBrowser: browserChrome,
     browserResults: [
       {
@@ -63,6 +79,7 @@ export const WithSingleBrowserError: Story = {
 
 export const WithManyBrowsersEqual: Story = {
   args: {
+    testStatus: TestStatus.Passed,
     selectedBrowser: browserChrome,
     browserResults: [
       {
@@ -79,6 +96,7 @@ export const WithManyBrowsersEqual: Story = {
 
 export const WithManyBrowsersSecondSelected: Story = {
   args: {
+    testStatus: TestStatus.Passed,
     selectedBrowser: browserSafari,
     browserResults: [
       {
@@ -95,6 +113,7 @@ export const WithManyBrowsersSecondSelected: Story = {
 
 export const WithManyBrowsersVaried: Story = {
   args: {
+    testStatus: TestStatus.Pending,
     selectedBrowser: browserChrome,
     browserResults: [
       {

--- a/src/components/BrowserSelector.tsx
+++ b/src/components/BrowserSelector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Browser, BrowserInfo, ComparisonResult } from "../gql/graphql";
+import { Browser, BrowserInfo, ComparisonResult, TestStatus } from "../gql/graphql";
 import { aggregateResult } from "../utils/aggregateResult";
 import { ArrowIcon } from "./icons/ArrowIcon";
 import { ChromeIcon } from "./icons/ChromeIcon";
@@ -20,12 +20,14 @@ const browserIcons = {
 type BrowserData = Pick<BrowserInfo, "id" | "key" | "name">;
 
 interface BrowserSelectorProps {
+  testStatus: TestStatus;
   selectedBrowser: BrowserData;
   browserResults: { browser: BrowserData; result: ComparisonResult }[];
   onSelectBrowser: (browser: BrowserData) => void;
 }
 
 export const BrowserSelector = ({
+  testStatus,
   selectedBrowser,
   browserResults,
   onSelectBrowser,
@@ -36,7 +38,9 @@ export const BrowserSelector = ({
       active: selectedBrowser === browser,
       id: browser.id,
       onClick: () => onSelectBrowser(browser),
-      right: result !== ComparisonResult.Equal && <StatusDot status={result} />,
+      right: testStatus !== TestStatus.Accepted && result !== ComparisonResult.Equal && (
+        <StatusDot status={result} />
+      ),
       title: browser.name,
     }));
 
@@ -46,7 +50,7 @@ export const BrowserSelector = ({
   const icon = browserIcons[selectedBrowser.key];
   return (
     <TooltipMenu placement="bottom" links={links}>
-      {aggregate === ComparisonResult.Equal ? (
+      {testStatus === TestStatus.Accepted || aggregate === ComparisonResult.Equal ? (
         icon
       ) : (
         <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>

--- a/src/components/BrowserSelector.tsx
+++ b/src/components/BrowserSelector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Browser, BrowserInfo, ComparisonResult, TestStatus } from "../gql/graphql";
+import { Browser, BrowserInfo, ComparisonResult } from "../gql/graphql";
 import { aggregateResult } from "../utils/aggregateResult";
 import { ArrowIcon } from "./icons/ArrowIcon";
 import { ChromeIcon } from "./icons/ChromeIcon";
@@ -20,14 +20,14 @@ const browserIcons = {
 type BrowserData = Pick<BrowserInfo, "id" | "key" | "name">;
 
 interface BrowserSelectorProps {
-  testStatus: TestStatus;
+  isAccepted: boolean;
   selectedBrowser: BrowserData;
   browserResults: { browser: BrowserData; result: ComparisonResult }[];
   onSelectBrowser: (browser: BrowserData) => void;
 }
 
 export const BrowserSelector = ({
-  testStatus,
+  isAccepted,
   selectedBrowser,
   browserResults,
   onSelectBrowser,
@@ -38,9 +38,7 @@ export const BrowserSelector = ({
       active: selectedBrowser === browser,
       id: browser.id,
       onClick: () => onSelectBrowser(browser),
-      right: testStatus !== TestStatus.Accepted && result !== ComparisonResult.Equal && (
-        <StatusDot status={result} />
-      ),
+      right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
       title: browser.name,
     }));
 
@@ -50,7 +48,7 @@ export const BrowserSelector = ({
   const icon = browserIcons[selectedBrowser.key];
   return (
     <TooltipMenu placement="bottom" links={links}>
-      {testStatus === TestStatus.Accepted || aggregate === ComparisonResult.Equal ? (
+      {isAccepted || aggregate === ComparisonResult.Equal ? (
         icon
       ) : (
         <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>

--- a/src/components/ViewportSelector.stories.ts
+++ b/src/components/ViewportSelector.stories.ts
@@ -1,7 +1,7 @@
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { ComparisonResult, TestStatus } from "../gql/graphql";
+import { ComparisonResult } from "../gql/graphql";
 import { ViewportSelector } from "./ViewportSelector";
 
 const viewport800Px = {
@@ -16,6 +16,7 @@ const viewport1200Px = {
 const meta = {
   component: ViewportSelector,
   args: {
+    isAccepted: false,
     onSelectViewport: action("onSelectViewport"),
   },
 } satisfies Meta<typeof ViewportSelector>;
@@ -25,7 +26,6 @@ type Story = StoryObj<typeof meta>;
 
 export const WithSingleViewportChanged: Story = {
   args: {
-    testStatus: TestStatus.Pending,
     selectedViewport: viewport1200Px,
     viewportResults: [
       {
@@ -38,7 +38,7 @@ export const WithSingleViewportChanged: Story = {
 
 export const WithSingleViewportAccepted: Story = {
   args: {
-    testStatus: TestStatus.Accepted,
+    isAccepted: true,
     selectedViewport: viewport1200Px,
     viewportResults: [
       {
@@ -51,7 +51,6 @@ export const WithSingleViewportAccepted: Story = {
 
 export const WithSingleViewportEqual: Story = {
   args: {
-    testStatus: TestStatus.Passed,
     selectedViewport: viewport1200Px,
     viewportResults: [
       {
@@ -64,7 +63,6 @@ export const WithSingleViewportEqual: Story = {
 
 export const WithSingleViewportError: Story = {
   args: {
-    testStatus: TestStatus.Broken,
     selectedViewport: viewport1200Px,
     viewportResults: [
       {
@@ -77,7 +75,6 @@ export const WithSingleViewportError: Story = {
 
 export const WithManyViewportsEqual: Story = {
   args: {
-    testStatus: TestStatus.Passed,
     selectedViewport: viewport800Px,
     viewportResults: [
       {
@@ -94,7 +91,6 @@ export const WithManyViewportsEqual: Story = {
 
 export const WithManyViewportsSecondSelected: Story = {
   args: {
-    testStatus: TestStatus.Pending,
     selectedViewport: viewport1200Px,
     viewportResults: [
       {
@@ -111,7 +107,6 @@ export const WithManyViewportsSecondSelected: Story = {
 
 export const WithManyViewportsVaried: Story = {
   args: {
-    testStatus: TestStatus.Pending,
     selectedViewport: viewport800Px,
     viewportResults: [
       {

--- a/src/components/ViewportSelector.stories.ts
+++ b/src/components/ViewportSelector.stories.ts
@@ -1,7 +1,7 @@
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { ComparisonResult } from "../gql/graphql";
+import { ComparisonResult, TestStatus } from "../gql/graphql";
 import { ViewportSelector } from "./ViewportSelector";
 
 const viewport800Px = {
@@ -25,6 +25,20 @@ type Story = StoryObj<typeof meta>;
 
 export const WithSingleViewportChanged: Story = {
   args: {
+    testStatus: TestStatus.Pending,
+    selectedViewport: viewport1200Px,
+    viewportResults: [
+      {
+        viewport: viewport1200Px,
+        result: ComparisonResult.Changed,
+      },
+    ],
+  },
+};
+
+export const WithSingleViewportAccepted: Story = {
+  args: {
+    testStatus: TestStatus.Accepted,
     selectedViewport: viewport1200Px,
     viewportResults: [
       {
@@ -37,6 +51,7 @@ export const WithSingleViewportChanged: Story = {
 
 export const WithSingleViewportEqual: Story = {
   args: {
+    testStatus: TestStatus.Passed,
     selectedViewport: viewport1200Px,
     viewportResults: [
       {
@@ -49,6 +64,7 @@ export const WithSingleViewportEqual: Story = {
 
 export const WithSingleViewportError: Story = {
   args: {
+    testStatus: TestStatus.Broken,
     selectedViewport: viewport1200Px,
     viewportResults: [
       {
@@ -61,6 +77,7 @@ export const WithSingleViewportError: Story = {
 
 export const WithManyViewportsEqual: Story = {
   args: {
+    testStatus: TestStatus.Passed,
     selectedViewport: viewport800Px,
     viewportResults: [
       {
@@ -77,6 +94,7 @@ export const WithManyViewportsEqual: Story = {
 
 export const WithManyViewportsSecondSelected: Story = {
   args: {
+    testStatus: TestStatus.Pending,
     selectedViewport: viewport1200Px,
     viewportResults: [
       {
@@ -93,6 +111,7 @@ export const WithManyViewportsSecondSelected: Story = {
 
 export const WithManyViewportsVaried: Story = {
   args: {
+    testStatus: TestStatus.Pending,
     selectedViewport: viewport800Px,
     viewportResults: [
       {

--- a/src/components/ViewportSelector.tsx
+++ b/src/components/ViewportSelector.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "@storybook/design-system";
 import React from "react";
 
-import { ComparisonResult, ViewportInfo } from "../gql/graphql";
+import { ComparisonResult, TestStatus, ViewportInfo } from "../gql/graphql";
 import { aggregateResult } from "../utils/aggregateResult";
 import { ArrowIcon } from "./icons/ArrowIcon";
 import { StatusDot, StatusDotWrapper } from "./StatusDot";
@@ -10,12 +10,14 @@ import { TooltipMenu } from "./TooltipMenu";
 type ViewportData = Pick<ViewportInfo, "id" | "name">;
 
 interface ViewportSelectorProps {
+  testStatus: TestStatus;
   selectedViewport: ViewportData;
   onSelectViewport: (viewport: ViewportData) => void;
   viewportResults: { viewport: ViewportData; result: ComparisonResult }[];
 }
 
 export const ViewportSelector = ({
+  testStatus,
   selectedViewport,
   viewportResults,
   onSelectViewport,
@@ -29,12 +31,14 @@ export const ViewportSelector = ({
       links={viewportResults.map(({ viewport, result }) => ({
         id: viewport.id,
         title: viewport.name,
-        right: result !== ComparisonResult.Equal && <StatusDot status={result} />,
+        right: testStatus !== TestStatus.Accepted && result !== ComparisonResult.Equal && (
+          <StatusDot status={result} />
+        ),
         onClick: () => onSelectViewport(viewport),
         active: selectedViewport === viewport,
       }))}
     >
-      {aggregate === ComparisonResult.Equal ? (
+      {testStatus === TestStatus.Accepted || aggregate === ComparisonResult.Equal ? (
         <Icon icon="grow" />
       ) : (
         <StatusDotWrapper status={aggregate}>

--- a/src/components/ViewportSelector.tsx
+++ b/src/components/ViewportSelector.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "@storybook/design-system";
 import React from "react";
 
-import { ComparisonResult, TestStatus, ViewportInfo } from "../gql/graphql";
+import { ComparisonResult, ViewportInfo } from "../gql/graphql";
 import { aggregateResult } from "../utils/aggregateResult";
 import { ArrowIcon } from "./icons/ArrowIcon";
 import { StatusDot, StatusDotWrapper } from "./StatusDot";
@@ -10,14 +10,14 @@ import { TooltipMenu } from "./TooltipMenu";
 type ViewportData = Pick<ViewportInfo, "id" | "name">;
 
 interface ViewportSelectorProps {
-  testStatus: TestStatus;
+  isAccepted: boolean;
   selectedViewport: ViewportData;
   onSelectViewport: (viewport: ViewportData) => void;
   viewportResults: { viewport: ViewportData; result: ComparisonResult }[];
 }
 
 export const ViewportSelector = ({
-  testStatus,
+  isAccepted,
   selectedViewport,
   viewportResults,
   onSelectViewport,
@@ -31,14 +31,12 @@ export const ViewportSelector = ({
       links={viewportResults.map(({ viewport, result }) => ({
         id: viewport.id,
         title: viewport.name,
-        right: testStatus !== TestStatus.Accepted && result !== ComparisonResult.Equal && (
-          <StatusDot status={result} />
-        ),
+        right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
         onClick: () => onSelectViewport(viewport),
         active: selectedViewport === viewport,
       }))}
     >
-      {testStatus === TestStatus.Accepted || aggregate === ComparisonResult.Equal ? (
+      {isAccepted || aggregate === ComparisonResult.Equal ? (
         <Icon icon="grow" />
       ) : (
         <StatusDotWrapper status={aggregate}>

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -63,7 +63,7 @@ export const SnapshotComparison = ({
                 hasChrome={false}
               >
                 <ViewportSelector
-                  testStatus={selectedTest.status}
+                  isAccepted={selectedTest.status === TestStatus.Accepted}
                   selectedViewport={selectedTest.parameters.viewport}
                   viewportResults={viewportResults}
                   onSelectViewport={onSelectViewport}
@@ -79,7 +79,7 @@ export const SnapshotComparison = ({
                 hasChrome={false}
               >
                 <BrowserSelector
-                  testStatus={selectedTest.status}
+                  isAccepted={selectedTest.status === TestStatus.Accepted}
                   selectedBrowser={selectedComparison.browser}
                   browserResults={browserResults}
                   onSelectBrowser={onSelectBrowser}

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -42,7 +42,8 @@ export const SnapshotComparison = ({
   const [focusVisible, setFocusVisible] = useState(false);
 
   const { selectedTest, selectedComparison, onSelectBrowser, onSelectViewport } = useTests(tests);
-  const { isInProgress, changeCount, browserResults, viewportResults } = summarizeTests(tests);
+  const { status, isInProgress, changeCount, browserResults, viewportResults } =
+    summarizeTests(tests);
 
   return (
     <>
@@ -63,7 +64,7 @@ export const SnapshotComparison = ({
                 hasChrome={false}
               >
                 <ViewportSelector
-                  isAccepted={selectedTest.status === TestStatus.Accepted}
+                  isAccepted={status === TestStatus.Accepted}
                   selectedViewport={selectedTest.parameters.viewport}
                   viewportResults={viewportResults}
                   onSelectViewport={onSelectViewport}
@@ -79,7 +80,7 @@ export const SnapshotComparison = ({
                 hasChrome={false}
               >
                 <BrowserSelector
-                  isAccepted={selectedTest.status === TestStatus.Accepted}
+                  isAccepted={status === TestStatus.Accepted}
                   selectedBrowser={selectedComparison.browser}
                   browserResults={browserResults}
                   onSelectBrowser={onSelectBrowser}

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -63,6 +63,7 @@ export const SnapshotComparison = ({
                 hasChrome={false}
               >
                 <ViewportSelector
+                  testStatus={selectedTest.status}
                   selectedViewport={selectedTest.parameters.viewport}
                   viewportResults={viewportResults}
                   onSelectViewport={onSelectViewport}
@@ -78,6 +79,7 @@ export const SnapshotComparison = ({
                 hasChrome={false}
               >
                 <BrowserSelector
+                  testStatus={selectedTest.status}
                   selectedBrowser={selectedComparison.browser}
                   browserResults={browserResults}
                   onSelectBrowser={onSelectBrowser}

--- a/src/screens/VisualTests/StoryInfo.tsx
+++ b/src/screens/VisualTests/StoryInfo.tsx
@@ -92,7 +92,9 @@ export const StoryInfo = ({
     details = (
       <Text>
         <b>
-          {changeCount ? pluralize("change", changeCount, true) : "No changes"}
+          {changeCount && status === TestStatus.Pending
+            ? pluralize("change", changeCount, true)
+            : "No changes"}
           {brokenCount ? `, ${pluralize("error", brokenCount, true)}` : null}
         </b>
         <StatusIcon

--- a/src/utils/summarizeTests.test.ts
+++ b/src/utils/summarizeTests.test.ts
@@ -86,7 +86,7 @@ it("Calculates static information correctly", () => {
       ],
       "changeCount": 1,
       "isInProgress": true,
-      "status": "BROKEN",
+      "status": "IN_PROGRESS",
       "viewportResults": [
         {
           "result": "EQUAL",

--- a/src/utils/summarizeTests.ts
+++ b/src/utils/summarizeTests.ts
@@ -2,12 +2,12 @@ import { ComparisonResult, StoryTestFieldsFragment, TestResult, TestStatus } fro
 import { aggregateResult } from "./aggregateResult";
 
 function pickStatus(statusCounts: { [K in TestStatus]?: number }) {
+  if (statusCounts[TestStatus.InProgress] > 0) return TestStatus.InProgress;
   if (statusCounts[TestStatus.Failed] > 0) return TestStatus.Failed;
   if (statusCounts[TestStatus.Broken] > 0) return TestStatus.Broken;
   if (statusCounts[TestStatus.Denied] > 0) return TestStatus.Denied;
   if (statusCounts[TestStatus.Pending] > 0) return TestStatus.Pending;
   if (statusCounts[TestStatus.Accepted] > 0) return TestStatus.Accepted;
-  if (statusCounts[TestStatus.InProgress] > 0) return TestStatus.InProgress;
   return TestStatus.Passed;
 }
 

--- a/src/utils/summarizeTests.ts
+++ b/src/utils/summarizeTests.ts
@@ -2,8 +2,8 @@ import { ComparisonResult, StoryTestFieldsFragment, TestResult, TestStatus } fro
 import { aggregateResult } from "./aggregateResult";
 
 function pickStatus(statusCounts: { [K in TestStatus]?: number }) {
-  if (statusCounts[TestStatus.InProgress] > 0) return TestStatus.InProgress;
   if (statusCounts[TestStatus.Failed] > 0) return TestStatus.Failed;
+  if (statusCounts[TestStatus.InProgress] > 0) return TestStatus.InProgress;
   if (statusCounts[TestStatus.Broken] > 0) return TestStatus.Broken;
   if (statusCounts[TestStatus.Denied] > 0) return TestStatus.Denied;
   if (statusCounts[TestStatus.Pending] > 0) return TestStatus.Pending;


### PR DESCRIPTION
Changes the title to "No changes" and hides the status dots on the viewport and browser selector when changes are accepted.

Also fixes AP-3601
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.52--canary.70.444e17c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.52--canary.70.444e17c.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.52--canary.70.444e17c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
