### PR TITLE
Fix issue with switching build without changing story

### DIFF
--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -573,30 +573,29 @@ export const PendingLocalBuildCapturedStory = {
       "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=2303-374529&t=qjmuGHxoALrVuhvX-0"
     ),
   },
-  // NOTE: this does not current work, the story is auto-selected
-  // play: async ({ canvasElement, args, argsByTarget }) => {
-  //   // We have to wait a moment for the story to render
-  //   const canvas = within(canvasElement);
-  //   await canvas.findAllByText("Latest");
+  play: async ({ canvasElement, args, argsByTarget }) => {
+    // We have to wait a moment for the story to render
+    const canvas = within(canvasElement);
+    await canvas.findAllByText("Latest");
 
-  //   // Ensure we don't switch to the new build, the user has to opt-in
-  //   mock(args.setSelectedBuildInfo!).mock.calls.forEach(([updater]) => {
-  //     const result = typeof updater === "function" ? updater(args.selectedBuildInfo) : updater;
-  //     expect(result).toEqual(args.selectedBuildInfo); // Unchanged
-  //   });
+    // Ensure we don't switch to the new build, the user has to opt-in
+    mock(args.setSelectedBuildInfo!).mock.calls.forEach(([updater]) => {
+      const result = typeof updater === "function" ? updater(args.selectedBuildInfo) : updater;
+      expect(result).toEqual(args.selectedBuildInfo); // Unchanged
+    });
 
-  //   // Now opt in
-  //   const viewLatestSnapshot = (await canvas.findAllByText("View latest snapshot"))[0];
-  //   await userEvent.click(viewLatestSnapshot);
+    // Now opt in
+    const viewLatestSnapshot = (await canvas.findAllByText("View latest snapshot"))[0];
+    await userEvent.click(viewLatestSnapshot);
 
-  //   const graphqlArgs = argsByTarget.graphql?.$graphql as typeof args.$graphql; // We need to type argsByTarget
-  //   await waitFor(() => {
-  //     expect(args.setSelectedBuildInfo).toHaveBeenCalledWith({
-  //       buildId: graphqlArgs?.AddonVisualTestsBuild?.lastBuildOnBranch?.id,
-  //       storyId: meta.args.storyId,
-  //     });
-  //   });
-  // },
+    const graphqlArgs = argsByTarget.graphql?.$graphql as typeof args.$graphql; // We need to type argsByTarget
+    await waitFor(() => {
+      expect(args.setSelectedBuildInfo).toHaveBeenCalledWith({
+        buildId: graphqlArgs?.AddonVisualTestsBuild?.lastBuildOnBranch?.id,
+        storyId: meta.args.storyId,
+      });
+    });
+  },
 } satisfies Story;
 
 /**
@@ -622,9 +621,8 @@ export const PendingCIBuildCapturedStory = {
       "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=2303-374529&t=qjmuGHxoALrVuhvX-0"
     ),
   },
-  // NOTE: this does not current work, the story is auto-selected
   // Should behave the same as when the local build captures the current story
-  // play: PendingLocalBuildCapturedStory.play,
+  play: PendingLocalBuildCapturedStory.play,
 } satisfies Story;
 
 export const Pending = {
@@ -862,8 +860,7 @@ export const CIBuildNewer = {
     },
   },
   // Similarly to a captured story, we should only switch when the user is ready
-  // NOTE: this does not current work, the story is auto-selected
-  // play: PendingLocalBuildCapturedStory.play,
+  play: PendingLocalBuildCapturedStory.play,
 } satisfies Story;
 
 /** The new build is newer than the story build and the git info */

--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -118,6 +118,7 @@ const meta = {
   },
   args: {
     setSelectedBuildInfo: action("setSelectedBuildInfo"),
+    dismissBuildError: action("dismissBuildError"),
     gitInfo: {
       userEmailHash: "xyz987",
       branch: "feature-branch",
@@ -623,6 +624,23 @@ export const PendingCIBuildCapturedStory = {
   },
   // Should behave the same as when the local build captures the current story
   play: PendingLocalBuildCapturedStory.play,
+} satisfies Story;
+
+/**
+ * Now what happens when the user actually clicks to change story?
+ */
+export const PendingCIBuildCapturedStoryAndUserChangedStory = {
+  args: {
+    selectedBuildInfo: { buildId: pendingBuild.id, storyId: "old--story" },
+    $graphql: PendingLocalBuildCapturedStory.args.$graphql,
+  },
+  parameters: {
+    ...withFigmaDesign(
+      "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=2303-374529&t=qjmuGHxoALrVuhvX-0"
+    ),
+  },
+  // In this case, we *should* switch to the new build
+  play: EmptyBranchLocalBuildCapturedCurrentStory.play,
 } satisfies Story;
 
 export const Pending = {

--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -373,10 +373,6 @@ export const StoryAddedInSelectedBuild = {
   },
 } satisfies Story;
 
-/**
- * Although this state doesn't immediately render the captured story (it probably should),
- * it should switch to the lastBuildOnBranch immediately.
- */
 export const StoryAddedInLastBuildOnBranchNotInSelected = {
   args: {
     selectedBuildInfo: { buildId: pendingBuild.id, storyId: meta.args.storyId },

--- a/src/utils/updateSelectedBuildInfo.test.ts
+++ b/src/utils/updateSelectedBuildInfo.test.ts
@@ -1,102 +1,83 @@
 import { updateSelectedBuildInfo } from "./updateSelectedBuildInfo";
 
-it("does nothing if there is no next build", () => {
-  expect(
-    updateSelectedBuildInfo(undefined, {
-      shouldSwitchToLastBuildOnBranch: false,
-      lastBuildOnBranchId: undefined,
-      storyId: "storyId",
-    })
-  ).toEqual(undefined);
-});
-
-it("sets the story build from the next build, simple", () => {
-  expect(
-    updateSelectedBuildInfo(undefined, {
-      shouldSwitchToLastBuildOnBranch: true,
-      lastBuildOnBranchId: "lastBuildOnBranchId",
-      storyId: "storyId",
-    })
-  ).toEqual({
-    buildId: "lastBuildOnBranchId",
-    storyId: "storyId",
+describe("with no selected build", () => {
+  it("does nothing if there is no next build", () => {
+    expect(
+      updateSelectedBuildInfo(undefined, {
+        shouldSwitchToLastBuildOnBranch: false,
+        lastBuildOnBranchId: undefined,
+        storyId: "storyId",
+      })
+    ).toEqual(undefined);
   });
-});
 
-// We should remain on the "new build" screen until we see a completed story
-it("does not set the story build from the next build, if the next build should not be switched to", () => {
-  expect(
-    updateSelectedBuildInfo(undefined, {
-      shouldSwitchToLastBuildOnBranch: false,
-      lastBuildOnBranchId: "lastBuildOnBranchId",
-      storyId: "storyId",
-    })
-  ).toEqual(undefined);
-});
-
-it("updates the story build from the next build, simple", () => {
-  expect(
-    updateSelectedBuildInfo(
-      { buildId: "oldBuildId", storyId: "storyId" },
-      {
+  it("sets the story build from the next build, simple", () => {
+    expect(
+      updateSelectedBuildInfo(undefined, {
         shouldSwitchToLastBuildOnBranch: true,
         lastBuildOnBranchId: "lastBuildOnBranchId",
         storyId: "storyId",
-      }
-    )
-  ).toEqual({
-    buildId: "lastBuildOnBranchId",
-    storyId: "storyId",
+      })
+    ).toEqual({
+      buildId: "lastBuildOnBranchId",
+      storyId: "storyId",
+    });
   });
-});
 
-it("does not update the story build from the next build, if the next build should not be switched to", () => {
-  expect(
-    updateSelectedBuildInfo(
-      { buildId: "oldBuildId", storyId: "storyId" },
-      {
+  // We should remain on the "new build" screen until we see a completed story
+  it("does not set the story build from the next build, if the next build should not be switched to", () => {
+    expect(
+      updateSelectedBuildInfo(undefined, {
         shouldSwitchToLastBuildOnBranch: false,
         lastBuildOnBranchId: "lastBuildOnBranchId",
         storyId: "storyId",
-      }
-    )
-  ).toEqual({ buildId: "oldBuildId", storyId: "storyId" });
-});
-
-it("updates the storyId, simple", () => {
-  expect(
-    updateSelectedBuildInfo(
-      {
-        buildId: "lastBuildOnBranchId",
-        storyId: "storyId",
-      },
-      {
-        shouldSwitchToLastBuildOnBranch: true,
-        lastBuildOnBranchId: "lastBuildOnBranchId",
-        storyId: "newStoryId",
-      }
-    )
-  ).toEqual({
-    buildId: "lastBuildOnBranchId",
-    storyId: "newStoryId",
+      })
+    ).toEqual(undefined);
   });
 });
 
-it("updates the storyId, keeping the old build if the next build should not be switched to", () => {
-  expect(
-    updateSelectedBuildInfo(
-      {
-        buildId: "oldBuildId",
-        storyId: "storyId",
-      },
-      {
-        shouldSwitchToLastBuildOnBranch: false,
-        lastBuildOnBranchId: "lastBuildOnBranchId",
-        storyId: "newStoryId",
-      }
-    )
-  ).toEqual({
-    buildId: "oldBuildId",
-    storyId: "newStoryId",
+describe("with a selected build, when not changing story", () => {
+  it("does not update the story build from the next build, no matter what", () => {
+    expect(
+      updateSelectedBuildInfo(
+        { buildId: "oldBuildId", storyId: "storyId" },
+        {
+          shouldSwitchToLastBuildOnBranch: true,
+          lastBuildOnBranchId: "lastBuildOnBranchId",
+          storyId: "storyId",
+        }
+      )
+    ).toEqual({ buildId: "oldBuildId", storyId: "storyId" });
+  });
+});
+
+describe("with a selected build, when changing story", () => {
+  it("updates the story build from the next build, simple", () => {
+    expect(
+      updateSelectedBuildInfo(
+        { buildId: "oldBuildId", storyId: "storyId" },
+        {
+          shouldSwitchToLastBuildOnBranch: true,
+          lastBuildOnBranchId: "lastBuildOnBranchId",
+          storyId: "newStoryId",
+        }
+      )
+    ).toEqual({
+      buildId: "lastBuildOnBranchId",
+      storyId: "newStoryId",
+    });
+  });
+
+  it("does not update the story build from the next build, if the next build should not be switched to", () => {
+    expect(
+      updateSelectedBuildInfo(
+        { buildId: "oldBuildId", storyId: "storyId" },
+        {
+          shouldSwitchToLastBuildOnBranch: false,
+          lastBuildOnBranchId: "lastBuildOnBranchId",
+          storyId: "newStoryId",
+        }
+      )
+    ).toEqual({ buildId: "oldBuildId", storyId: "newStoryId" });
   });
 });

--- a/src/utils/updateSelectedBuildInfo.test.ts
+++ b/src/utils/updateSelectedBuildInfo.test.ts
@@ -1,20 +1,22 @@
 import { updateSelectedBuildInfo } from "./updateSelectedBuildInfo";
 
 describe("with no selected build", () => {
-  it("does nothing if there is no next build", () => {
+  it("does nothing if there is no last build on branch", () => {
     expect(
       updateSelectedBuildInfo(undefined, {
         shouldSwitchToLastBuildOnBranch: false,
+        forceSwitchToLastBuildOnBranch: false,
         lastBuildOnBranchId: undefined,
         storyId: "storyId",
       })
     ).toEqual(undefined);
   });
 
-  it("sets the story build from the next build, simple", () => {
+  it("sets the selected build from the last build on branch, simple", () => {
     expect(
       updateSelectedBuildInfo(undefined, {
         shouldSwitchToLastBuildOnBranch: true,
+        forceSwitchToLastBuildOnBranch: false,
         lastBuildOnBranchId: "lastBuildOnBranchId",
         storyId: "storyId",
       })
@@ -25,10 +27,11 @@ describe("with no selected build", () => {
   });
 
   // We should remain on the "new build" screen until we see a completed story
-  it("does not set the story build from the next build, if the next build should not be switched to", () => {
+  it("does not set the selected build from the last build on branch, if the last build on branch should not be switched to", () => {
     expect(
       updateSelectedBuildInfo(undefined, {
         shouldSwitchToLastBuildOnBranch: false,
+        forceSwitchToLastBuildOnBranch: false,
         lastBuildOnBranchId: "lastBuildOnBranchId",
         storyId: "storyId",
       })
@@ -37,27 +40,43 @@ describe("with no selected build", () => {
 });
 
 describe("with a selected build, when not changing story", () => {
-  it("does not update the story build from the next build, no matter what", () => {
+  it("does not update the selected build from the last build on branch, even if we should", () => {
     expect(
       updateSelectedBuildInfo(
         { buildId: "oldBuildId", storyId: "storyId" },
         {
           shouldSwitchToLastBuildOnBranch: true,
+          forceSwitchToLastBuildOnBranch: false,
           lastBuildOnBranchId: "lastBuildOnBranchId",
           storyId: "storyId",
         }
       )
     ).toEqual({ buildId: "oldBuildId", storyId: "storyId" });
   });
-});
 
-describe("with a selected build, when changing story", () => {
-  it("updates the story build from the next build, simple", () => {
+  it("does update the selected build from the last build on branch, if forced", () => {
     expect(
       updateSelectedBuildInfo(
         { buildId: "oldBuildId", storyId: "storyId" },
         {
           shouldSwitchToLastBuildOnBranch: true,
+          forceSwitchToLastBuildOnBranch: true,
+          lastBuildOnBranchId: "lastBuildOnBranchId",
+          storyId: "storyId",
+        }
+      )
+    ).toEqual({ buildId: "lastBuildOnBranchId", storyId: "storyId" });
+  });
+});
+
+describe("with a selected build, when changing story", () => {
+  it("updates the selected build from the last build on branch, simple", () => {
+    expect(
+      updateSelectedBuildInfo(
+        { buildId: "oldBuildId", storyId: "storyId" },
+        {
+          shouldSwitchToLastBuildOnBranch: true,
+          forceSwitchToLastBuildOnBranch: false,
           lastBuildOnBranchId: "lastBuildOnBranchId",
           storyId: "newStoryId",
         }
@@ -68,12 +87,13 @@ describe("with a selected build, when changing story", () => {
     });
   });
 
-  it("does not update the story build from the next build, if the next build should not be switched to", () => {
+  it("does not update the selected build from the last build on branch, if the last build on branch should not be switched to", () => {
     expect(
       updateSelectedBuildInfo(
         { buildId: "oldBuildId", storyId: "storyId" },
         {
           shouldSwitchToLastBuildOnBranch: false,
+          forceSwitchToLastBuildOnBranch: false,
           lastBuildOnBranchId: "lastBuildOnBranchId",
           storyId: "newStoryId",
         }

--- a/src/utils/updateSelectedBuildInfo.ts
+++ b/src/utils/updateSelectedBuildInfo.ts
@@ -15,6 +15,9 @@ export function updateSelectedBuildInfo(
     storyId: string;
   }
 ) {
+  // Never touch the selected build if we don't change story
+  if (oldSelectedBuildInfo?.storyId === storyId) return oldSelectedBuildInfo;
+
   if (!shouldSwitchToLastBuildOnBranch) {
     if (!oldSelectedBuildInfo) return undefined;
 

--- a/src/utils/updateSelectedBuildInfo.ts
+++ b/src/utils/updateSelectedBuildInfo.ts
@@ -7,16 +7,20 @@ export function updateSelectedBuildInfo(
   oldSelectedBuildInfo: SelectedBuildInfo | undefined,
   {
     shouldSwitchToLastBuildOnBranch,
+    forceSwitchToLastBuildOnBranch,
     lastBuildOnBranchId,
     storyId,
   }: {
     shouldSwitchToLastBuildOnBranch: boolean;
+    forceSwitchToLastBuildOnBranch: boolean;
     lastBuildOnBranchId?: string;
     storyId: string;
   }
 ) {
   // Never touch the selected build if we don't change story
-  if (oldSelectedBuildInfo?.storyId === storyId) return oldSelectedBuildInfo;
+  if (oldSelectedBuildInfo?.storyId === storyId && !forceSwitchToLastBuildOnBranch) {
+    return oldSelectedBuildInfo;
+  }
 
   if (!shouldSwitchToLastBuildOnBranch) {
     if (!oldSelectedBuildInfo) return undefined;


### PR DESCRIPTION
Telescoping from https://github.com/chromaui/addon-visual-tests/pull/124

We had a bug where it automatically switched you to the new build when you already had a selected build as soon as you captured a new story. The specified behaviour was that it should "hold" until you opt-in (by clicking the header) or change story.

This ensures that (and adds a story that tests the changing story part actually works)...

To QA:

1. Open a branch with a build, view a snapshot
2. Run another build, let it finish
3. Ensure you are still viewing the old snapshot (it should say "View latest snapshot" in the header, or check the build # in the footer).
4. Change story
5. Check you are now viewing the new build.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.106--canary.130.19df40a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.106--canary.130.19df40a.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.106--canary.130.19df40a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
