### PR TITLE
Some visual and performance tweaks

### DIFF
--- a/src/components/SnapshotImage.tsx
+++ b/src/components/SnapshotImage.tsx
@@ -92,11 +92,12 @@ export const SnapshotImage = ({
   focusVisible,
   ...props
 }: SnapshotImageProps & ComponentProps<typeof Container>) => {
-  const hasDiff = latestImage && diffImage && comparisonResult === ComparisonResult.Changed;
+  const hasDiff = !!latestImage && !!diffImage && comparisonResult === ComparisonResult.Changed;
   const hasError = comparisonResult === ComparisonResult.CaptureError;
+  const hasFocus = hasDiff && !!focusImage;
   const containerProps = hasDiff ? { as: "a" as any, href: testUrl, target: "_blank" } : {};
   const showDiff = hasDiff && diffVisible;
-  const showFocus = hasDiff && focusImage && focusVisible;
+  const showFocus = hasFocus && focusVisible;
 
   return (
     <Container {...props} {...containerProps}>
@@ -120,20 +121,26 @@ export const SnapshotImage = ({
           }}
         />
       )}
-      {showDiff && (
+      {hasDiff && (
         <img
           alt=""
           data-overlay="diff"
           src={diffImage.imageUrl}
-          style={{ maxWidth: `${(diffImage.imageWidth / latestImage.imageWidth) * 100}%` }}
+          style={{
+            maxWidth: `${(diffImage.imageWidth / latestImage.imageWidth) * 100}%`,
+            opacity: showDiff ? 1 : 0,
+          }}
         />
       )}
-      {showFocus && (
+      {hasFocus && (
         <img
           alt=""
           data-overlay="focus"
           src={focusImage.imageUrl}
-          style={{ maxWidth: `${(focusImage.imageWidth / latestImage.imageWidth) * 100}%` }}
+          style={{
+            maxWidth: `${(focusImage.imageWidth / latestImage.imageWidth) * 100}%`,
+            opacity: showFocus ? 1 : 0,
+          }}
         />
       )}
       {hasDiff && <Icons icon="sharealt" />}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -6,6 +6,7 @@ export const Sections = styled.div<{ hidden?: boolean }>(
     display: "flex",
     flexDirection: "column",
     height: "100%",
+    overflowY: "auto",
   },
   ({ hidden }) => hidden && { display: "none" }
 );

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -271,6 +271,7 @@ export const SnapshotComparison = ({
         )}
         {!isInProgress && selectedComparison && (
           <SnapshotImage
+            key={selectedComparison.id}
             componentName={selectedTest.story?.component?.name}
             storyName={selectedTest.story?.name}
             testUrl={selectedTest.webUrl}

--- a/src/screens/VisualTests/SnapshotControls.tsx
+++ b/src/screens/VisualTests/SnapshotControls.tsx
@@ -93,7 +93,6 @@ export const SnapshotControls = ({
 
   const isAcceptable = changeCount > 0 && selectedTest.status !== TestStatus.Accepted;
   const isUnacceptable = changeCount > 0 && selectedTest.status === TestStatus.Accepted;
-  const hasBaselineSnapshot = !!selectedComparison?.baseCapture?.captureImage;
 
   return (
     <>
@@ -107,28 +106,27 @@ export const SnapshotControls = ({
       </Label>
 
       <Controls>
-        {hasBaselineSnapshot && (
-          <WithTooltip
-            tooltip={
-              <TooltipNote
-                note={baselineImageVisible ? "Show latest snapshot" : "Show baseline snapshot"}
-              />
-            }
-            trigger="hover"
-            hasChrome={false}
-          >
-            <IconButton
-              aria-label={baselineImageVisible ? "Show latest snapshot" : "Show baseline snapshot"}
-              onClick={() => toggleBaselineImage()}
-            >
-              <Icons icon="transfer" />
-              Switch
-            </IconButton>
-          </WithTooltip>
-        )}
-
         {selectedComparison?.result === ComparisonResult.Changed && (
           <>
+            <WithTooltip
+              tooltip={
+                <TooltipNote
+                  note={baselineImageVisible ? "Show latest snapshot" : "Show baseline snapshot"}
+                />
+              }
+              trigger="hover"
+              hasChrome={false}
+            >
+              <IconButton
+                aria-label={
+                  baselineImageVisible ? "Show latest snapshot" : "Show baseline snapshot"
+                }
+                onClick={() => toggleBaselineImage()}
+              >
+                <Icons icon="transfer" />
+                Switch
+              </IconButton>
+            </WithTooltip>
             <WithTooltip
               tooltip={<TooltipNote note={focusVisible ? "Hide spotlight" : "Show spotlight"} />}
               trigger="hover"


### PR DESCRIPTION
Fix ability to scroll the panel contents.
Hide switch button if there are no visual changes.
Load diff and spotlight images in the background while they're not shown yet.
When switching browser/mode, prevent previous snapshot from "sticking" while new one is loading.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.120--canary.150.4d5f492.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.120--canary.150.4d5f492.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.120--canary.150.4d5f492.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
