### PR TITLE
UI: Move toolbar button to sidebar

### DIFF
--- a/src/Tool.stories.ts
+++ b/src/Tool.stories.ts
@@ -1,0 +1,26 @@
+import { action } from "@storybook/addon-actions";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ToolContent } from "./Tool";
+
+const meta = {
+  component: ToolContent,
+  args: {
+    startBuild: action("startBuild"),
+  },
+} satisfies Meta<typeof ToolContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isRunning: false,
+  },
+};
+
+export const IsRunning: Story = {
+  args: {
+    isRunning: true,
+  },
+};

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -33,6 +33,16 @@ export const Tool = () => {
     return null;
   }
 
+  return <ToolContent isRunning={isRunning} startBuild={startBuild} />;
+};
+
+export const ToolContent = ({
+  isRunning = false,
+  startBuild,
+}: {
+  isRunning?: boolean;
+  startBuild: () => void;
+}) => {
   if (isRunning) {
     return (
       <WithTooltip tooltip="Running visual tests...">

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -1,11 +1,22 @@
+import { IconButton, Icons, WithTooltip } from "@storybook/components";
 import { useChannel } from "@storybook/manager-api";
-import React, { useState } from "react";
+import { styled } from "@storybook/theming";
+import React, { ComponentProps, FC } from "react";
 
-import { RunTestsButton } from "./components/RunTestsButton";
-import { RUNNING_BUILD, RunningBuildPayload, START_BUILD, TOOL_ID } from "./constants";
+import { RUNNING_BUILD, RunningBuildPayload, START_BUILD } from "./constants";
 import { useAddonState } from "./useAddonState/manager";
 import { useAccessToken } from "./utils/graphQLClient";
 import { useProjectId } from "./utils/useProjectId";
+
+export const SidebarIconButton = styled(IconButton)<ComponentProps<typeof IconButton>>(
+  ({ theme }) => ({
+    position: "relative",
+    overflow: "visible",
+    color: theme.textMutedColor,
+    marginTop: 0,
+    zIndex: 1,
+  })
+);
 
 export const Tool = () => {
   const { projectId } = useProjectId();
@@ -13,9 +24,27 @@ export const Tool = () => {
   const isLoggedIn = !!accessToken;
 
   const [runningBuild] = useAddonState<RunningBuildPayload>(RUNNING_BUILD);
+  const isRunning = !!runningBuild && runningBuild.step !== "complete";
+
   const emit = useChannel({});
   const startBuild = () => emit(START_BUILD);
 
-  const isStarting = ["initializing"].includes(runningBuild?.step);
-  return <RunTestsButton key={TOOL_ID} {...{ isStarting, projectId, isLoggedIn, startBuild }} />;
+  if (!projectId || isLoggedIn === false) {
+    return null;
+  }
+
+  if (isRunning) {
+    return (
+      <WithTooltip tooltip="Running visual tests...">
+        <SidebarIconButton>
+          <Icons icon="play" />
+        </SidebarIconButton>
+      </WithTooltip>
+    );
+  }
+  return (
+    <SidebarIconButton active={false} disabled={false} onClick={() => startBuild()}>
+      <Icons icon="play" />
+    </SidebarIconButton>
+  );
 };

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -8,8 +8,7 @@ import { Tool } from "./Tool";
 
 addons.register(ADDON_ID, (api) => {
   addons.add(TOOL_ID, {
-    type: types.TOOL,
-    title: "Run visual tests",
+    type: types.experimental_SIDEBAR_TOP,
     render: Tool,
   });
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,9 +6,7 @@ export default defineConfig((options) => [
     splitting: false,
     minify: !options.watch,
     format: ["cjs"],
-    dts: {
-      resolve: true,
-    },
+    dts: false,
     treeshake: true,
     sourcemap: true,
     clean: !options.watch,
@@ -22,9 +20,7 @@ export default defineConfig((options) => [
     splitting: false,
     minify: !options.watch,
     format: ["esm"],
-    dts: {
-      resolve: true,
-    },
+    dts: false,
     treeshake: true,
     sourcemap: true,
     clean: !options.watch,


### PR DESCRIPTION
# What I did:

- I changed the manager addon registration so it registers a sidebar-top item, instead of a tool
- I changed the UI of the component

# How to test

- Open storybook in repo
- Check if the toolbar button is removed
- Check if the sidebar shows the play-icon
- When logging out, or if you haven't selected a project yet, the sidebar Icon should NOT show.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.56--canary.77.02e49b5.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.56--canary.77.02e49b5.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.56--canary.77.02e49b5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
