### PR TITLE
Add Getting Help section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 The Visual Testing addon enables you to run visual tests on your stories and compare changes with the latest baselines across multiple viewports and browsers to catch UI regressions early in development without leaving Storybook.
 
+## Getting Help
+
+We're here to help if you encounter any issues! Please sign in to [chromatic.com](https://www.chromatic.com) and contact support via the blue bubble in the bottom right of the screen.
 
 ## Prerequisites
 


### PR DESCRIPTION
This just adds a callout to the top of the readme directing folks to our normal support channel.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.80--canary.112.1d1f549.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.80--canary.112.1d1f549.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.80--canary.112.1d1f549.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
