### PR TITLE
Reviewing: Rerun query when accepting & un-accepting changes

### DIFF
--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -88,7 +88,10 @@ export const VisualTests = ({
           input: { testId, status: ReviewTestInputStatus.Accepted, batch },
         });
 
-        if (reviewError) throw reviewError;
+        if (reviewError) {
+          throw reviewError;
+        }
+        rerun();
       } catch (err) {
         // https://linear.app/chromaui/issue/AP-3279/error-handling
         // eslint-disable-next-line no-console

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -110,7 +110,10 @@ export const VisualTests = ({
           input: { testId, status: ReviewTestInputStatus.Pending },
         });
 
-        if (reviewError) throw reviewError;
+        if (reviewError) {
+          throw reviewError;
+        }
+        rerun();
       } catch (err) {
         // https://linear.app/chromaui/issue/AP-3279/error-handling
         // eslint-disable-next-line no-console

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -100,7 +100,7 @@ export const VisualTests = ({
         console.log(err);
       }
     },
-    [reviewTest]
+    [rerun, reviewTest]
   );
 
   const onUnaccept = useCallback(
@@ -122,7 +122,7 @@ export const VisualTests = ({
         console.log(err);
       }
     },
-    [reviewTest]
+    [rerun, reviewTest]
   );
 
   const nextBuild = getFragment(FragmentNextBuildFields, data?.project?.lastBuild);


### PR DESCRIPTION
# What I did

As per @tmeasday's suggestion: I added a call to `rerun()` to the `onAccept` & `onUnaccept` callbacks making mutation

# How to test

- open storybook in repo
- make a change thaty will show up in the UI
- start a build & wait for it to report changes
- accept the change, assert this toggles to the reviewed state fast
- un-accept the change, assert this toggles to unreviewed state fast
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.62--canary.86.a78ce21.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.62--canary.86.a78ce21.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.62--canary.86.a78ce21.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
