### PR TITLE
Show label even when there is only one mode

### DIFF
--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -10,6 +10,9 @@ import { StatusDot, StatusDotWrapper } from "./StatusDot";
 import { TooltipMenu } from "./TooltipMenu";
 
 const IconWrapper = styled.div(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6,
   height: 14,
   margin: "7px 7px",
   color: `${theme.color.defaultText}99`,
@@ -57,7 +60,9 @@ export const ModeSelector = ({
       hasChrome={false}
       placement="top"
       trigger="hover"
-      tooltip={<TooltipNote note={links ? "Switch mode" : `View mode: ${modeResults[0].mode}`} />}
+      tooltip={
+        <TooltipNote note={links ? "Switch mode" : `View mode: ${modeResults[0].mode.name}`} />
+      }
     >
       {links ? (
         <TooltipMenu placement="bottom" links={links}>
@@ -66,7 +71,10 @@ export const ModeSelector = ({
           <ArrowIcon icon="arrowdown" />
         </TooltipMenu>
       ) : (
-        <IconWrapper>{icon}</IconWrapper>
+        <IconWrapper>
+          {icon}
+          {selectedMode.name}
+        </IconWrapper>
       )}
     </WithTooltip>
   );


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.90--canary.118.b1dae5b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.90--canary.118.b1dae5b.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.90--canary.118.b1dae5b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
