### PR TITLE
Don't show menu when there's only one viewport or browser

### DIFF
--- a/src/components/BrowserSelector.tsx
+++ b/src/components/BrowserSelector.tsx
@@ -50,13 +50,15 @@ export const BrowserSelector = ({
     icon = <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>;
   }
 
-  const links = browserResults.map(({ browser, result }) => ({
-    active: selectedBrowser === browser,
-    id: browser.id,
-    onClick: () => onSelectBrowser(browser),
-    right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
-    title: browser.name,
-  }));
+  const links =
+    browserResults.length > 1 &&
+    browserResults.map(({ browser, result }) => ({
+      active: selectedBrowser === browser,
+      id: browser.id,
+      onClick: () => onSelectBrowser(browser),
+      right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
+      title: browser.name,
+    }));
 
   return (
     <WithTooltip
@@ -65,19 +67,17 @@ export const BrowserSelector = ({
       trigger="hover"
       tooltip={
         <TooltipNote
-          note={
-            links.length === 1 ? `Tested in ${browserResults[0].browser.name}` : "Switch browser"
-          }
+          note={links ? "Switch browser" : `Tested in ${browserResults[0].browser.name}`}
         />
       }
     >
-      {links.length === 1 ? (
-        <IconWrapper>{icon}</IconWrapper>
-      ) : (
+      {links ? (
         <TooltipMenu placement="bottom" links={links}>
           {icon}
           <ArrowIcon icon="arrowdown" />
         </TooltipMenu>
+      ) : (
+        <IconWrapper>{icon}</IconWrapper>
       )}
     </WithTooltip>
   );

--- a/src/components/ModeSelector.stories.ts
+++ b/src/components/ModeSelector.stories.ts
@@ -2,7 +2,7 @@ import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { ComparisonResult } from "../gql/graphql";
-import { ViewportSelector } from "./ViewportSelector";
+import { ModeSelector } from "./ModeSelector";
 
 const viewport800Px = {
   id: "_800",
@@ -14,12 +14,12 @@ const viewport1200Px = {
 };
 
 const meta = {
-  component: ViewportSelector,
+  component: ModeSelector,
   args: {
     isAccepted: false,
     onSelectViewport: action("onSelectViewport"),
   },
-} satisfies Meta<typeof ViewportSelector>;
+} satisfies Meta<typeof ModeSelector>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/components/ModeSelector.stories.ts
+++ b/src/components/ModeSelector.stories.ts
@@ -17,7 +17,7 @@ const meta = {
   component: ModeSelector,
   args: {
     isAccepted: false,
-    onSelectViewport: action("onSelectViewport"),
+    onSelectMode: action("onSelectMode"),
   },
 } satisfies Meta<typeof ModeSelector>;
 
@@ -26,8 +26,8 @@ type Story = StoryObj<typeof meta>;
 
 export const WithSingleViewportChanged: Story = {
   args: {
-    selectedViewport: viewport1200Px,
-    viewportResults: [
+    selectedMode: viewport1200Px,
+    modeResults: [
       {
         viewport: viewport1200Px,
         result: ComparisonResult.Changed,
@@ -39,8 +39,8 @@ export const WithSingleViewportChanged: Story = {
 export const WithSingleViewportAccepted: Story = {
   args: {
     isAccepted: true,
-    selectedViewport: viewport1200Px,
-    viewportResults: [
+    selectedMode: viewport1200Px,
+    modeResults: [
       {
         viewport: viewport1200Px,
         result: ComparisonResult.Changed,
@@ -51,8 +51,8 @@ export const WithSingleViewportAccepted: Story = {
 
 export const WithSingleViewportEqual: Story = {
   args: {
-    selectedViewport: viewport1200Px,
-    viewportResults: [
+    selectedMode: viewport1200Px,
+    modeResults: [
       {
         viewport: viewport1200Px,
         result: ComparisonResult.Equal,
@@ -63,8 +63,8 @@ export const WithSingleViewportEqual: Story = {
 
 export const WithSingleViewportError: Story = {
   args: {
-    selectedViewport: viewport1200Px,
-    viewportResults: [
+    selectedMode: viewport1200Px,
+    modeResults: [
       {
         viewport: viewport1200Px,
         result: ComparisonResult.CaptureError,
@@ -75,8 +75,8 @@ export const WithSingleViewportError: Story = {
 
 export const WithManyViewportsEqual: Story = {
   args: {
-    selectedViewport: viewport800Px,
-    viewportResults: [
+    selectedMode: viewport800Px,
+    modeResults: [
       {
         viewport: viewport800Px,
         result: ComparisonResult.Equal,
@@ -91,8 +91,8 @@ export const WithManyViewportsEqual: Story = {
 
 export const WithManyViewportsSecondSelected: Story = {
   args: {
-    selectedViewport: viewport1200Px,
-    viewportResults: [
+    selectedMode: viewport1200Px,
+    modeResults: [
       {
         viewport: viewport800Px,
         result: ComparisonResult.Equal,
@@ -107,8 +107,8 @@ export const WithManyViewportsSecondSelected: Story = {
 
 export const WithManyViewportsVaried: Story = {
   args: {
-    selectedViewport: viewport800Px,
-    viewportResults: [
+    selectedMode: viewport800Px,
+    modeResults: [
       {
         viewport: viewport800Px,
         result: ComparisonResult.Equal,

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -20,23 +20,23 @@ const IconWrapper = styled.div(({ theme }) => ({
 
 type ViewportData = Pick<ViewportInfo, "id" | "name">;
 
-interface ViewportSelectorProps {
+interface ModeSelectorProps {
   isAccepted: boolean;
   selectedViewport: ViewportData;
   onSelectViewport: (viewport: ViewportData) => void;
   viewportResults: { viewport: ViewportData; result: ComparisonResult }[];
 }
 
-export const ViewportSelector = ({
+export const ModeSelector = ({
   isAccepted,
   selectedViewport,
   viewportResults,
   onSelectViewport,
-}: ViewportSelectorProps) => {
+}: ModeSelectorProps) => {
   const aggregate = aggregateResult(viewportResults.map(({ result }) => result));
   if (!aggregate) return null;
 
-  let icon = <Icon icon="grow" />;
+  let icon = <Icon icon="diamond" />;
   if (!isAccepted && aggregate !== ComparisonResult.Equal) {
     icon = <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>;
   }
@@ -57,7 +57,7 @@ export const ViewportSelector = ({
       tooltip={
         <TooltipNote
           note={
-            links.length === 1 ? `Tested at ${viewportResults[0].viewport.name}` : "Switch viewport"
+            links.length === 1 ? `View mode: ${viewportResults[0].viewport.name}` : "Switch mode"
           }
         />
       }

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -18,22 +18,22 @@ const IconWrapper = styled.div(({ theme }) => ({
   },
 }));
 
-type ViewportData = Pick<ViewportInfo, "id" | "name">;
+type ModeData = Pick<ViewportInfo, "id" | "name">;
 
 interface ModeSelectorProps {
   isAccepted: boolean;
-  selectedViewport: ViewportData;
-  onSelectViewport: (viewport: ViewportData) => void;
-  viewportResults: { viewport: ViewportData; result: ComparisonResult }[];
+  selectedMode: ModeData;
+  onSelectMode: (viewport: ModeData) => void;
+  modeResults: { viewport: ModeData; result: ComparisonResult }[];
 }
 
 export const ModeSelector = ({
   isAccepted,
-  selectedViewport,
-  viewportResults,
-  onSelectViewport,
+  selectedMode,
+  modeResults,
+  onSelectMode,
 }: ModeSelectorProps) => {
-  const aggregate = aggregateResult(viewportResults.map(({ result }) => result));
+  const aggregate = aggregateResult(modeResults.map(({ result }) => result));
   if (!aggregate) return null;
 
   let icon = <Icon icon="diamond" />;
@@ -41,12 +41,12 @@ export const ModeSelector = ({
     icon = <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>;
   }
 
-  const links = viewportResults.map(({ viewport, result }) => ({
+  const links = modeResults.map(({ viewport, result }) => ({
     id: viewport.id,
     title: viewport.name,
     right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
-    onClick: () => onSelectViewport(viewport),
-    active: selectedViewport === viewport,
+    onClick: () => onSelectMode(viewport),
+    active: selectedMode === viewport,
   }));
 
   return (
@@ -56,9 +56,7 @@ export const ModeSelector = ({
       trigger="hover"
       tooltip={
         <TooltipNote
-          note={
-            links.length === 1 ? `View mode: ${viewportResults[0].viewport.name}` : "Switch mode"
-          }
+          note={links.length === 1 ? `View mode: ${modeResults[0].viewport.name}` : "Switch mode"}
         />
       }
     >
@@ -67,7 +65,7 @@ export const ModeSelector = ({
       ) : (
         <TooltipMenu placement="bottom" links={links}>
           {icon}
-          {selectedViewport.name}
+          {selectedMode.name}
           <ArrowIcon icon="arrowdown" />
         </TooltipMenu>
       )}

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -41,13 +41,15 @@ export const ModeSelector = ({
     icon = <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>;
   }
 
-  const links = modeResults.map(({ viewport, result }) => ({
-    id: viewport.id,
-    title: viewport.name,
-    right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
-    onClick: () => onSelectMode(viewport),
-    active: selectedMode === viewport,
-  }));
+  const links =
+    modeResults.length > 1 &&
+    modeResults.map(({ viewport, result }) => ({
+      id: viewport.id,
+      title: viewport.name,
+      right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
+      onClick: () => onSelectMode(viewport),
+      active: selectedMode === viewport,
+    }));
 
   return (
     <WithTooltip
@@ -55,19 +57,17 @@ export const ModeSelector = ({
       placement="top"
       trigger="hover"
       tooltip={
-        <TooltipNote
-          note={links.length === 1 ? `View mode: ${modeResults[0].viewport.name}` : "Switch mode"}
-        />
+        <TooltipNote note={links ? "Switch mode" : `View mode: ${modeResults[0].viewport.name}`} />
       }
     >
-      {links.length === 1 ? (
-        <IconWrapper>{icon}</IconWrapper>
-      ) : (
+      {links ? (
         <TooltipMenu placement="bottom" links={links}>
           {icon}
           {selectedMode.name}
           <ArrowIcon icon="arrowdown" />
         </TooltipMenu>
+      ) : (
+        <IconWrapper>{icon}</IconWrapper>
       )}
     </WithTooltip>
   );

--- a/src/components/ViewportSelector.tsx
+++ b/src/components/ViewportSelector.tsx
@@ -1,4 +1,6 @@
+import { TooltipNote, WithTooltip } from "@storybook/components";
 import { Icon } from "@storybook/design-system";
+import { styled } from "@storybook/theming";
 import React from "react";
 
 import { ComparisonResult, ViewportInfo } from "../gql/graphql";
@@ -6,6 +8,15 @@ import { aggregateResult } from "../utils/aggregateResult";
 import { ArrowIcon } from "./icons/ArrowIcon";
 import { StatusDot, StatusDotWrapper } from "./StatusDot";
 import { TooltipMenu } from "./TooltipMenu";
+
+const IconWrapper = styled.div(({ theme }) => ({
+  height: 14,
+  margin: "7px 7px",
+  color: `${theme.color.defaultText}99`,
+  svg: {
+    verticalAlign: "top",
+  },
+}));
 
 type ViewportData = Pick<ViewportInfo, "id" | "name">;
 
@@ -25,26 +36,41 @@ export const ViewportSelector = ({
   const aggregate = aggregateResult(viewportResults.map(({ result }) => result));
   if (!aggregate) return null;
 
+  let icon = <Icon icon="grow" />;
+  if (!isAccepted && aggregate !== ComparisonResult.Equal) {
+    icon = <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>;
+  }
+
+  const links = viewportResults.map(({ viewport, result }) => ({
+    id: viewport.id,
+    title: viewport.name,
+    right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
+    onClick: () => onSelectViewport(viewport),
+    active: selectedViewport === viewport,
+  }));
+
   return (
-    <TooltipMenu
-      placement="bottom"
-      links={viewportResults.map(({ viewport, result }) => ({
-        id: viewport.id,
-        title: viewport.name,
-        right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
-        onClick: () => onSelectViewport(viewport),
-        active: selectedViewport === viewport,
-      }))}
+    <WithTooltip
+      hasChrome={false}
+      placement="top"
+      trigger="hover"
+      tooltip={
+        <TooltipNote
+          note={
+            links.length === 1 ? `Tested at ${viewportResults[0].viewport.name}` : "Switch viewport"
+          }
+        />
+      }
     >
-      {isAccepted || aggregate === ComparisonResult.Equal ? (
-        <Icon icon="grow" />
+      {links.length === 1 ? (
+        <IconWrapper>{icon}</IconWrapper>
       ) : (
-        <StatusDotWrapper status={aggregate}>
-          <Icon icon="grow" />
-        </StatusDotWrapper>
+        <TooltipMenu placement="bottom" links={links}>
+          {icon}
+          {selectedViewport.name}
+          <ArrowIcon icon="arrowdown" />
+        </TooltipMenu>
       )}
-      {selectedViewport.name}
-      <ArrowIcon icon="arrowdown" />
-    </TooltipMenu>
+    </WithTooltip>
   );
 };

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -41,9 +41,8 @@ export const SnapshotComparison = ({
   const [diffVisible, setDiffVisible] = useState(true);
   const [focusVisible, setFocusVisible] = useState(false);
 
-  const { selectedTest, selectedComparison, onSelectBrowser, onSelectViewport } = useTests(tests);
-  const { status, isInProgress, changeCount, browserResults, viewportResults } =
-    summarizeTests(tests);
+  const { selectedTest, selectedComparison, onSelectBrowser, onSelectMode } = useTests(tests);
+  const { status, isInProgress, changeCount, browserResults, modeResults } = summarizeTests(tests);
 
   return (
     <>
@@ -56,13 +55,13 @@ export const SnapshotComparison = ({
         </Bar>
       ) : (
         <Bar>
-          {viewportResults.length > 0 && (
+          {modeResults.length > 0 && (
             <Col>
               <ModeSelector
                 isAccepted={status === TestStatus.Accepted}
-                selectedViewport={selectedTest.parameters.viewport}
-                viewportResults={viewportResults}
-                onSelectViewport={onSelectViewport}
+                selectedMode={selectedTest.parameters.viewport}
+                modeResults={modeResults}
+                onSelectMode={onSelectMode}
               />
             </Col>
           )}

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -58,34 +58,22 @@ export const SnapshotComparison = ({
         <Bar>
           {viewportResults.length > 0 && (
             <Col>
-              <WithTooltip
-                tooltip={<TooltipNote note="Switch viewport" />}
-                trigger="hover"
-                hasChrome={false}
-              >
-                <ViewportSelector
-                  isAccepted={status === TestStatus.Accepted}
-                  selectedViewport={selectedTest.parameters.viewport}
-                  viewportResults={viewportResults}
-                  onSelectViewport={onSelectViewport}
-                />
-              </WithTooltip>
+              <ViewportSelector
+                isAccepted={status === TestStatus.Accepted}
+                selectedViewport={selectedTest.parameters.viewport}
+                viewportResults={viewportResults}
+                onSelectViewport={onSelectViewport}
+              />
             </Col>
           )}
           {browserResults.length > 0 && (
             <Col>
-              <WithTooltip
-                tooltip={<TooltipNote note="Switch browser" />}
-                trigger="hover"
-                hasChrome={false}
-              >
-                <BrowserSelector
-                  isAccepted={status === TestStatus.Accepted}
-                  selectedBrowser={selectedComparison.browser}
-                  browserResults={browserResults}
-                  onSelectBrowser={onSelectBrowser}
-                />
-              </WithTooltip>
+              <BrowserSelector
+                isAccepted={status === TestStatus.Accepted}
+                selectedBrowser={selectedComparison.browser}
+                browserResults={browserResults}
+                onSelectBrowser={onSelectBrowser}
+              />
             </Col>
           )}
           {selectedComparison?.result === ComparisonResult.Changed && (

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -6,10 +6,10 @@ import { BrowserSelector } from "../../components/BrowserSelector";
 import { IconButton } from "../../components/IconButton";
 import { ProgressIcon } from "../../components/icons/ProgressIcon";
 import { Bar, Col } from "../../components/layout";
+import { ModeSelector } from "../../components/ModeSelector";
 import { Placeholder } from "../../components/Placeholder";
 import { SnapshotImage } from "../../components/SnapshotImage";
 import { TooltipMenu } from "../../components/TooltipMenu";
-import { ViewportSelector } from "../../components/ViewportSelector";
 import {
   ComparisonResult,
   ReviewTestBatch,
@@ -58,7 +58,7 @@ export const SnapshotComparison = ({
         <Bar>
           {viewportResults.length > 0 && (
             <Col>
-              <ViewportSelector
+              <ModeSelector
                 isAccepted={status === TestStatus.Accepted}
                 selectedViewport={selectedTest.parameters.viewport}
                 viewportResults={viewportResults}

--- a/src/screens/VisualTests/StoryInfo.tsx
+++ b/src/screens/VisualTests/StoryInfo.tsx
@@ -35,7 +35,7 @@ export const StoryInfo = ({
   isBuildFailed,
 }: StoryInfoSectionProps) => {
   // isInProgress means we have tests but they are still unfinished
-  const { status, isInProgress, changeCount, brokenCount, viewportResults, browserResults } =
+  const { status, isInProgress, changeCount, brokenCount, modeResults, browserResults } =
     summarizeTests(tests ?? []);
 
   const startedAgo =
@@ -105,14 +105,14 @@ export const StoryInfo = ({
         />
         <br />
         <small>
-          {viewportResults.length > 0 && (
+          {modeResults.length > 0 && (
             <span>
-              {pluralize("viewport", viewportResults.length, true)}
+              {pluralize("mode", modeResults.length, true)}
               {", "}
               {pluralize("browser", browserResults.length, true)}
             </span>
           )}
-          {viewportResults.length > 0 && " • "}
+          {modeResults.length > 0 && " • "}
           {isInProgress && <span>Test in progress...</span>}
           {!isInProgress && <span title={new Date(startedAt).toUTCString()}>{startedAgo}</span>}
         </small>

--- a/src/utils/summarizeTests.test.ts
+++ b/src/utils/summarizeTests.test.ts
@@ -51,7 +51,7 @@ const tests = [
 ];
 
 it("Calculates static information correctly", () => {
-  const { status, isInProgress, changeCount, brokenCount, browserResults, viewportResults } =
+  const { status, isInProgress, changeCount, brokenCount, browserResults, modeResults } =
     summarizeTests(tests);
 
   expect({
@@ -60,7 +60,7 @@ it("Calculates static information correctly", () => {
     changeCount,
     brokenCount,
     browserResults,
-    viewportResults,
+    modeResults,
   }).toMatchInlineSnapshot(`
     {
       "brokenCount": 1,
@@ -87,7 +87,7 @@ it("Calculates static information correctly", () => {
       "changeCount": 1,
       "isInProgress": true,
       "status": "IN_PROGRESS",
-      "viewportResults": [
+      "modeResults": [
         {
           "result": "EQUAL",
           "viewport": {

--- a/src/utils/summarizeTests.test.ts
+++ b/src/utils/summarizeTests.test.ts
@@ -86,7 +86,6 @@ it("Calculates static information correctly", () => {
       ],
       "changeCount": 1,
       "isInProgress": true,
-      "status": "IN_PROGRESS",
       "modeResults": [
         {
           "result": "EQUAL",
@@ -125,6 +124,7 @@ it("Calculates static information correctly", () => {
           },
         },
       ],
+      "status": "IN_PROGRESS",
     }
   `);
 });

--- a/src/utils/summarizeTests.ts
+++ b/src/utils/summarizeTests.ts
@@ -82,7 +82,7 @@ export function summarizeTests(tests: StoryTestFieldsFragment[]) {
     browser: browserInfoById[id],
     result,
   }));
-  const viewportResults = Object.entries(resultsByViewport).map(([id, result]) => ({
+  const modeResults = Object.entries(resultsByViewport).map(([id, result]) => ({
     viewport: viewportInfoById[id],
     result,
   }));
@@ -93,6 +93,6 @@ export function summarizeTests(tests: StoryTestFieldsFragment[]) {
     changeCount,
     brokenCount,
     browserResults,
-    viewportResults,
+    modeResults,
   };
 }

--- a/src/utils/useTests.ts
+++ b/src/utils/useTests.ts
@@ -2,8 +2,8 @@ import { useCallback, useState } from "react";
 
 import { BrowserInfo, StoryTestFieldsFragment, ViewportInfo } from "../gql/graphql";
 
-type ViewportData = Pick<ViewportInfo, "id" | "name">;
 type BrowserData = Pick<BrowserInfo, "id" | "key" | "name">;
+type ModeData = Pick<ViewportInfo, "id" | "name">;
 
 /**
  * Pick a single test+comparison (by viewport+browser) from a set of tests
@@ -13,15 +13,15 @@ export function useTests(tests: StoryTestFieldsFragment[]) {
   const [selectedBrowserId, onSelectBrowserId] = useState<BrowserData["id"]>(
     tests[0].comparisons[0].browser.id
   );
-  const [selectedViewportId, onSelectViewportId] = useState<ViewportData["id"]>(
+  const [selectedModeId, onSelectModeId] = useState<ModeData["id"]>(
     tests[0].comparisons[0].viewport.id
   );
 
   const onSelectBrowser = useCallback(({ id }: BrowserData) => onSelectBrowserId(id), []);
-  const onSelectViewport = useCallback(({ id }: ViewportData) => onSelectViewportId(id), []);
+  const onSelectMode = useCallback(({ id }: ModeData) => onSelectModeId(id), []);
 
   const selectedTest =
-    tests.find(({ parameters }) => parameters.viewport.id === selectedViewportId) || tests[0];
+    tests.find(({ parameters }) => parameters.viewport.id === selectedModeId) || tests[0];
 
   const selectedComparison =
     selectedTest.comparisons.find(({ browser }) => browser.id === selectedBrowserId) ||
@@ -31,6 +31,6 @@ export function useTests(tests: StoryTestFieldsFragment[]) {
     selectedTest,
     selectedComparison,
     onSelectBrowser,
-    onSelectViewport,
+    onSelectMode,
   };
 }


### PR DESCRIPTION
This yields a more minimalist UI if there is only one viewport and/or browser:

<img width="419" alt="Screenshot 2023-09-04 at 17 02 56" src="https://github.com/chromaui/addon-visual-tests/assets/321738/b573248b-bef3-4279-85cc-da023d462936">

(here we have one viewport, one browser)

Compare to the UI when we do have multiple viewports / browsers:

<img width="420" alt="Screenshot 2023-09-04 at 17 03 18" src="https://github.com/chromaui/addon-visual-tests/assets/321738/10c85fbf-2e72-4f12-aa07-09c89181f90e">

I also renamed "viewport" to "mode" and updated the icon.

With tooltips:

<img width="271" alt="Screen Recording 2023-09-04 at 19.20.25" src="https://github.com/chromaui/addon-visual-tests/assets/321738/56396404-b598-4d83-bdfa-f33a3e01175d">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.55--canary.72.51f5eed.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.55--canary.72.51f5eed.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.55--canary.72.51f5eed.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
