### PR TITLE
Bug: Remove the duplicated manager entry for storybook

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -1,1 +1,0 @@
-export * from "./dist/manager";


### PR DESCRIPTION
# What I did:

We were adding the manager entry twice.
When storybook resolves from an absolute path it prefers to only add explicit file-exports:
_(warning this code is overly complex)_
https://github.com/storybookjs/storybook/blob/0b5dc9a4fd8f62e2bd071677d2e83ccdbddbf5b7/code/lib/core-common/src/presets.ts#L72-L177

We're already adding the manager entry here:
https://github.com/chromaui/storybook-visual-tests/blob/29085ad4155ed77ed3b04091cd156605e89045e5/src/index.ts#L18-L23

So really all storybook has to do is treat this as a preset.