### PR TITLE
fix: hide tooltip menu on click

### DIFF
--- a/src/components/TooltipMenu.tsx
+++ b/src/components/TooltipMenu.tsx
@@ -25,11 +25,19 @@ export const TooltipMenu = ({ children, links, note, ...props }: TooltipMenuProp
       closeOnOutsideClick
       closeOnTriggerHidden
       onVisibleChange={(visible) => setActive(visible)}
-      tooltip={
+      tooltip={({ onHide }) => (
         <Tooltip>
-          <TooltipLinkList links={links} />
+          <TooltipLinkList
+            links={links.map((link) => ({
+              ...link,
+              onClick: (...args) => {
+                onHide();
+                return link.onClick(...args);
+              },
+            }))}
+          />
         </Tooltip>
-      }
+      )}
       trigger="click"
       {...props}
     >


### PR DESCRIPTION
Adds the onHide to the onClick for menu items.

@ghengeveld from our pairing session this morning.