### PR TITLE
Add a compose `@storybook/components` in our Storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -55,7 +55,7 @@ const config: StorybookConfig = {
   refs: {
     "@storybook/components": {
       title: "@storybook/components",
-      url: "https://next--635781f3500dd2c49e189caf.chromatic.com/?path=/story/blocks-blocks-anchor--default",
+      url: "https://next--635781f3500dd2c49e189caf.chromatic.com",
     },
   },
 };

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -52,5 +52,11 @@ const config: StorybookConfig = {
   staticDirs: ["../public"],
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
   logLevel: "debug",
+  refs: {
+    "@storybook/components": {
+      title: "@storybook/components",
+      url: "https://next--635781f3500dd2c49e189caf.chromatic.com/?path=/story/blocks-blocks-anchor--default",
+    },
+  },
 };
 export default config;


### PR DESCRIPTION
@ndelangen this isn't working for me. Any idea why?

<img width="369" alt="image" src="https://github.com/chromaui/addon-visual-tests/assets/132554/7324fed8-2e58-45b2-9550-174dfb6ddeda">

<img width="886" alt="image" src="https://github.com/chromaui/addon-visual-tests/assets/132554/cc8bbefd-db0c-471a-b01d-ba488a7b95cc">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.65--canary.88.12cd3d6.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.65--canary.88.12cd3d6.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.65--canary.88.12cd3d6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
