### PR TITLE
Refactor `VisualTests` component into three

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -4,7 +4,7 @@ const config: CodegenConfig = {
   // @see https://github.com/chromaui/chromatic/blob/main/lib/schema/public-schema.graphql
   // We don't automatically update the schema yet, we copy it manually whenever it changes.
   schema: "src/gql/public-schema.graphql",
-  documents: ["src/**/*.tsx"],
+  documents: ["src/**/*.tsx", "src/**/*.ts"],
   ignoreNoDocuments: true, // for better experience with the watcher
   generates: {
     "./src/gql/": {

--- a/src/screens/VisualTests/BuildResults.tsx
+++ b/src/screens/VisualTests/BuildResults.tsx
@@ -1,6 +1,6 @@
 import { Icons } from "@storybook/components";
 import { Icon, TooltipNote, WithTooltip } from "@storybook/design-system";
-import React, { Dispatch, SetStateAction } from "react";
+import React, { Dispatch, SetStateAction, useState } from "react";
 
 import { Button } from "../../components/Button";
 import { Container } from "../../components/Container";
@@ -27,52 +27,43 @@ import { Warnings } from "./Warnings";
 
 interface BuildResultsProps {
   runningBuild: RunningBuildPayload;
+  storyBuild: StoryBuildFieldsFragment;
   nextBuild: NextBuildFieldsFragment;
-  switchToNextBuild: () => void;
-  canSwitchToNextBuild: boolean;
-  settingsVisible: boolean;
-  warningsVisible: boolean;
+  switchToNextBuild?: () => void;
   startDevBuild: () => void;
   isAccepting: boolean;
   onAccept: (testId: string, batch: ReviewTestBatch) => Promise<void>;
-  baselineImageVisible: boolean;
-  setSettingsVisible: Dispatch<SetStateAction<boolean>>;
-  setWarningsVisible: Dispatch<SetStateAction<boolean>>;
-  toggleBaselineImage: () => void;
-  storyBuild: StoryBuildFieldsFragment;
   setAccessToken: (accessToken: string | null) => void;
   uncommittedHash: string;
 }
 
 export const BuildResults = ({
   runningBuild,
-  canSwitchToNextBuild,
   nextBuild,
   switchToNextBuild,
-  settingsVisible,
-  warningsVisible,
   startDevBuild,
   isAccepting,
   onAccept,
-  baselineImageVisible,
-  setSettingsVisible,
-  setWarningsVisible,
-  toggleBaselineImage,
   storyBuild,
   setAccessToken,
   uncommittedHash,
 }: BuildResultsProps) => {
+  const [settingsVisible, setSettingsVisible] = useState(false);
+  const [warningsVisible, setWarningsVisible] = useState(false);
+  const [baselineImageVisible, setBaselineImageVisible] = useState(false);
+  const toggleBaselineImage = () => setBaselineImageVisible(!baselineImageVisible);
+
   const isRunningBuildInProgress = runningBuild && runningBuild.step !== "complete";
   const showBuildStatus =
     // We always want to show the status of the running build (until it is done)
     isRunningBuildInProgress ||
     // Even if there's no build running, we want to show the next build if it hasn't been selected.
-    (canSwitchToNextBuild && nextBuild.id !== storyBuild?.id);
+    (switchToNextBuild && nextBuild.id !== storyBuild?.id);
   const runningBuildIsNextBuild = runningBuild && runningBuild?.id === nextBuild?.id;
   const buildStatus = showBuildStatus && (
     <BuildProgress
       runningBuild={(runningBuildIsNextBuild || isRunningBuildInProgress) && runningBuild}
-      switchToNextBuild={canSwitchToNextBuild && switchToNextBuild}
+      switchToNextBuild={switchToNextBuild}
     />
   );
 

--- a/src/screens/VisualTests/BuildResults.tsx
+++ b/src/screens/VisualTests/BuildResults.tsx
@@ -1,0 +1,227 @@
+import { Icons } from "@storybook/components";
+import { Icon, TooltipNote, WithTooltip } from "@storybook/design-system";
+import React, { Dispatch, SetStateAction } from "react";
+
+import { Button } from "../../components/Button";
+import { Container } from "../../components/Container";
+import { FooterMenu } from "../../components/FooterMenu";
+import { Heading } from "../../components/Heading";
+import { IconButton } from "../../components/IconButton";
+import { Bar, Col, Section, Sections, Text } from "../../components/layout";
+import { Text as CenterText } from "../../components/Text";
+import { RunningBuildPayload } from "../../constants";
+import { getFragment } from "../../gql";
+import {
+  BuildStatus,
+  NextBuildFieldsFragment,
+  ReviewTestBatch,
+  StoryBuildFieldsFragment,
+  TestResult,
+} from "../../gql/graphql";
+import { BuildProgress } from "./BuildProgress";
+import { FragmentStoryTestFields } from "./graphql";
+import { RenderSettings } from "./RenderSettings";
+import { SnapshotComparison } from "./SnapshotComparison";
+import { StoryInfo } from "./StoryInfo";
+import { Warnings } from "./Warnings";
+
+interface BuildResultsProps {
+  runningBuild: RunningBuildPayload;
+  nextBuild: NextBuildFieldsFragment;
+  switchToNextBuild: () => void;
+  canSwitchToNextBuild: boolean;
+  settingsVisible: boolean;
+  warningsVisible: boolean;
+  startDevBuild: () => void;
+  isAccepting: boolean;
+  onAccept: (testId: string, batch: ReviewTestBatch) => Promise<void>;
+  baselineImageVisible: boolean;
+  setSettingsVisible: Dispatch<SetStateAction<boolean>>;
+  setWarningsVisible: Dispatch<SetStateAction<boolean>>;
+  toggleBaselineImage: () => void;
+  storyBuild: StoryBuildFieldsFragment;
+  setAccessToken: (accessToken: string | null) => void;
+  uncommittedHash: string;
+}
+
+export const BuildResults = ({
+  runningBuild,
+  canSwitchToNextBuild,
+  nextBuild,
+  switchToNextBuild,
+  settingsVisible,
+  warningsVisible,
+  startDevBuild,
+  isAccepting,
+  onAccept,
+  baselineImageVisible,
+  setSettingsVisible,
+  setWarningsVisible,
+  toggleBaselineImage,
+  storyBuild,
+  setAccessToken,
+  uncommittedHash,
+}: BuildResultsProps) => {
+  const isRunningBuildInProgress = runningBuild && runningBuild.step !== "complete";
+  const showBuildStatus =
+    // We always want to show the status of the running build (until it is done)
+    isRunningBuildInProgress ||
+    // Even if there's no build running, we want to show the next build if it hasn't been selected.
+    (canSwitchToNextBuild && nextBuild.id !== storyBuild?.id);
+  const runningBuildIsNextBuild = runningBuild && runningBuild?.id === nextBuild?.id;
+  const buildStatus = showBuildStatus && (
+    <BuildProgress
+      runningBuild={(runningBuildIsNextBuild || isRunningBuildInProgress) && runningBuild}
+      switchToNextBuild={canSwitchToNextBuild && switchToNextBuild}
+    />
+  );
+
+  const storyTests = [
+    ...getFragment(
+      FragmentStoryTestFields,
+      "testsForStory" in storyBuild ? storyBuild.testsForStory.nodes : []
+    ),
+  ];
+
+  // It shouldn't be possible for one test to be skipped but not all of them
+  const isSkipped = !!storyTests?.find((t) => t.result === TestResult.Skipped);
+  if (isSkipped) {
+    return (
+      <Sections>
+        {buildStatus}
+        <Section grow>
+          <Container>
+            <Heading>This story was skipped</Heading>
+            <CenterText>
+              If you would like to resume testing it, comment out or remove
+              `parameters.chromatic.disableSnapshot = true` from the CSF file.
+            </CenterText>
+            <Button
+              belowText
+              small
+              tertiary
+              containsIcon
+              // @ts-expect-error Button component is not quite typed properly
+              target="_new"
+              isLink
+              href="https://www.chromatic.com/docs/ignoring-elements#ignore-stories"
+            >
+              <Icons icon="document" />
+              View Docs
+            </Button>
+          </Container>
+        </Section>
+      </Sections>
+    );
+  }
+
+  const isStoryBuildStarting = [
+    BuildStatus.Announced,
+    BuildStatus.Published,
+    BuildStatus.Prepared,
+  ].includes(storyBuild?.status);
+  const startedAt = "startedAt" in storyBuild && storyBuild.startedAt;
+  const isOutdated = storyBuild && storyBuild.uncommittedHash !== uncommittedHash;
+  const isBuildFailed = storyBuild.status === BuildStatus.Failed;
+
+  return (
+    <Sections>
+      {buildStatus}
+
+      <Section grow hidden={settingsVisible || warningsVisible}>
+        <StoryInfo
+          {...{
+            tests: storyTests,
+            isOutdated,
+            startedAt,
+            isStarting: isStoryBuildStarting,
+            startDevBuild,
+            isBuildFailed,
+          }}
+        />
+        {!isStoryBuildStarting && storyTests && storyTests.length > 0 && (
+          <SnapshotComparison
+            {...{ tests: storyTests, isAccepting, isOutdated, onAccept, baselineImageVisible }}
+          />
+        )}
+      </Section>
+
+      <Section grow hidden={!settingsVisible}>
+        <RenderSettings onClose={() => setSettingsVisible(false)} />
+      </Section>
+      <Section grow hidden={!warningsVisible}>
+        <Warnings onClose={() => setWarningsVisible(false)} />
+      </Section>
+      <Section>
+        <Bar>
+          <Col>
+            <WithTooltip
+              tooltip={<TooltipNote note="Switch snapshot" />}
+              trigger="hover"
+              hasChrome={false}
+            >
+              <IconButton
+                data-testid="button-toggle-snapshot"
+                onClick={() => toggleBaselineImage()}
+              >
+                <Icon icon="transfer" />
+              </IconButton>
+            </WithTooltip>
+          </Col>
+          <Col style={{ overflow: "hidden", whiteSpace: "nowrap" }}>
+            {baselineImageVisible ? (
+              <Text style={{ marginLeft: 5, width: "100%" }}>
+                <b>Baseline</b> Build {storyBuild.number} on {storyBuild.branch}
+              </Text>
+            ) : (
+              <Text style={{ marginLeft: 5, width: "100%" }}>
+                <b>Latest</b> Build {storyBuild.number} on {storyBuild.branch}
+              </Text>
+            )}
+          </Col>
+          {/* <Col push>
+            <WithTooltip
+              tooltip={<TooltipNote note="Render settings" />}
+              trigger="hover"
+              hasChrome={false}
+            >
+            <IconButton
+              active={settingsVisible}
+              aria-label={`${settingsVisible ? "Hide" : "Show"} render settings`}
+              onClick={() => {
+                setSettingsVisible(!settingsVisible);
+                setWarningsVisible(false);
+              }}
+            >
+              <Icons icon="controls" />
+            </IconButton>
+          </WithTooltip>
+          </Col>
+          <Col>
+            <WithTooltip
+              tooltip={<TooltipNote note="View warnings" />}
+              trigger="hover"
+              hasChrome={false}
+            >
+              <IconButton
+                active={warningsVisible}
+                aria-label={`${warningsVisible ? "Hide" : "Show"} warnings`}
+                onClick={() => {
+                  setWarningsVisible(!warningsVisible);
+                  setSettingsVisible(false);
+                }}
+                status="warning"
+              >
+                <Icons icon="alert" />2
+              </IconButton>
+  
+            </WithTooltip>
+          </Col> */}
+          <Col push>
+            <FooterMenu setAccessToken={setAccessToken} />
+          </Col>
+        </Bar>
+      </Section>
+    </Sections>
+  );
+};

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -9,29 +9,24 @@ import { Heading } from "../../components/Heading";
 import { ProgressIcon } from "../../components/icons/ProgressIcon";
 import { Bar, Col, Row, Section, Sections, Text } from "../../components/layout";
 import { Text as CenterText } from "../../components/Text";
-import { GitInfoPayload } from "../../constants";
-import { AddonVisualTestsBuildQuery, NextBuildFieldsFragment } from "../../gql/graphql";
 
 interface NoBuildProps {
   error: CombinedError;
-  data: AddonVisualTestsBuildQuery;
-  nextBuild: NextBuildFieldsFragment;
+  hasData: boolean;
+  hasNextBuild: boolean;
   startDevBuild: () => void;
   isRunningBuildStarting: boolean;
-  gitInfo: Pick<
-    GitInfoPayload,
-    "slug" | "branch" | "committedAt" | "uncommittedHash" | "userEmailHash"
-  >;
+  branch: string;
   setAccessToken: (accessToken: string | null) => void;
 }
 
 export const NoBuild = ({
   error,
-  data,
-  nextBuild,
+  hasData,
+  hasNextBuild,
   startDevBuild,
   isRunningBuildStarting,
-  gitInfo,
+  branch,
   setAccessToken,
 }: NoBuildProps) => (
   <Sections>
@@ -44,9 +39,9 @@ export const NoBuild = ({
         </Row>
       )}
 
-      {!data && <Loader />}
+      {!hasData && <Loader />}
 
-      {data && !nextBuild && !error && (
+      {hasData && !hasNextBuild && !error && (
         <Container>
           <Heading>Create a test baseline</Heading>
           <CenterText>
@@ -70,7 +65,7 @@ export const NoBuild = ({
       <Bar>
         <Col>
           <Text style={{ marginLeft: 5 }}>
-            {data ? `Waiting for build on ${gitInfo.branch}` : "Loading..."}
+            {hasData ? `Waiting for build on ${branch}` : "Loading..."}
           </Text>
         </Col>
         <Col push>

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -1,0 +1,82 @@
+import { Icons, Loader } from "@storybook/components";
+import React from "react";
+import { CombinedError } from "urql";
+
+import { Button } from "../../components/Button";
+import { Container } from "../../components/Container";
+import { FooterMenu } from "../../components/FooterMenu";
+import { Heading } from "../../components/Heading";
+import { ProgressIcon } from "../../components/icons/ProgressIcon";
+import { Bar, Col, Row, Section, Sections, Text } from "../../components/layout";
+import { Text as CenterText } from "../../components/Text";
+import { GitInfoPayload } from "../../constants";
+import { AddonVisualTestsBuildQuery, NextBuildFieldsFragment } from "../../gql/graphql";
+
+interface NoBuildProps {
+  error: CombinedError;
+  data: AddonVisualTestsBuildQuery;
+  nextBuild: NextBuildFieldsFragment;
+  startDevBuild: () => void;
+  isRunningBuildStarting: boolean;
+  gitInfo: Pick<
+    GitInfoPayload,
+    "slug" | "branch" | "committedAt" | "uncommittedHash" | "userEmailHash"
+  >;
+  setAccessToken: (accessToken: string | null) => void;
+}
+
+export const NoBuild = ({
+  error,
+  data,
+  nextBuild,
+  startDevBuild,
+  isRunningBuildStarting,
+  gitInfo,
+  setAccessToken,
+}: NoBuildProps) => (
+  <Sections>
+    <Section grow>
+      {error && (
+        <Row>
+          <Col>
+            <Text>{error.message}</Text>
+          </Col>
+        </Row>
+      )}
+
+      {!data && <Loader />}
+
+      {data && !nextBuild && !error && (
+        <Container>
+          <Heading>Create a test baseline</Heading>
+          <CenterText>
+            Take an image snapshot of each story to save their &quot;last known good state&quot; as
+            test baselines.
+          </CenterText>
+          <br />
+          <Button small secondary onClick={startDevBuild} disabled={isRunningBuildStarting}>
+            {isRunningBuildStarting ? (
+              <ProgressIcon parentComponent="Button" style={{ marginRight: 6 }} />
+            ) : (
+              <Icons icon="play" />
+            )}
+            Take snapshots
+          </Button>
+        </Container>
+      )}
+    </Section>
+
+    <Section>
+      <Bar>
+        <Col>
+          <Text style={{ marginLeft: 5 }}>
+            {data ? `Waiting for build on ${gitInfo.branch}` : "Loading..."}
+          </Text>
+        </Col>
+        <Col push>
+          <FooterMenu setAccessToken={setAccessToken} />
+        </Col>
+      </Bar>
+    </Section>
+  </Sections>
+);

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -49,11 +49,6 @@ export const VisualTests = ({
   gitInfo,
   storyId,
 }: VisualTestsProps) => {
-  const [settingsVisible, setSettingsVisible] = useState(false);
-  const [warningsVisible, setWarningsVisible] = useState(false);
-  const [baselineImageVisible, setBaselineImageVisible] = useState(false);
-  const toggleBaselineImage = () => setBaselineImageVisible(!baselineImageVisible);
-
   // The storyId and buildId that drive the test(s) we are currently looking at
   // The user can choose when to change story (via sidebar) and build (via opting into new builds)
   const [storyBuildInfo, setStoryBuildInfo] = useState<{
@@ -152,15 +147,16 @@ export const VisualTests = ({
 
   const isRunningBuildStarting = runningBuild?.step === "initialize";
 
+  const { branch, uncommittedHash } = gitInfo;
   return !nextBuild || error ? (
     <NoBuild
       {...{
         error,
-        data,
-        nextBuild,
+        hasData: !!data,
+        hasNextBuild: !!nextBuild,
         startDevBuild,
         isRunningBuildStarting,
-        gitInfo,
+        branch,
         setAccessToken,
       }}
     />
@@ -169,20 +165,13 @@ export const VisualTests = ({
       {...{
         runningBuild,
         nextBuild,
-        switchToNextBuild,
-        canSwitchToNextBuild,
-        settingsVisible,
-        warningsVisible,
+        switchToNextBuild: canSwitchToNextBuild && switchToNextBuild,
         startDevBuild,
         isAccepting,
         onAccept,
-        baselineImageVisible,
-        setSettingsVisible,
-        setWarningsVisible,
-        toggleBaselineImage,
         storyBuild,
         setAccessToken,
-        uncommittedHash: gitInfo.uncommittedHash,
+        uncommittedHash,
       }}
     />
   );

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -152,24 +152,19 @@ export const VisualTests = ({
 
   const isRunningBuildStarting = runningBuild?.step === "initialize";
 
-  if (!nextBuild || error) {
-    return (
-      <NoBuild
-        {...{
-          error,
-          data,
-          nextBuild,
-          startDevBuild,
-          isRunningBuildStarting,
-          gitInfo,
-          setAccessToken,
-        }}
-      />
-    );
-  }
-  const { uncommittedHash } = gitInfo;
-
-  return (
+  return !nextBuild || error ? (
+    <NoBuild
+      {...{
+        error,
+        data,
+        nextBuild,
+        startDevBuild,
+        isRunningBuildStarting,
+        gitInfo,
+        setAccessToken,
+      }}
+    />
+  ) : (
     <BuildResults
       {...{
         runningBuild,
@@ -187,7 +182,7 @@ export const VisualTests = ({
         toggleBaselineImage,
         storyBuild,
         setAccessToken,
-        uncommittedHash,
+        uncommittedHash: gitInfo.uncommittedHash,
       }}
     />
   );

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -1,43 +1,27 @@
-import { Icons } from "@storybook/components";
-import { Icon, TooltipNote, WithTooltip } from "@storybook/design-system";
 import type { API_StatusState } from "@storybook/types";
 import React, { useCallback, useEffect, useState } from "react";
 import { useMutation, useQuery } from "urql";
 
-import { Button } from "../../components/Button";
-import { Container } from "../../components/Container";
-import { FooterMenu } from "../../components/FooterMenu";
-import { Heading } from "../../components/Heading";
-import { IconButton } from "../../components/IconButton";
-import { Bar, Col, Section, Sections, Text } from "../../components/layout";
-import { Text as CenterText } from "../../components/Text";
 import { GitInfoPayload, RunningBuildPayload } from "../../constants";
 import { getFragment } from "../../gql";
 import {
   AddonVisualTestsBuildQuery,
   AddonVisualTestsBuildQueryVariables,
-  BuildStatus,
   ReviewTestBatch,
   ReviewTestInputStatus,
-  TestResult,
   TestStatus,
 } from "../../gql/graphql";
 import { UpdateStatusFunction } from "../../types";
 import { statusMap, testsToStatusUpdate } from "../../utils/testsToStatusUpdate";
-import { BuildProgress } from "./BuildProgress";
+import { BuildResults } from "./BuildResults";
 import {
   FragmentNextBuildFields,
   FragmentStatusTestFields,
   FragmentStoryBuildFields,
-  FragmentStoryTestFields,
   MutationReviewTest,
   QueryBuild,
 } from "./graphql";
 import { NoBuild } from "./NoBuild";
-import { RenderSettings } from "./RenderSettings";
-import { SnapshotComparison } from "./SnapshotComparison";
-import { StoryInfo } from "./StoryInfo";
-import { Warnings } from "./Warnings";
 
 const createEmptyStoryStatusUpdate = (state: API_StatusState) => {
   return Object.fromEntries(Object.entries(state).map(([id, update]) => [id, null]));
@@ -183,166 +167,28 @@ export const VisualTests = ({
       />
     );
   }
+  const { uncommittedHash } = gitInfo;
 
-  const isRunningBuildInProgress = runningBuild && runningBuild.step !== "complete";
-  const showBuildStatus =
-    // We always want to show the status of the running build (until it is done)
-    isRunningBuildInProgress ||
-    // Even if there's no build running, we want to show the next build if it hasn't been selected.
-    (canSwitchToNextBuild && nextBuild.id !== storyBuild?.id);
-  const runningBuildIsNextBuild = runningBuild && runningBuild?.id === nextBuild?.id;
-  const buildStatus = showBuildStatus && (
-    <BuildProgress
-      runningBuild={(runningBuildIsNextBuild || isRunningBuildInProgress) && runningBuild}
-      switchToNextBuild={canSwitchToNextBuild && switchToNextBuild}
-    />
-  );
-
-  const storyTests = [
-    ...getFragment(
-      FragmentStoryTestFields,
-      "testsForStory" in storyBuild ? storyBuild.testsForStory.nodes : []
-    ),
-  ];
-
-  // It shouldn't be possible for one test to be skipped but not all of them
-  const isSkipped = !!storyTests?.find((t) => t.result === TestResult.Skipped);
-  if (isSkipped) {
-    return (
-      <Sections>
-        {buildStatus}
-        <Section grow>
-          <Container>
-            <Heading>This story was skipped</Heading>
-            <CenterText>
-              If you would like to resume testing it, comment out or remove
-              `parameters.chromatic.disableSnapshot = true` from the CSF file.
-            </CenterText>
-            <Button
-              belowText
-              small
-              tertiary
-              containsIcon
-              // @ts-expect-error Button component is not quite typed properly
-              target="_new"
-              isLink
-              href="https://www.chromatic.com/docs/ignoring-elements#ignore-stories"
-            >
-              <Icons icon="document" />
-              View Docs
-            </Button>
-          </Container>
-        </Section>
-      </Sections>
-    );
-  }
-
-  const isStoryBuildStarting = [
-    BuildStatus.Announced,
-    BuildStatus.Published,
-    BuildStatus.Prepared,
-  ].includes(storyBuild?.status);
-  const startedAt = "startedAt" in storyBuild && storyBuild.startedAt;
-  const isOutdated = storyBuild && storyBuild.uncommittedHash !== gitInfo.uncommittedHash;
-  const isBuildFailed = storyBuild.status === BuildStatus.Failed;
   return (
-    <Sections>
-      {buildStatus}
-
-      <Section grow hidden={settingsVisible || warningsVisible}>
-        <StoryInfo
-          {...{
-            tests: storyTests,
-            isOutdated,
-            startedAt,
-            isStarting: isStoryBuildStarting,
-            startDevBuild,
-            isBuildFailed,
-          }}
-        />
-        {!isStoryBuildStarting && storyTests && storyTests.length > 0 && (
-          <SnapshotComparison
-            {...{ tests: storyTests, isAccepting, isOutdated, onAccept, baselineImageVisible }}
-          />
-        )}
-      </Section>
-
-      <Section grow hidden={!settingsVisible}>
-        <RenderSettings onClose={() => setSettingsVisible(false)} />
-      </Section>
-      <Section grow hidden={!warningsVisible}>
-        <Warnings onClose={() => setWarningsVisible(false)} />
-      </Section>
-      <Section>
-        <Bar>
-          <Col>
-            <WithTooltip
-              tooltip={<TooltipNote note="Switch snapshot" />}
-              trigger="hover"
-              hasChrome={false}
-            >
-              <IconButton
-                data-testid="button-toggle-snapshot"
-                onClick={() => toggleBaselineImage()}
-              >
-                <Icon icon="transfer" />
-              </IconButton>
-            </WithTooltip>
-          </Col>
-          <Col style={{ overflow: "hidden", whiteSpace: "nowrap" }}>
-            {baselineImageVisible ? (
-              <Text style={{ marginLeft: 5, width: "100%" }}>
-                <b>Baseline</b> Build {storyBuild.number} on {storyBuild.branch}
-              </Text>
-            ) : (
-              <Text style={{ marginLeft: 5, width: "100%" }}>
-                <b>Latest</b> Build {storyBuild.number} on {storyBuild.branch}
-              </Text>
-            )}
-          </Col>
-          {/* <Col push>
-            <WithTooltip
-              tooltip={<TooltipNote note="Render settings" />}
-              trigger="hover"
-              hasChrome={false}
-            >
-            <IconButton
-              active={settingsVisible}
-              aria-label={`${settingsVisible ? "Hide" : "Show"} render settings`}
-              onClick={() => {
-                setSettingsVisible(!settingsVisible);
-                setWarningsVisible(false);
-              }}
-            >
-              <Icons icon="controls" />
-            </IconButton>
-          </WithTooltip>
-          </Col>
-          <Col>
-            <WithTooltip
-              tooltip={<TooltipNote note="View warnings" />}
-              trigger="hover"
-              hasChrome={false}
-            >
-              <IconButton
-                active={warningsVisible}
-                aria-label={`${warningsVisible ? "Hide" : "Show"} warnings`}
-                onClick={() => {
-                  setWarningsVisible(!warningsVisible);
-                  setSettingsVisible(false);
-                }}
-                status="warning"
-              >
-                <Icons icon="alert" />2
-              </IconButton>
-
-            </WithTooltip>
-          </Col> */}
-          <Col push>
-            <FooterMenu setAccessToken={setAccessToken} />
-          </Col>
-        </Bar>
-      </Section>
-    </Sections>
+    <BuildResults
+      {...{
+        runningBuild,
+        nextBuild,
+        switchToNextBuild,
+        canSwitchToNextBuild,
+        settingsVisible,
+        warningsVisible,
+        startDevBuild,
+        isAccepting,
+        onAccept,
+        baselineImageVisible,
+        setSettingsVisible,
+        setWarningsVisible,
+        toggleBaselineImage,
+        storyBuild,
+        setAccessToken,
+        uncommittedHash,
+      }}
+    />
   );
 };

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -1,4 +1,4 @@
-import { Icons, Loader } from "@storybook/components";
+import { Icons } from "@storybook/components";
 import { Icon, TooltipNote, WithTooltip } from "@storybook/design-system";
 import type { API_StatusState } from "@storybook/types";
 import React, { useCallback, useEffect, useState } from "react";
@@ -9,8 +9,7 @@ import { Container } from "../../components/Container";
 import { FooterMenu } from "../../components/FooterMenu";
 import { Heading } from "../../components/Heading";
 import { IconButton } from "../../components/IconButton";
-import { ProgressIcon } from "../../components/icons/ProgressIcon";
-import { Bar, Col, Row, Section, Sections, Text } from "../../components/layout";
+import { Bar, Col, Section, Sections, Text } from "../../components/layout";
 import { Text as CenterText } from "../../components/Text";
 import { GitInfoPayload, RunningBuildPayload } from "../../constants";
 import { getFragment } from "../../gql";
@@ -34,6 +33,7 @@ import {
   MutationReviewTest,
   QueryBuild,
 } from "./graphql";
+import { NoBuild } from "./NoBuild";
 import { RenderSettings } from "./RenderSettings";
 import { SnapshotComparison } from "./SnapshotComparison";
 import { StoryInfo } from "./StoryInfo";
@@ -170,48 +170,17 @@ export const VisualTests = ({
 
   if (!nextBuild || error) {
     return (
-      <Sections>
-        <Section grow>
-          {error && (
-            <Row>
-              <Col>
-                <Text>{error.message}</Text>
-              </Col>
-            </Row>
-          )}
-          {!data && <Loader />}
-          {data && !nextBuild && !error && (
-            <Container>
-              <Heading>Create a test baseline</Heading>
-              <CenterText>
-                Take an image snapshot of each story to save their &quot;last known good state&quot;
-                as test baselines.
-              </CenterText>
-              <br />
-              <Button small secondary onClick={startDevBuild} disabled={isRunningBuildStarting}>
-                {isRunningBuildStarting ? (
-                  <ProgressIcon parentComponent="Button" style={{ marginRight: 6 }} />
-                ) : (
-                  <Icons icon="play" />
-                )}
-                Take snapshots
-              </Button>
-            </Container>
-          )}
-        </Section>
-        <Section>
-          <Bar>
-            <Col>
-              <Text style={{ marginLeft: 5 }}>
-                {data ? `Waiting for build on ${gitInfo.branch}` : "Loading..."}
-              </Text>
-            </Col>
-            <Col push>
-              <FooterMenu setAccessToken={setAccessToken} />
-            </Col>
-          </Bar>
-        </Section>
-      </Sections>
+      <NoBuild
+        {...{
+          error,
+          data,
+          nextBuild,
+          startDevBuild,
+          isRunningBuildStarting,
+          gitInfo,
+          setAccessToken,
+        }}
+      />
     );
   }
 

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -13,7 +13,7 @@ import { ProgressIcon } from "../../components/icons/ProgressIcon";
 import { Bar, Col, Row, Section, Sections, Text } from "../../components/layout";
 import { Text as CenterText } from "../../components/Text";
 import { GitInfoPayload, RunningBuildPayload } from "../../constants";
-import { getFragment, graphql } from "../../gql";
+import { getFragment } from "../../gql";
 import {
   AddonVisualTestsBuildQuery,
   AddonVisualTestsBuildQueryVariables,
@@ -26,205 +26,18 @@ import {
 import { UpdateStatusFunction } from "../../types";
 import { statusMap, testsToStatusUpdate } from "../../utils/testsToStatusUpdate";
 import { BuildProgress } from "./BuildProgress";
+import {
+  FragmentNextBuildFields,
+  FragmentStatusTestFields,
+  FragmentStoryBuildFields,
+  FragmentStoryTestFields,
+  MutationReviewTest,
+  QueryBuild,
+} from "./graphql";
 import { RenderSettings } from "./RenderSettings";
 import { SnapshotComparison } from "./SnapshotComparison";
 import { StoryInfo } from "./StoryInfo";
 import { Warnings } from "./Warnings";
-
-const QueryBuild = graphql(/* GraphQL */ `
-  query AddonVisualTestsBuild(
-    $projectId: ID!
-    $branch: String!
-    $gitUserEmailHash: String!
-    $slug: String
-    $storyId: String!
-    $testStatuses: [TestStatus!]!
-    $storyBuildId: ID!
-    $hasStoryBuildId: Boolean!
-  ) {
-    project(id: $projectId) {
-      name
-      lastBuild(
-        branches: [$branch]
-        slug: $slug
-        localBuilds: { localBuildEmailHash: $gitUserEmailHash }
-      ) {
-        ...NextBuildFields
-        ...StoryBuildFields @skip(if: $hasStoryBuildId)
-      }
-    }
-    storyBuild: build(id: $storyBuildId) @include(if: $hasStoryBuildId) {
-      ...StoryBuildFields
-    }
-  }
-`);
-
-const FragmentNextBuildFields = graphql(/* GraphQL */ `
-  fragment NextBuildFields on Build {
-    __typename
-    id
-    commit
-    committedAt
-    browsers {
-      id
-      key
-      name
-    }
-    ... on StartedBuild {
-      changeCount: testCount(results: [ADDED, CHANGED, FIXED])
-      brokenCount: testCount(results: [CAPTURE_ERROR])
-      testsForStatus: tests(first: 1000, statuses: $testStatuses) {
-        nodes {
-          ...StatusTestFields
-        }
-      }
-    }
-    ... on CompletedBuild {
-      result
-      changeCount: testCount(results: [ADDED, CHANGED, FIXED])
-      brokenCount: testCount(results: [CAPTURE_ERROR])
-      testsForStatus: tests(statuses: $testStatuses) {
-        nodes {
-          ...StatusTestFields
-        }
-      }
-    }
-  }
-`);
-
-const FragmentStoryBuildFields = graphql(/* GraphQL */ `
-  fragment StoryBuildFields on Build {
-    __typename
-    id
-    number
-    branch
-    uncommittedHash
-    status
-    ... on StartedBuild {
-      startedAt
-      testsForStory: tests(storyId: $storyId) {
-        nodes {
-          ...StoryTestFields
-        }
-      }
-    }
-    ... on CompletedBuild {
-      startedAt
-      testsForStory: tests(storyId: $storyId) {
-        nodes {
-          ...StoryTestFields
-        }
-      }
-    }
-  }
-`);
-
-const FragmentStatusTestFields = graphql(/* GraphQL */ `
-  fragment StatusTestFields on Test {
-    id
-    status
-    story {
-      storyId
-    }
-  }
-`);
-
-const FragmentStoryTestFields = graphql(/* GraphQL */ `
-  fragment StoryTestFields on Test {
-    id
-    status
-    result
-    webUrl
-    comparisons {
-      id
-      result
-      browser {
-        id
-        key
-        name
-        version
-      }
-      captureDiff {
-        diffImage {
-          imageUrl
-          imageWidth
-        }
-      }
-      headCapture {
-        captureImage {
-          imageUrl
-          imageWidth
-        }
-        captureError {
-          kind
-          ... on CaptureErrorInteractionFailure {
-            error
-          }
-          ... on CaptureErrorJSError {
-            error
-          }
-          ... on CaptureErrorFailedJS {
-            error
-          }
-        }
-      }
-      baseCapture {
-        captureImage {
-          imageUrl
-          imageWidth
-        }
-      }
-      viewport {
-        id
-        name
-        width
-        isDefault
-      }
-    }
-    parameters {
-      viewport {
-        id
-        name
-        width
-        isDefault
-      }
-    }
-    story {
-      storyId
-      name
-      component {
-        name
-      }
-    }
-  }
-`);
-
-const MutationReviewTest = graphql(/* GraphQL */ `
-  mutation ReviewTest($input: ReviewTestInput!) {
-    reviewTest(input: $input) {
-      updatedTests {
-        id
-        status
-      }
-      userErrors {
-        ... on UserError {
-          __typename
-          message
-        }
-        ... on BuildSupersededError {
-          build {
-            id
-          }
-        }
-        ... on TestUnreviewableError {
-          test {
-            id
-          }
-        }
-      }
-    }
-  }
-`);
 
 const createEmptyStoryStatusUpdate = (state: API_StatusState) => {
   return Object.fromEntries(Object.entries(state).map(([id, update]) => [id, null]));

--- a/src/screens/VisualTests/graphql.ts
+++ b/src/screens/VisualTests/graphql.ts
@@ -1,0 +1,196 @@
+import { graphql } from "../../gql";
+
+export const QueryBuild = graphql(/* GraphQL */ `
+  query AddonVisualTestsBuild(
+    $projectId: ID!
+    $branch: String!
+    $gitUserEmailHash: String!
+    $slug: String
+    $storyId: String!
+    $testStatuses: [TestStatus!]!
+    $storyBuildId: ID!
+    $hasStoryBuildId: Boolean!
+  ) {
+    project(id: $projectId) {
+      name
+      lastBuild(
+        branches: [$branch]
+        slug: $slug
+        localBuilds: { localBuildEmailHash: $gitUserEmailHash }
+      ) {
+        ...NextBuildFields
+        ...StoryBuildFields @skip(if: $hasStoryBuildId)
+      }
+    }
+    storyBuild: build(id: $storyBuildId) @include(if: $hasStoryBuildId) {
+      ...StoryBuildFields
+    }
+  }
+`);
+
+export const FragmentNextBuildFields = graphql(/* GraphQL */ `
+  fragment NextBuildFields on Build {
+    __typename
+    id
+    commit
+    committedAt
+    browsers {
+      id
+      key
+      name
+    }
+    ... on StartedBuild {
+      changeCount: testCount(results: [ADDED, CHANGED, FIXED])
+      brokenCount: testCount(results: [CAPTURE_ERROR])
+      testsForStatus: tests(first: 1000, statuses: $testStatuses) {
+        nodes {
+          ...StatusTestFields
+        }
+      }
+    }
+    ... on CompletedBuild {
+      result
+      changeCount: testCount(results: [ADDED, CHANGED, FIXED])
+      brokenCount: testCount(results: [CAPTURE_ERROR])
+      testsForStatus: tests(statuses: $testStatuses) {
+        nodes {
+          ...StatusTestFields
+        }
+      }
+    }
+  }
+`);
+
+export const FragmentStoryBuildFields = graphql(/* GraphQL */ `
+  fragment StoryBuildFields on Build {
+    __typename
+    id
+    number
+    branch
+    uncommittedHash
+    status
+    ... on StartedBuild {
+      startedAt
+      testsForStory: tests(storyId: $storyId) {
+        nodes {
+          ...StoryTestFields
+        }
+      }
+    }
+    ... on CompletedBuild {
+      startedAt
+      testsForStory: tests(storyId: $storyId) {
+        nodes {
+          ...StoryTestFields
+        }
+      }
+    }
+  }
+`);
+
+export const FragmentStatusTestFields = graphql(/* GraphQL */ `
+  fragment StatusTestFields on Test {
+    id
+    status
+    story {
+      storyId
+    }
+  }
+`);
+
+export const FragmentStoryTestFields = graphql(/* GraphQL */ `
+  fragment StoryTestFields on Test {
+    id
+    status
+    result
+    webUrl
+    comparisons {
+      id
+      result
+      browser {
+        id
+        key
+        name
+        version
+      }
+      captureDiff {
+        diffImage {
+          imageUrl
+          imageWidth
+        }
+      }
+      headCapture {
+        captureImage {
+          imageUrl
+          imageWidth
+        }
+        captureError {
+          kind
+          ... on CaptureErrorInteractionFailure {
+            error
+          }
+          ... on CaptureErrorJSError {
+            error
+          }
+          ... on CaptureErrorFailedJS {
+            error
+          }
+        }
+      }
+      baseCapture {
+        captureImage {
+          imageUrl
+          imageWidth
+        }
+      }
+      viewport {
+        id
+        name
+        width
+        isDefault
+      }
+    }
+    parameters {
+      viewport {
+        id
+        name
+        width
+        isDefault
+      }
+    }
+    story {
+      storyId
+      name
+      component {
+        name
+      }
+    }
+  }
+`);
+
+export const MutationReviewTest = graphql(/* GraphQL */ `
+  mutation ReviewTest($input: ReviewTestInput!) {
+    reviewTest(input: $input) {
+      updatedTests {
+        id
+        status
+      }
+      userErrors {
+        ... on UserError {
+          __typename
+          message
+        }
+        ... on BuildSupersededError {
+          build {
+            id
+          }
+        }
+        ... on TestUnreviewableError {
+          test {
+            id
+          }
+        }
+      }
+    }
+  }
+`);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.58--canary.80.e4863d9.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.58--canary.80.e4863d9.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.58--canary.80.e4863d9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
