### PR TITLE
Clear the filter when removing the sidebar toggle button

### DIFF
--- a/src/components/SidebarToggleButton.tsx
+++ b/src/components/SidebarToggleButton.tsx
@@ -1,7 +1,7 @@
 import { Badge as BaseBadge } from "@storybook/components";
 import { css, styled } from "@storybook/theming";
 import pluralize from "pluralize";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { IconButton } from "./IconButton";
 
@@ -45,6 +45,9 @@ export const SidebarToggleButton = React.memo(function SidebarToggleButton({
     if (filter) onDisable();
     else onEnable();
   };
+
+  // Ensure the filter is disabled if the button is not visible
+  useEffect(() => () => onDisable(), [onDisable]);
 
   return (
     <Button active={filter} onClick={toggleFilter}>


### PR DESCRIPTION
It was possible to filter the sidebar, then change branch (or run another build) so that the button disappears but the filter remains active (so you can no longer clear it!). This change means that the filter will reset whenever the filter goes away (whenever the story book state has no warnings).

In theory there might be situations where this happens for a brief moment, but it doesn't seem to happen in my testing.

## To QA

1. Pick a branch where the latest build has changes (or make one)
2. Turn on the filter
3. Switch to a branch where there are no changes on the latest build (e.g. `main`).
4. The filter should turn off and all stories should be visible.