### PR TITLE
Fix package configuration to be in line with tsup configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 dist/
 node_modules/
-storybook-static/
-build-storybook.log
 .DS_Store
 .env
 yarn-error.log
+storybook-static/
+build-storybook.log
+chromatic.log
+chromatic-build-*.xml
+chromatic-diagnostics.json

--- a/package.json
+++ b/package.json
@@ -20,21 +20,11 @@
   "license": "MIT",
   "author": "Chromatic <support@chromatic.com>",
   "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
-    },
-    "./manager": {
-      "require": "./dist/manager.js",
-      "import": "./dist/manager.mjs",
-      "types": "./dist/manager.d.ts"
-    },
+    ".": "./dist/index.js",
+    "./manager": "./dist/manager.mjs",
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",
     "README.md",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,30 +1,26 @@
 import { defineConfig } from "tsup";
 
+// We're not building an API for consumption by other projects. Instead, Storybook will bundle
+// everything in the end, which is why we don't compile dts or sourcemaps.
 export default defineConfig((options) => [
   {
-    entry: ["src/index.ts"],
-    splitting: false,
-    minify: !options.watch,
-    format: ["cjs"],
-    dts: false,
-    treeshake: true,
-    sourcemap: true,
     clean: !options.watch,
+    entry: ["src/index.ts"],
+    format: ["cjs"],
     platform: "node",
+    splitting: false,
+    treeshake: true,
     esbuildOptions(options) {
       options.conditions = ["module"];
     },
   },
   {
-    entry: ["src/manager.tsx"],
-    splitting: false,
-    minify: !options.watch,
-    format: ["esm"],
-    dts: false,
-    treeshake: true,
-    sourcemap: true,
     clean: !options.watch,
+    entry: ["src/manager.tsx"],
+    format: ["esm"],
     platform: "browser",
+    splitting: false,
+    treeshake: true,
     esbuildOptions(options) {
       options.conditions = ["module"];
     },


### PR DESCRIPTION
This should fix the following issue:

```
Error: Failed to resolve entry for package "@chromaui/addon-visual-tests".
The package may have incorrect main/module/exports specified in its package.json.
```

Also, ignore Chromatic-generated files.