### PR TITLE
git is required for visual test addon via chromatic cli

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -7,6 +7,7 @@ import { Sections } from "./components/layout";
 import {
   ADDON_ID,
   GIT_INFO,
+  GIT_INFO_ERROR,
   IS_OUTDATED,
   LOCAL_BUILD_PROGRESS,
   PANEL_ID,
@@ -14,6 +15,7 @@ import {
 } from "./constants";
 import { Project } from "./gql/graphql";
 import { Authentication } from "./screens/Authentication/Authentication";
+import { GitNotFound } from "./screens/GitNotFound/GitNotFound";
 import { LinkedProject } from "./screens/LinkProject/LinkedProject";
 import { LinkingProjectFailed } from "./screens/LinkProject/LinkingProjectFailed";
 import { LinkProject } from "./screens/LinkProject/LinkProject";
@@ -33,6 +35,7 @@ export const Panel = ({ active, api }: PanelProps) => {
   const { storyId } = useStorybookState();
 
   const [gitInfo] = useAddonState<GitInfoPayload>(GIT_INFO);
+  const [gitInfoError] = useAddonState<Error>(GIT_INFO_ERROR);
   const [localBuildProgress] = useAddonState<LocalBuildProgress>(LOCAL_BUILD_PROGRESS);
   const [, setOutdated] = useAddonState<boolean>(IS_OUTDATED);
   const emit = useChannel({});
@@ -54,6 +57,16 @@ export const Panel = ({ active, api }: PanelProps) => {
 
   // If the user creates a project in a dialog (either during login or later, it get set here)
   const [createdProjectId, setCreatedProjectId] = useState<Project["id"]>();
+
+  if (gitInfoError) {
+    return (
+      <Provider key={PANEL_ID} value={client}>
+        <Sections hidden={!active}>
+          <GitNotFound gitInfoError={gitInfoError} />
+        </Sections>
+      </Provider>
+    );
+  }
 
   // Render the Authentication flow if the user is not signed in.
   if (!accessToken) {

--- a/src/SidebarTop.tsx
+++ b/src/SidebarTop.tsx
@@ -100,24 +100,6 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
     localBuildProgress?.changeCount,
   ]);
 
-  useEffect(() => {
-    if (gitInfoError?.message) {
-      addNotification({
-        id: `${ADDON_ID}/git-info-error`,
-        content: {
-          headline: "Git not detected",
-          subHeadline:
-            "The visual tests addon requires Git to associate test results with commits and branches. Set up Git and restart storybook to continue.",
-        },
-        icon: {
-          name: "lock",
-          color: "negative",
-        },
-        // @ts-expect-error SB needs a proper API for no link
-        link: undefined,
-      });
-    }
-  }, [addNotification, gitInfoError?.message]);
   const emit = useChannel({});
   const startBuild = () => emit(START_BUILD);
 

--- a/src/SidebarTop.tsx
+++ b/src/SidebarTop.tsx
@@ -64,8 +64,8 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
           subHeadline: localBuildProgress.errorCount
             ? `Encountered ${pluralize("component error", localBuildProgress.errorCount, true)}`
             : localBuildProgress.changeCount
-              ? `Found ${pluralize("change", localBuildProgress.changeCount, true)}`
-              : "No visual changes detected",
+            ? `Found ${pluralize("change", localBuildProgress.changeCount, true)}`
+            : "No visual changes detected",
         },
         icon: {
           name: "passed",

--- a/src/SidebarTop.tsx
+++ b/src/SidebarTop.tsx
@@ -107,7 +107,7 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
         content: {
           headline: "Git not detected",
           subHeadline:
-            "The visual tests addon requires Git to associate test results with commits and branches.",
+            "The visual tests addon requires Git to associate test results with commits and branches. Set up Git and restart storybook to continue.",
         },
         icon: {
           name: "lock",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const ACCESS_TOKEN_KEY = `${ADDON_ID}/access-token/${CHROMATIC_BASE_URL}`
 export const DEV_BUILD_ID_KEY = `${ADDON_ID}/dev-build-id`;
 
 export const GIT_INFO = `${ADDON_ID}/gitInfo`;
+export const GIT_INFO_ERROR = `${ADDON_ID}/gitInfoError`;
 export const PROJECT_INFO = `${ADDON_ID}/projectInfo`;
 export const IS_OUTDATED = `${ADDON_ID}/isOutdated`;
 export const START_BUILD = `${ADDON_ID}/startBuild`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ const observeGitInfo = async (
       prev = gitInfo;
       timer = setTimeout(act, interval);
     } catch (e: any) {
-      console.error("getGitInfo failed. Ending loop.", e);
+      console.error(`Failed to fetch git info, with error:\n${e}`);
       errorCallback(e);
     }
   };

--- a/src/screens/GitNotFound/GitNotFound.stories.tsx
+++ b/src/screens/GitNotFound/GitNotFound.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { storyWrapper } from "../../utils/graphQLClient";
+import { GitNotFound } from "./GitNotFound";
+
+const meta = {
+  component: GitNotFound,
+  decorators: [storyWrapper],
+  args: {
+    gitInfoError: new Error("Git info not found"),
+  },
+} satisfies Meta<typeof GitNotFound>;
+
+export const Default = {} satisfies StoryObj<typeof meta>;
+
+export default meta;

--- a/src/screens/GitNotFound/GitNotFound.tsx
+++ b/src/screens/GitNotFound/GitNotFound.tsx
@@ -1,0 +1,66 @@
+import { Code } from "@storybook/components";
+import { Icon, Link } from "@storybook/design-system";
+import { styled } from "@storybook/theming";
+import React from "react";
+
+import { Button } from "../../components/Button";
+import { Container } from "../../components/Container";
+import { Heading } from "../../components/Heading";
+import { VisualTestsIcon } from "../../components/icons/VisualTestsIcon";
+import { Col, Row, Section } from "../../components/layout";
+import { Stack } from "../../components/Stack";
+import { Text } from "../../components/Text";
+
+interface GitNotFoundProps {
+  gitInfoError: Error;
+}
+
+const InfoSection = styled(Section)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  borderRadius: theme.appBorderRadius,
+  background: theme.color.lightest,
+  padding: 15,
+  flex: 1,
+  boxShadow: `0px 1px 3px 0px rgba(0, 0, 0, 0.10), 0px 2px 5px 0px rgba(0, 0, 0, 0.05)`,
+}));
+
+const InfoSectionText = styled(Text)(({ theme }) => ({
+  marginLeft: 14,
+  flex: 1,
+  textAlign: "left",
+  color: theme.color.darker,
+}));
+
+export const GitNotFound = ({ gitInfoError }: GitNotFoundProps) => (
+  <Container>
+    <Stack>
+      <div>
+        <VisualTestsIcon />
+        <Heading>Visual tests</Heading>
+        <Text>
+          Catch bugs in UI appearance automatically. Compare image snapshots to detect visual
+          changes.
+        </Text>
+      </div>
+      <InfoSection>
+        <Col>
+          <Icon icon="lock" />
+        </Col>
+        {/* <Col>
+          <b>Git not detected</b>
+          This addon requires Git to associate test results with commits and branches.
+        </Col> */}
+        <InfoSectionText>
+          <b>Git not detected</b>
+          <br />
+          This addon requires Git to associate test results with commits and branches.
+        </InfoSectionText>
+      </InfoSection>
+      <Link target="_new" href="https://www.chromatic.com/docs/cli/" withArrow>
+        Visual tests requirements
+      </Link>
+    </Stack>
+  </Container>
+);

--- a/src/screens/GitNotFound/GitNotFound.tsx
+++ b/src/screens/GitNotFound/GitNotFound.tsx
@@ -1,13 +1,11 @@
-import { Code } from "@storybook/components";
 import { Icon, Link } from "@storybook/design-system";
 import { styled } from "@storybook/theming";
 import React from "react";
 
-import { Button } from "../../components/Button";
 import { Container } from "../../components/Container";
 import { Heading } from "../../components/Heading";
 import { VisualTestsIcon } from "../../components/icons/VisualTestsIcon";
-import { Col, Row, Section } from "../../components/layout";
+import { Section } from "../../components/layout";
 import { Stack } from "../../components/Stack";
 import { Text } from "../../components/Text";
 
@@ -45,13 +43,7 @@ export const GitNotFound = ({ gitInfoError }: GitNotFoundProps) => (
         </Text>
       </div>
       <InfoSection>
-        <Col>
-          <Icon icon="lock" />
-        </Col>
-        {/* <Col>
-          <b>Git not detected</b>
-          This addon requires Git to associate test results with commits and branches.
-        </Col> */}
+        <Icon icon="lock" />
         <InfoSectionText>
           <b>Git not detected</b>
           <br />


### PR DESCRIPTION
This adds an error state to the panel, disables the run button, and shows a notification if the addon is run in a project without git configured.

To test this:
 - Run storybook with addon installed.
 - Rename or delete .git directory to trigger an error.
 - It should show a single notification and update the panel with the git error.

Note: this currently stops the gitObservable loop from occurring and requires the server to be restarted after fixing the issue. Added language in the notification to prompt the user to restart storybook after fixing.

Note: This does not handle build errors once the gitInfo can be retrieved. The pr this branches off of should handle build-level errors including the git one commit issue.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.99--canary.126.8f69032.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.99--canary.126.8f69032.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.99--canary.126.8f69032.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
