### PR TITLE
Get CI green again.

### DIFF
--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -154,7 +154,6 @@ export const VisualTestsWithoutSelectedBuildId = ({
     getFragment(FragmentStatusTestFields, lastBuildOnBranch.testsForStatus.nodes);
   const statusUpdate = lastBuildOnBranchIsSelectable && testsToStatusUpdate(testsForStatus || []);
   useEffect(() => {
-    // @ts-expect-error The return type of this function is wrong in the API, it should allow `null` values
     updateBuildStatus((state) => ({
       ...createEmptyStoryStatusUpdate(state),
       ...statusUpdate,

--- a/src/utils/testsToStatusUpdate.ts
+++ b/src/utils/testsToStatusUpdate.ts
@@ -45,6 +45,5 @@ export function testsToStatusUpdate<T extends StatusTestFieldsFragment>(
     ])
   );
 
-  // @ts-expect-error SB's API type is incorrect here you are allowed to pass null
   return update;
 }


### PR DESCRIPTION
I accidentally pushed an update to SB@7.6.4 to main, which broke CI.

I'm not quite sure what the revert practice is so instead, we should maybe just fix it. This PR

1. Removes some `@ts-expect-errors` that were working around an SB bug that got fixed.
2. Approves changes to colors due to the `theme.textMutedColor` changing: https://github.com/storybookjs/storybook/pull/24525 (please confirm @MichaelArestad)
3. There's also [this broken story](https://www.chromatic.com/test?appId=6480e1b0042842f149cfd74c&id=6576517167d8d01812482c48), which was already problematic before the upgrade. Any idea what's happening here @ghengeveld ?