### PR TITLE
Override any configuration that might cause conflicts

### DIFF
--- a/src/runChromaticBuild.ts
+++ b/src/runChromaticBuild.ts
@@ -184,6 +184,12 @@ export const runChromaticBuild = async (
     options: {
       ...options,
 
+      // Local changes should never be auto-accepted
+      autoAcceptChanges: false,
+      // Test results must be awaited to get progress updates
+      exitOnceUploaded: false,
+      // Don't raise any alarms when changes are found
+      exitZeroOnChanges: true,
       // We might want to drop this later and instead record "uncommitted hashes" on builds
       forceRebuild: true,
       // Builds initiated from the addon are always considered local

--- a/src/runChromaticBuild.ts
+++ b/src/runChromaticBuild.ts
@@ -192,8 +192,12 @@ export const runChromaticBuild = async (
       exitZeroOnChanges: true,
       // We might want to drop this later and instead record "uncommitted hashes" on builds
       forceRebuild: true,
+      // This should never be set for local builds
+      fromCI: false,
       // Builds initiated from the addon are always considered local
       isLocalBuild: true,
+      // Never skip local builds
+      skip: false,
 
       experimental_onTaskStart: onStartOrProgress(localBuildProgress, timeout),
       experimental_onTaskProgress: onStartOrProgress(localBuildProgress, timeout),


### PR DESCRIPTION
Users may have `autoAcceptChanges`, `exitOnceUploaded` or `exitZeroOnChanges` configured in their `chromatic.config.json`. This PR overrides these values to ensure compatibility with local builds.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.121--canary.152.c545746.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.121--canary.152.c545746.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.121--canary.152.c545746.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
