### PR TITLE
UI: Hide panel in auth and loading states

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -55,11 +55,16 @@ export const Panel = ({ active, api }: PanelProps) => {
   } = useProjectId();
 
   // Render the Authentication flow if the user is not signed in.
-  if (!accessToken) return <Authentication key={PANEL_ID} setAccessToken={setAccessToken} />;
+  if (!accessToken)
+    return (
+      <Sections hidden={!active}>
+        <Authentication key={PANEL_ID} setAccessToken={setAccessToken} />
+      </Sections>
+    );
 
   // Momentarily wait on addonState (should be very fast)
   if (projectInfoLoading || !gitInfo) {
-    return <Spinner />;
+    return active ? <Spinner /> : null;
   }
 
   if (!projectId)


### PR DESCRIPTION
# What I did:

- I found that 2 states of the panel were not hiding themselves when `active` is false.