### PR TITLE
Update to 7.1.0 of CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@storybook/csf-tools": "7.5.0-alpha.1",
     "@storybook/design-system": "^7.15.15",
-    "chromatic": "7.1.0-canary.3",
+    "chromatic": "^7.1.0",
     "date-fns": "^2.30.0",
     "pluralize": "^8.0.0",
     "ts-dedent": "^2.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,9 +131,9 @@ async function serverChannel(
         forceRebuild: true,
         // Builds initiated from the addon are always considered local
         isLocalBuild: true,
-        onTaskStart: onStartOrProgress,
-        onTaskProgress: onStartOrProgress,
-        onTaskComplete(ctx) {
+        experimental_onTaskStart: onStartOrProgress,
+        experimental_onTaskProgress: onStartOrProgress,
+        experimental_onTaskComplete(ctx) {
           if (ctx.task === "snapshot") {
             runningBuildState.value = { step: "complete", id: ctx.announcedBuild?.id };
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5445,10 +5445,10 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromatic@7.1.0-canary.3:
-  version "7.1.0-canary.3"
-  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-7.1.0-canary.3.tgz#121f2e022ec7dbdbf44ef8519b17346002e66a92"
-  integrity sha512-5vyGyZNCtVxEQ1REdFYpj9KHRlzl1MwHgAKwFPXtf17tHxV1cFK7YpEZ+IS1iYPgl01q/neQwlqDL2Bbx7xrpA==
+chromatic@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-7.1.0.tgz#9d9977df2ce18555d497de6c9830b9ab6ca968cf"
+  integrity sha512-4hvWVxj2TxsgmzQK7zsAIVapxF+mzAXFuYIoAKKACdKtI+kjz0GfKJYpnzD4xciY3SGaySsis6gWxJ9q8GIxiQ==
 
 ci-info@^3.2.0:
   version "3.8.0"


### PR DESCRIPTION
Remove fixed canary version, and update API names.

Self merging @ghengeveld 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.59--canary.83.6ad577c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.59--canary.83.6ad577c.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.59--canary.83.6ad577c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
