### PR TITLE
Fix z-index to prevent weird rendering bug with Storybook panel

### DIFF
--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -57,7 +57,7 @@ const ParentGrid = styled.div(({ theme }) => ({
 const HeaderSection = styled.div(({ theme }) => ({
   gridArea: "header",
   position: "sticky",
-  zIndex: 10,
+  zIndex: 1,
   top: 0,
   background: theme.background.app,
 }));
@@ -71,7 +71,7 @@ const MainSection = styled.div(({ theme }) => ({
 const FooterSection = styled.div(({ theme }) => ({
   gridArea: "footer",
   position: "sticky",
-  zIndex: 10,
+  zIndex: 1,
   bottom: 0,
   borderTop: `1px solid ${theme.appBorderColor}`,
   background: theme.background.app,


### PR DESCRIPTION
Prevents the sticky header from sticking around when the panel is closed.

<img width="859" alt="Screenshot 2023-10-10 at 21 17 14" src="https://github.com/chromaui/addon-visual-tests/assets/321738/80f448a1-2b90-435e-9b4e-19cf913bf650">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.104--canary.129.7dd4ed3.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.104--canary.129.7dd4ed3.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.104--canary.129.7dd4ed3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
