### PR TITLE
UI: Add ability to un-accept per story

### DIFF
--- a/src/screens/VisualTests/BuildResults.tsx
+++ b/src/screens/VisualTests/BuildResults.tsx
@@ -61,7 +61,7 @@ export const BuildResults = ({
     isRunningBuildInProgress ||
     // Even if there's no build running, we want to show the next build if it hasn't been selected.
     (switchToNextBuild && nextBuild.id !== storyBuild?.id);
-  const runningBuildIsNextBuild = runningBuild && runningBuild?.id === nextBuild?.id;
+  const runningBuildIsNextBuild = runningBuild && runningBuild?.id === nextBuild.id;
   const buildStatus = showBuildStatus && (
     <BuildProgress
       runningBuild={(runningBuildIsNextBuild || isRunningBuildInProgress) && runningBuild}
@@ -112,10 +112,11 @@ export const BuildResults = ({
     BuildStatus.Announced,
     BuildStatus.Published,
     BuildStatus.Prepared,
-  ].includes(storyBuild?.status);
+  ].includes(storyBuild.status);
   const startedAt = "startedAt" in storyBuild && storyBuild.startedAt;
-  const isOutdated = storyBuild && storyBuild.uncommittedHash !== uncommittedHash;
+  const isOutdated = storyBuild.uncommittedHash !== uncommittedHash;
   const isBuildFailed = storyBuild.status === BuildStatus.Failed;
+  const isReviewable = storyBuild.id === nextBuild.id;
 
   return (
     <Sections>
@@ -136,6 +137,7 @@ export const BuildResults = ({
           <SnapshotComparison
             {...{
               tests: storyTests,
+              isReviewable,
               isReviewing,
               isOutdated,
               onAccept,

--- a/src/screens/VisualTests/SnapshotComparison.stories.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
         { status: TestStatus.Passed, viewport: 1200 },
       ],
     }),
-    isAccepting: false,
+    isReviewing: false,
     onAccept: action("onAccept"),
     onUnaccept: action("onUnaccept"),
     baselineImageVisible: false,
@@ -77,7 +77,7 @@ export const WithSingleTest: Story = {
 
 export const WithSingleTestAccepting: Story = {
   args: {
-    isAccepting: true,
+    isReviewing: true,
     tests: [makeTest({ status: TestStatus.Pending })],
   },
 };

--- a/src/screens/VisualTests/SnapshotComparison.stories.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.stories.tsx
@@ -26,6 +26,7 @@ const meta = {
     }),
     isAccepting: false,
     onAccept: action("onAccept"),
+    onUnaccept: action("onUnaccept"),
     baselineImageVisible: false,
   },
 } satisfies Meta<typeof SnapshotComparison>;

--- a/src/screens/VisualTests/SnapshotComparison.stories.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.stories.tsx
@@ -24,6 +24,7 @@ const meta = {
         { status: TestStatus.Passed, viewport: 1200 },
       ],
     }),
+    isReviewable: true,
     isReviewing: false,
     onAccept: action("onAccept"),
     onUnaccept: action("onUnaccept"),

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -41,6 +41,7 @@ const StackTrace = styled.div(({ theme }) => ({
 
 interface SnapshotSectionProps {
   tests: StoryTestFieldsFragment[];
+  isReviewable: boolean;
   isReviewing: boolean;
   baselineImageVisible: boolean;
   onAccept: (testId: StoryTestFieldsFragment["id"], batch?: ReviewTestBatch) => void;
@@ -49,6 +50,7 @@ interface SnapshotSectionProps {
 
 export const SnapshotComparison = ({
   tests,
+  isReviewable,
   isReviewing,
   onAccept,
   onUnaccept,
@@ -113,7 +115,7 @@ export const SnapshotComparison = ({
               </WithTooltip>
             </Col>
           )}
-          {changeCount > 0 && selectedTest.status !== TestStatus.Accepted && (
+          {isReviewable && changeCount > 0 && selectedTest.status !== TestStatus.Accepted && (
             <>
               <Col push>
                 <WithTooltip
@@ -173,7 +175,7 @@ export const SnapshotComparison = ({
               </Col>
             </>
           )}
-          {changeCount > 0 && selectedTest.status === TestStatus.Accepted && (
+          {isReviewable && changeCount > 0 && selectedTest.status === TestStatus.Accepted && (
             <>
               <Col push>
                 <WithTooltip

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -41,7 +41,7 @@ const StackTrace = styled.div(({ theme }) => ({
 
 interface SnapshotSectionProps {
   tests: StoryTestFieldsFragment[];
-  isAccepting: boolean;
+  isReviewing: boolean;
   baselineImageVisible: boolean;
   onAccept: (testId: StoryTestFieldsFragment["id"], batch?: ReviewTestBatch) => void;
   onUnaccept: (testId: StoryTestFieldsFragment["id"]) => void;
@@ -49,7 +49,7 @@ interface SnapshotSectionProps {
 
 export const SnapshotComparison = ({
   tests,
-  isAccepting,
+  isReviewing,
   onAccept,
   onUnaccept,
   baselineImageVisible,
@@ -121,7 +121,11 @@ export const SnapshotComparison = ({
                   trigger="hover"
                   hasChrome={false}
                 >
-                  <IconButton secondary onClick={() => onAccept(selectedTest.id)}>
+                  <IconButton
+                    secondary
+                    disabled={isReviewing}
+                    onClick={() => onAccept(selectedTest.id)}
+                  >
                     Accept
                   </IconButton>
                 </WithTooltip>
@@ -135,30 +139,30 @@ export const SnapshotComparison = ({
                       title: "Accept story",
                       center: "Accept all unreviewed changes to this story",
                       onClick: () => onAccept(selectedTest.id, ReviewTestBatch.Spec),
-                      disabled: isAccepting,
-                      loading: isAccepting,
+                      disabled: isReviewing,
+                      loading: isReviewing,
                     },
                     {
                       id: "acceptComponent",
                       title: "Accept component",
                       center: "Accept all unreviewed changes for this component",
                       onClick: () => onAccept(selectedTest.id, ReviewTestBatch.Component),
-                      disabled: isAccepting,
-                      loading: isAccepting,
+                      disabled: isReviewing,
+                      loading: isReviewing,
                     },
                     {
                       id: "acceptBuild",
                       title: "Accept entire build",
                       center: "Accept all unreviewed changes for every story in the Storybook",
                       onClick: () => onAccept(selectedTest.id, ReviewTestBatch.Build),
-                      disabled: isAccepting,
-                      loading: isAccepting,
+                      disabled: isReviewing,
+                      loading: isReviewing,
                     },
                   ]}
                 >
                   {(active) => (
                     <IconButton secondary active={active} aria-label="Batch accept">
-                      {isAccepting ? (
+                      {isReviewing ? (
                         <ProgressIcon parentComponent="IconButton" />
                       ) : (
                         <Icons icon="batchaccept" />
@@ -177,7 +181,7 @@ export const SnapshotComparison = ({
                   trigger="hover"
                   hasChrome={false}
                 >
-                  <IconButton onClick={() => onUnaccept(selectedTest.id)}>
+                  <IconButton disabled={isReviewing} onClick={() => onUnaccept(selectedTest.id)}>
                     <Icons icon="undo" />
                     Unaccept
                   </IconButton>

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -44,12 +44,14 @@ interface SnapshotSectionProps {
   isAccepting: boolean;
   baselineImageVisible: boolean;
   onAccept: (testId: StoryTestFieldsFragment["id"], batch?: ReviewTestBatch) => void;
+  onUnaccept: (testId: StoryTestFieldsFragment["id"]) => void;
 }
 
 export const SnapshotComparison = ({
   tests,
   isAccepting,
   onAccept,
+  onUnaccept,
   baselineImageVisible,
 }: SnapshotSectionProps) => {
   const [diffVisible, setDiffVisible] = useState(true);
@@ -164,6 +166,22 @@ export const SnapshotComparison = ({
                     </IconButton>
                   )}
                 </TooltipMenu>
+              </Col>
+            </>
+          )}
+          {changeCount > 0 && selectedTest.status === TestStatus.Accepted && (
+            <>
+              <Col push>
+                <WithTooltip
+                  tooltip={<TooltipNote note="Unaccept this snapshot" />}
+                  trigger="hover"
+                  hasChrome={false}
+                >
+                  <IconButton onClick={() => onUnaccept(selectedTest.id)}>
+                    <Icons icon="undo" />
+                    Unaccept
+                  </IconButton>
+                </WithTooltip>
               </Col>
             </>
           )}

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -287,7 +287,7 @@ export const VisualTests = ({
     return () => clearInterval(interval);
   }, [rerun]);
 
-  const [{ fetching: isAccepting }, reviewTest] = useMutation(MutationReviewTest);
+  const [{ fetching: isReviewing }, reviewTest] = useMutation(MutationReviewTest);
 
   const onAccept = useCallback(
     async (testId: string, batch: ReviewTestBatch) => {
@@ -501,7 +501,7 @@ export const VisualTests = ({
           <SnapshotComparison
             {...{
               tests: storyTests,
-              isAccepting,
+              isReviewing,
               isOutdated,
               onAccept,
               onUnaccept,

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -308,6 +308,25 @@ export const VisualTests = ({
     [reviewTest]
   );
 
+  const onUnaccept = useCallback(
+    async (testId: string) => {
+      try {
+        const { error: reviewError } = await reviewTest({
+          input: { testId, status: ReviewTestInputStatus.Pending },
+        });
+
+        if (reviewError) throw reviewError;
+      } catch (err) {
+        // https://linear.app/chromaui/issue/AP-3279/error-handling
+        // eslint-disable-next-line no-console
+        console.log("Failed to unaccept changes:");
+        // eslint-disable-next-line no-console
+        console.log(err);
+      }
+    },
+    [reviewTest]
+  );
+
   const nextBuild = getFragment(FragmentNextBuildFields, data?.project?.lastBuild);
   // Before we set the storyInfo, we use the nextBuild for story data
   const storyBuild = getFragment(
@@ -480,7 +499,14 @@ export const VisualTests = ({
         />
         {!isStoryBuildStarting && storyTests && storyTests.length > 0 && (
           <SnapshotComparison
-            {...{ tests: storyTests, isAccepting, isOutdated, onAccept, baselineImageVisible }}
+            {...{
+              tests: storyTests,
+              isAccepting,
+              isOutdated,
+              onAccept,
+              onUnaccept,
+              baselineImageVisible,
+            }}
           />
         )}
       </Section>


### PR DESCRIPTION
# What I did:

- I added an extra callback function prop that invokes a mutation changing the status back to pending
- I passed this callback down to the right component
- In the `SnapshotComparison`-component I added an button that is shown when the status is `APPROVED`
- The button invokes the callback when clicked

# How to test

I tried this and it did not work! I need help figuring out why!

- Open the repo storybook
- Make a change that will be detected in chromatic
- Start a build (clicking the button in the sidebar should do it)
- Go to the addon's Panel
- Wait for the change to appear
- Approve the change
- Wait for that to build to be updated
- It should now show the "Unapprove" button <-- This was not working when I was testing this locally
- Clicking the "Unapprove" button should cause the "Approve" button to appear again.

# Open questions:

I suspect that there are scenarios where there's a newer build coming in where "Approve" and "Unapprove" need to be disabled. @tmeasday 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.59--canary.82.de5dbe0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.59--canary.82.de5dbe0.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.59--canary.82.de5dbe0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
