### PR TITLE
Implement experimental "single component" mode

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -143,6 +143,11 @@ export const Panel = ({ active, api }: PanelProps) => {
   }
 
   const localBuildIsRightBranch = gitInfo.branch === localBuildProgress?.branch;
+  const startDevBuild = () => {
+    const { title } = api.getCurrentStoryData();
+    const onlyStoryNames = [`${title}/*`];
+    emit(START_BUILD, { accessToken, onlyStoryNames });
+  };
   return (
     <Provider key={PANEL_ID} value={client}>
       <Sections hidden={!active}>
@@ -151,7 +156,7 @@ export const Panel = ({ active, api }: PanelProps) => {
             dismissBuildError={() => setLocalBuildProgress(undefined)}
             isOutdated={!!isOutdated}
             localBuildProgress={localBuildIsRightBranch ? localBuildProgress : undefined}
-            startDevBuild={() => emit(START_BUILD, { accessToken })}
+            startDevBuild={startDevBuild}
             setAccessToken={setAccessToken}
             setOutdated={setOutdated}
             updateBuildStatus={updateBuildStatus}

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,10 +104,19 @@ async function serverChannel(
     channel
   );
 
-  channel.on(START_BUILD, async ({ accessToken: userToken }) => {
+  channel.on(START_BUILD, async ({ accessToken: userToken, onlyStoryNames, onlyChanged }) => {
     const { projectId } = projectInfoState.value || {};
     try {
-      await runChromaticBuild(localBuildProgress, { configFile, projectId, userToken });
+      await runChromaticBuild(localBuildProgress, {
+        configFile,
+        projectId,
+        userToken,
+        ...(onlyStoryNames && {
+          onlyStoryNames,
+          onlyChanged: false,
+          externals: null,
+        }),
+      });
     } catch (e) {
       console.error(`Failed to run Chromatic build, with error:\n${e}`);
     }

--- a/src/screens/VisualTests/SnapshotControls.tsx
+++ b/src/screens/VisualTests/SnapshotControls.tsx
@@ -299,14 +299,26 @@ export const SnapshotControls = ({
           )}
 
           <WithTooltip
-            tooltip={<TooltipNote note={isOutdated ? "Run new tests" : "Rerun tests"} />}
+            tooltip={
+              <TooltipNote
+                note={
+                  isOutdated
+                    ? "Run new tests for just this component"
+                    : "Rerun tests for just this component"
+                }
+              />
+            }
             trigger="hover"
             hasChrome={false}
           >
             <ActionButton
               containsIcon
               secondary
-              aria-label={isOutdated ? "Run new tests" : "Rerun tests"}
+              aria-label={
+                isOutdated
+                  ? "Run new tests for just this component"
+                  : "Rerun testsfor just this component for just this component"
+              }
               onClick={() => startDevBuild()}
             >
               <Icons icon={isOutdated ? "play" : "sync"} />


### PR DESCRIPTION
NOTE: this is an experiment to get a feel for timing, it is not a working implementation.

In this branch, all builds initiated from the panel will disable TurboSnap and use `--onlyStoryNames` to only capture the current component's stories.

This isn't a complete solution because:
 - We need to figure out what the UX for starting a single-component build is. Should there be a dropdown on the rerun button?
 - `--onlyStoryNames` will mean we assume the untested stories haven't changed, which will be inaccurate. This will lead to broken baselines. We need a proper concept of "untested" stories that are not assumed to be equal to their baseline.

Available as `@chromaui/addon-visual-tests@0.0.124--canary.c47be74.0`