### PR TITLE
A prototype of "local extraction"

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from "@storybook/design-system";
 import type { API } from "@storybook/manager-api";
 import { useChannel, useStorybookState } from "@storybook/manager-api";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import { Sections } from "./components/layout";
 import {
@@ -42,6 +42,24 @@ export const Panel = ({ active, api }: PanelProps) => {
     useSharedState<LocalBuildProgress>(LOCAL_BUILD_PROGRESS);
   const [, setOutdated] = useSharedState<boolean>(IS_OUTDATED);
   const emit = useChannel({});
+
+  useEffect(() => {
+    console.log(localBuildProgress?.storybookBuildUrl);
+    if (localBuildProgress?.storybookBuildUrl) {
+      window.addEventListener(
+        "message",
+        ({ data }) => {
+          // console.log(data);
+          if (data.message === "extractResults") {
+            console.log({ data });
+          }
+        },
+        false
+      );
+
+      document.body.innerHTML += `<iframe style="display: none" src="${localBuildProgress.storybookBuildUrl}extract.html" />`;
+    }
+  }, [localBuildProgress?.storybookBuildUrl]);
 
   const updateBuildStatus = useCallback<UpdateStatusFunction>(
     (update) => api.experimental_updateStatus(ADDON_ID, update),

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -44,13 +44,13 @@ export const Panel = ({ active, api }: PanelProps) => {
   const emit = useChannel({});
 
   useEffect(() => {
-    console.log(localBuildProgress?.storybookBuildUrl);
     if (localBuildProgress?.storybookBuildUrl) {
+      console.log("Build step completed, starting local extract");
       window.addEventListener(
         "message",
         ({ data }) => {
-          // console.log(data);
           if (data.message === "extractResults") {
+            console.log("Got local extract results");
             console.log({ data });
           }
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,7 @@ async function serverChannel(
   let started = false;
   localBuildProgress.on("change", (progress) => {
     if (progress?.currentStep === "upload" && progress.storybookBuildDir && !started) {
+      console.log("Build step completed, starting local extract");
       const app = express();
       app.get("/extract.html", (request, response) => {
         response.writeHead(200, { contentType: "text/html" });

--- a/src/runChromaticBuild.ts
+++ b/src/runChromaticBuild.ts
@@ -107,6 +107,7 @@ export const onStartOrProgress =
       buildProgressPercentage: Math.min(newPercentage, endPercentage),
       currentStep: ctx.task,
       stepProgress,
+      storybookBuildDir: ctx.sourceDir,
     };
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,9 @@ export type LocalBuildProgress = {
    * */
   storybookBuildDir?: string;
 
+  /** URL of local built storybook */
+  storybookBuildUrl?: string;
+
   /** Number of visual changes detected */
   changeCount?: number;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,12 @@ export type LocalBuildProgress = {
   /** The step of the build process we have reached */
   currentStep: KnownStep | "aborted" | "complete" | "error";
 
+  /**
+   * The location of the storybook build, set immediately but not available until
+   * we reach the upload step
+   * */
+  storybookBuildDir?: string;
+
   /** Number of visual changes detected */
   changeCount?: number;
 


### PR DESCRIPTION
After the SB build step completes, open a hidden iframe that serves the built storybook, alongside an "extract script" that extracts the SB data we need to run a build, and post it back up to the addon.

We could then send those results with the `publishBuild` mutation and bypass extract on the server.

Running against this SB (with batching disabled), the time between ["Build Step complete..."](https://github.com/chromaui/addon-visual-tests/blob/b738efc30aa549a6e441549b9b9da674640e8108/src/Panel.tsx#L48) and ["Got local extract results"](https://github.com/chromaui/addon-visual-tests/blob/b738efc30aa549a6e441549b9b9da674640e8108/src/Panel.tsx#L53) is around 650ms.

Running against the Chromatic monorepo, with:
 - Batching unchanged, took: 3.5s
 - Batching disabled, took: 2.6s


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.125--canary.156.a4e1724.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/addon-visual-tests@0.0.125--canary.156.a4e1724.0
  # or 
  yarn add @chromaui/addon-visual-tests@0.0.125--canary.156.a4e1724.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
