### PR TITLE
Handle unexpected errors from the runChromaticBuild method (cli misconfigured, missing build commmand, etc)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,11 @@ async function serverChannel(
 
   channel.on(START_BUILD, async () => {
     const { projectToken } = projectInfoState.value || {};
-    await runChromaticBuild(localBuildProgress, { projectToken });
+    try {
+      await runChromaticBuild(localBuildProgress, { projectToken });
+    } catch (e) {
+      console.error(`Failed to run Chromatic build, with error:\n${e}`);
+    }
   });
 
   channel.on(STOP_BUILD, stopChromaticBuild);


### PR DESCRIPTION
This is a quick fix to handle unexpected errors from the cli run method. The UI portion of the failure is handled by the onBuildProgressOrError, but the try-catch is necessary to prevent the server from crashing. Added a console.error to log the error that was caught, however this error is not as useful as the actual CLI logs. I felt it would be useful to keep in case an error occurs that the cli doesn't properly log for.