### PR TITLE
TestBuild: Add `SB_TESTBUILD` env-variable to switch on `--test` buildMode in storybook

### DIFF
--- a/src/runChromaticBuild.ts
+++ b/src/runChromaticBuild.ts
@@ -174,6 +174,8 @@ export const runChromaticBuild = async (
   abortController?.abort();
   abortController = new AbortController();
 
+  process.env.SB_TESTBUILD = "true";
+
   await run({
     // Currently we have to have these flags.
     // We should move the checks to after flags have been parsed into options.


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.117--canary.147.1c26ff5.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.117--canary.147.1c26ff5.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.117--canary.147.1c26ff5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
