### PR TITLE
Fix warnings in browser console

### DIFF
--- a/src/components/BuildProgressBarInline.tsx
+++ b/src/components/BuildProgressBarInline.tsx
@@ -19,7 +19,10 @@ export function BuildProgressInline({
   localBuildProgress: LocalBuildProgress;
 }) {
   return (
-    <ProgressTextWrapper style={{ display: "flex", flexDirection: "column", gap: 10, width: 200 }}>
+    <ProgressTextWrapper
+      as="div"
+      style={{ display: "flex", flexDirection: "column", gap: 10, width: 200 }}
+    >
       <ProgressTrack>
         {typeof localBuildProgress.buildProgressPercentage === "number" && (
           <ProgressBar style={{ width: `${localBuildProgress.buildProgressPercentage}%` }} />

--- a/src/screens/VisualTests/StoryInfo.tsx
+++ b/src/screens/VisualTests/StoryInfo.tsx
@@ -37,7 +37,7 @@ const Info = styled.div(({ theme }) => ({
       fontSize: "inherit",
     },
 
-    "& > *:first-child": {
+    "& > span:first-of-type": {
       display: "inline-flex",
       alignItems: "center",
       height: 24,
@@ -133,12 +133,14 @@ export const StoryInfo = ({
   } else if (shouldSwitchToLastBuildOnBranch) {
     details = (
       <Info>
-        <b>
-          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-          <Link isButton onClick={switchToLastBuildOnBranch}>
-            View latest snapshot
-          </Link>
-        </b>
+        <span>
+          <b>
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            <Link isButton onClick={switchToLastBuildOnBranch}>
+              View latest snapshot
+            </Link>
+          </b>
+        </span>
         <span>Newer test results are available for this story</span>
       </Info>
     );

--- a/src/utils/useProjectId.ts
+++ b/src/utils/useProjectId.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { PROJECT_INFO } from "../constants";
 import { ProjectInfoPayload } from "../types";
@@ -10,13 +10,16 @@ export const useProjectId = () => {
   // Once we've seen the state of the update, we can "clear" it to move on
   const [clearUpdated, setClearUpdated] = useState(false);
 
-  const updateProject = (newProjectId: string, newProjectToken: string) => {
-    setClearUpdated(false);
-    setProjectInfo({
-      projectId: newProjectId,
-      projectToken: newProjectToken,
-    });
-  };
+  const updateProject = useCallback(
+    (newProjectId: string, newProjectToken: string) => {
+      setClearUpdated(false);
+      setProjectInfo({
+        projectId: newProjectId,
+        projectToken: newProjectToken,
+      });
+    },
+    [setProjectInfo]
+  );
 
   const { projectId, projectToken, written, configFile } = projectInfo || {};
   return {

--- a/src/utils/useSharedState.ts
+++ b/src/utils/useSharedState.ts
@@ -18,12 +18,9 @@ export function useSharedState<T>(key: string) {
 
   return [
     state,
-    useCallback(
-      (newValue: T | undefined) => {
-        setState(newValue);
-        sharedStateRef.current.value = newValue;
-      },
-      [sharedStateRef]
-    ),
+    useCallback((newValue: T | undefined) => {
+      setState(newValue);
+      sharedStateRef.current.value = newValue;
+    }, []),
   ] as const;
 }

--- a/src/utils/useSharedState.ts
+++ b/src/utils/useSharedState.ts
@@ -1,5 +1,5 @@
 import { useStorybookApi } from "@storybook/manager-api";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { SharedState } from "./SharedState";
 
@@ -7,19 +7,23 @@ export function useSharedState<T>(key: string) {
   const channel = useStorybookApi().getChannel();
   if (!channel) throw new Error("Channel not available");
 
-  const sharedState = useRef(SharedState.subscribe<T>(key, channel)).current;
-  const [state, setState] = useState<T | undefined>(sharedState.value);
+  const sharedStateRef = useRef(SharedState.subscribe<T>(key, channel));
+  const [state, setState] = useState<T | undefined>(sharedStateRef.current.value);
 
-  sharedState.on("change", setState);
+  useEffect(() => {
+    const sharedState = sharedStateRef.current;
+    sharedState.on("change", setState);
+    return () => sharedState.off("change", setState);
+  }, [sharedStateRef]);
 
   return [
     state,
     useCallback(
       (newValue: T | undefined) => {
         setState(newValue);
-        sharedState.value = newValue;
+        sharedStateRef.current.value = newValue;
       },
-      [sharedState]
+      [sharedStateRef]
     ),
   ] as const;
 }


### PR DESCRIPTION
Fixes AP-3814

- `:first-child` warning (even though irrelevant)
- `setState` on unmounted component
- `setState` in render (cannot update a component while rendering a different component)
- `<div> cannot appear as a descendant of <p>` in `BuildProgressInline`

This should also be a nice performance improvement, as we were needlessly setting up too many event listeners and had a bunch of crosstalk between them (I'm actually surprised it didn't make my browser really slow).

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.113--canary.141.66e051a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.113--canary.141.66e051a.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.113--canary.141.66e051a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
