### PR TITLE
Fix package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,12 @@
   "license": "MIT",
   "author": "Chromatic <support@chromatic.com>",
   "exports": {
-    ".": "./dist/index.js",
-    "./manager": "./dist/manager.mjs",
+    ".": {
+      "require": "./dist/index.js"
+    },
+    "./manager": {
+      "import": "./dist/manager.mjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
Fixes the addon not loading (blank panel) in v0.0.111.

The `import` specifier is necessary. For consistency/clarity I reintroduced `require` as well, but it's not strictly necessary.