### PR TITLE
Show build progress on 'no build' screen

### DIFF
--- a/src/components/BuildProgressLabel.stories.tsx
+++ b/src/components/BuildProgressLabel.stories.tsx
@@ -37,7 +37,7 @@ export const Upload: Story = {
   args: {
     localBuildProgress: {
       ...INITIAL_BUILD_PAYLOAD,
-      buildProgressPercentage: 50,
+      buildProgressPercentage: 25,
       currentStep: "upload",
       stepProgress: {
         ...INITIAL_BUILD_PAYLOAD.stepProgress,
@@ -58,7 +58,7 @@ export const Verify: Story = {
   args: {
     localBuildProgress: {
       ...INITIAL_BUILD_PAYLOAD,
-      buildProgressPercentage: 75,
+      buildProgressPercentage: 50,
       currentStep: "verify",
     },
   },
@@ -71,7 +71,7 @@ export const Snapshot: Story = {
   args: {
     localBuildProgress: {
       ...INITIAL_BUILD_PAYLOAD,
-      buildProgressPercentage: 90,
+      buildProgressPercentage: 75,
       currentStep: "snapshot",
       stepProgress: {
         ...INITIAL_BUILD_PAYLOAD.stepProgress,

--- a/src/components/BuildProgressLabel.tsx
+++ b/src/components/BuildProgressLabel.tsx
@@ -5,13 +5,18 @@ import { LocalBuildProgress } from "../types";
 
 interface BuildProgressLabelProps {
   localBuildProgress: LocalBuildProgress;
+  withEmoji?: boolean;
 }
 
-export const BuildProgressLabel = ({ localBuildProgress }: BuildProgressLabelProps) => {
+export const BuildProgressLabel = ({
+  localBuildProgress,
+  withEmoji = false,
+}: BuildProgressLabelProps) => {
   const { emoji, renderProgress } = BUILD_STEP_CONFIG[localBuildProgress.currentStep];
+  const label = renderProgress(localBuildProgress);
   return (
-    <>
-      {emoji} {renderProgress(localBuildProgress)}
-    </>
+    <span>
+      {withEmoji && emoji} {label}
+    </span>
   );
 };

--- a/src/components/SidebarTopButton.tsx
+++ b/src/components/SidebarTopButton.tsx
@@ -65,7 +65,7 @@ export const SidebarTopButton = ({
         tooltip={
           <TooltipContent>
             <div>
-              <BuildProgressLabel localBuildProgress={localBuildProgress} />
+              <BuildProgressLabel localBuildProgress={localBuildProgress} withEmoji />
             </div>
             <ProgressTrack>
               {typeof buildProgressPercentage === "number" && (

--- a/src/screens/VisualTests/BuildEyebrow.tsx
+++ b/src/screens/VisualTests/BuildEyebrow.tsx
@@ -160,7 +160,7 @@ export const BuildEyebrow = ({
         <Header onClick={toggleExpanded}>
           <Bar percentage={localBuildProgress.buildProgressPercentage} />
           <Label>
-            <BuildProgressLabel localBuildProgress={localBuildProgress} />
+            <BuildProgressLabel localBuildProgress={localBuildProgress} withEmoji />
           </Label>
           <IconButton as="div">
             {expanded ? <Icons icon="collapse" /> : <Icons icon="expandalt" />}

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -2,20 +2,22 @@ import { Icons, Loader } from "@storybook/components";
 import React from "react";
 import { CombinedError } from "urql";
 
+import { BuildProgressLabel } from "../../components/BuildProgressLabel";
 import { Button } from "../../components/Button";
 import { Container } from "../../components/Container";
 import { FooterMenu } from "../../components/FooterMenu";
 import { Heading } from "../../components/Heading";
-import { ProgressIcon } from "../../components/icons/ProgressIcon";
 import { Bar, Col, Row, Section, Sections, Text } from "../../components/layout";
+import { ProgressBar, ProgressTrack } from "../../components/SidebarTopButton";
 import { Text as CenterText } from "../../components/Text";
+import { LocalBuildProgress } from "../../types";
 
 interface NoBuildProps {
   error: CombinedError;
   hasData: boolean;
   hasStoryBuild: boolean;
   startDevBuild: () => void;
-  isLocalBuildStarting: boolean;
+  localBuildProgress: LocalBuildProgress;
   branch: string;
   setAccessToken: (accessToken: string | null) => void;
 }
@@ -25,7 +27,7 @@ export const NoBuild = ({
   hasData,
   hasStoryBuild,
   startDevBuild,
-  isLocalBuildStarting,
+  localBuildProgress,
   branch,
   setAccessToken,
 }: NoBuildProps) => (
@@ -49,14 +51,23 @@ export const NoBuild = ({
             test baselines.
           </CenterText>
           <br />
-          <Button small secondary onClick={startDevBuild} disabled={isLocalBuildStarting}>
-            {isLocalBuildStarting ? (
-              <ProgressIcon parentComponent="Button" style={{ marginRight: 6 }} />
-            ) : (
+          {localBuildProgress ? (
+            <CenterText style={{ display: "flex", flexDirection: "column", gap: 10, width: 200 }}>
+              <ProgressTrack>
+                {typeof localBuildProgress.buildProgressPercentage === "number" && (
+                  <ProgressBar
+                    style={{ width: `${localBuildProgress.buildProgressPercentage}%` }}
+                  />
+                )}
+              </ProgressTrack>
+              <BuildProgressLabel localBuildProgress={localBuildProgress} />
+            </CenterText>
+          ) : (
+            <Button small secondary onClick={startDevBuild}>
               <Icons icon="play" />
-            )}
-            Take snapshots
-          </Button>
+              Take snapshots
+            </Button>
+          )}
         </Container>
       )}
     </Section>

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -50,7 +50,6 @@ export const NoBuild = ({
             Take an image snapshot of each story to save their &quot;last known good state&quot; as
             test baselines.
           </CenterText>
-          <br />
           {localBuildProgress ? (
             <CenterText style={{ display: "flex", flexDirection: "column", gap: 10, width: 200 }}>
               <ProgressTrack>
@@ -63,10 +62,13 @@ export const NoBuild = ({
               <BuildProgressLabel localBuildProgress={localBuildProgress} />
             </CenterText>
           ) : (
-            <Button small secondary onClick={startDevBuild}>
-              <Icons icon="play" />
-              Take snapshots
-            </Button>
+            <>
+              <br />
+              <Button small secondary onClick={startDevBuild}>
+                <Icons icon="play" />
+                Take snapshots
+              </Button>
+            </>
           )}
         </Container>
       )}

--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -251,6 +251,7 @@ export const EmptyBranchLocalBuildUploading: Story = {
   args: {
     localBuildProgress: {
       ...INITIAL_BUILD_PAYLOAD,
+      buildProgressPercentage: 25,
       currentStep: "upload",
       stepProgress: {
         ...INITIAL_BUILD_PAYLOAD.stepProgress,
@@ -272,7 +273,7 @@ export const EmptyBranchLocalBuildCapturing: Story = {
   args: {
     localBuildProgress: {
       ...INITIAL_BUILD_PAYLOAD,
-      buildProgressPercentage: 60,
+      buildProgressPercentage: 75,
       currentStep: "snapshot",
       stepProgress: {
         ...INITIAL_BUILD_PAYLOAD.stepProgress,

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -194,9 +194,6 @@ export const VisualTests = ({
     [canSwitchToLastBuildOnBranch, lastBuildOnBranch?.id, storyId]
   );
 
-  const isLocalBuildStarting =
-    localBuildProgress && !["success", "error"].includes(localBuildProgress.currentStep);
-
   return !selectedBuild || error ? (
     <NoBuild
       {...{
@@ -204,7 +201,7 @@ export const VisualTests = ({
         hasData: !!data,
         hasStoryBuild: !!selectedBuild,
         startDevBuild,
-        isLocalBuildStarting,
+        localBuildProgress,
         branch: gitInfo.branch,
         setAccessToken,
       }}


### PR DESCRIPTION

<img width="313" alt="Screenshot 2023-09-15 at 16 12 25" src="https://github.com/chromaui/addon-visual-tests/assets/321738/86c4f4c9-2075-42ea-b4cd-f249e68d2b3b">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.76--canary.107.70e25d3.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.76--canary.107.70e25d3.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.76--canary.107.70e25d3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
