### PR TITLE
Restore the chromatic dependency to `latest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@storybook/design-system": "^7.15.15",
-    "chromatic": "7.2.0-next.1",
+    "chromatic": "^7.2.0",
     "date-fns": "^2.30.0",
     "jsonfile": "^6.1.0",
     "filesize": "^10.0.12",

--- a/src/components/SidebarTopButton.stories.ts
+++ b/src/components/SidebarTopButton.stories.ts
@@ -44,6 +44,8 @@ export const IsRunning: Story = {
   play: playAll(async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = await canvas.findByRole("button", { name: "Run tests" });
+    // Wait one second just to ensure the screen has proper focus
+    await new Promise((r) => setTimeout(r, 1000));
     await userEvent.hover(button);
     await screen.findAllByText("🏗 Building your Storybook...");
   }),

--- a/src/components/SidebarTopButton.stories.ts
+++ b/src/components/SidebarTopButton.stories.ts
@@ -1,6 +1,7 @@
 import { action } from "@storybook/addon-actions";
+import { expect } from "@storybook/jest";
 import type { Meta, StoryObj } from "@storybook/react";
-import { userEvent, within } from "@storybook/testing-library";
+import { screen, userEvent, within } from "@storybook/testing-library";
 
 import { INITIAL_BUILD_PAYLOAD } from "../buildSteps";
 import { playAll } from "../utils/playAll";
@@ -21,6 +22,7 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     const button = await canvas.findByRole("button", { name: "Run tests" });
     await userEvent.click(button);
+    await screen.findAllByRole("button", { name: "Rerun tests" });
   }),
 };
 
@@ -43,5 +45,6 @@ export const IsRunning: Story = {
     const canvas = within(canvasElement);
     const button = await canvas.findByRole("button", { name: "Run tests" });
     await userEvent.hover(button);
+    await screen.findAllByText("🏗 Building your Storybook...");
   }),
 };

--- a/src/components/SidebarTopButton.tsx
+++ b/src/components/SidebarTopButton.tsx
@@ -110,7 +110,7 @@ export const SidebarTopButton = ({
       tooltip={
         <TooltipContent>
           <div>No code changes detected. Rerun tests to take new snapshots.</div>
-          <IconButton onClick={() => startBuild()}>
+          <IconButton onClick={() => startBuild()} aria-label="Rerun tests">
             <Icons icon="sync" />
             Rerun tests
           </IconButton>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5437,10 +5437,10 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromatic@7.2.0-next.1:
-  version "7.2.0-next.1"
-  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-7.2.0-next.1.tgz#e02c6260aeea0bf20754b90be4d2d4047f9bfe92"
-  integrity sha512-VPzZXfolmhCVU2QLunoH8i+NIpzLQ/Ui2Ay8bmbgv585RCG6sZSwz4AzEMB1l9CjTv6mA3csGm3zPV8Wrr3sCg==
+chromatic@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-7.2.0.tgz#2d33c39c3efe8ffea5d0b2a83d86c13adf1c0836"
+  integrity sha512-EbuvmsM6XAVFC4EQpqR2AT2PaXY4IS8qWxxg6N10AhpRulfX2b2AtW1hUc88cCosRyztd6esxkBdj3FSKR7zVw==
 
 ci-info@^3.2.0:
   version "3.8.0"


### PR DESCRIPTION
Now that `7.2.0` is released for real.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.81--canary.113.fc14e1e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.81--canary.113.fc14e1e.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.81--canary.113.fc14e1e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
