### PR TITLE
Change addon name to `@chromatic-com/storybook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Visual Testing addon enables you to run visual tests on your stories and com
 Run the following command to install the addon and automatically configure it for your project via Storybook's CLI:
 
 ```shell
-npx storybook@latest add @chromaui/addon-visual-tests
+npx storybook add @chromatic-com/storybook
 ```
 
 Start Storybook and navigate to the Visual Tests panel to run your first visual test with Chromatic!
@@ -39,9 +39,9 @@ const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: [
     // Other Storybook addons
-    "@chromaui/addon-visual-tests",
+    "@chromatic-com/storybook",
     {
-      name: "@chromaui/addon-visual-tests",
+      name: "@chromatic-com/storybook",
       options: {
         projectId: "Project:64cbcde96f99841e8b007d75",
         buildScriptName: "build-storybook",

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,0 +1,1 @@
+{"projectId":"Project:64936c844fd570be8b75bdac"}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@chromaui/addon-visual-tests",
+  "name": "@chromatic-com/storybook",
   "version": "0.0.124",
   "description": "Visual Testing addon with Chromatic",
   "engines": {


### PR DESCRIPTION
The rationale for the name change:

1. We want to make it clear that it's a Chromatic project (`@chromaui` wasn't doing that, thus the change of npm org), so people understand what Chromatic is.
2. We have a naming scheme under the `@chromatic-com` namespace where the second word is the tool we are integrating with (e.g. `@chromatic-com/playwright`). This is consistent with that.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1--canary.163.be3b834.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.0.1--canary.163.be3b834.0
  # or 
  yarn add @chromatic-com/storybook@1.0.1--canary.163.be3b834.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
