### PR TITLE
Adjust Status Visibility on Mode & Browser Selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,41 +19,7 @@ Start Storybook and navigate to the Visual Tests panel to run your first visual 
 
 ## Configuration
 
-By default, the addon offers zero-config support to run visual tests with Storybook and Chromatic. However, you can extend your Storybook configuration file (i.e., `.storybook/main.js|ts`) and provide additional options to control how tests are run. Listed below are the available options and examples of how to use them.
-
-| Option            | Description                                                                                                                              |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `buildScriptName` | Optional. Defines the custom Storybook build script <br/> `options: { buildScriptName: 'deploy-storybook' }`                             |
-| `debug`           | Optional. Output verbose debugging information to the console. <br/> `options: { debug: true }`                                          |
-| `projectId`       | Automatically configured. Sets the value for the project identifier <br/> `options: { projectId: Project:64cbcde96f99841e8b007d75 }`     |
-| `zip`             | Recommended for large projects. Configures the addon to deploy your Storybook to Chromatic as a zip file. <br/> `options: { zip: true }` |
-
-```ts
-// .storybook/main.ts
-
-// Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-vite)
-import type { StorybookConfig } from "@storybook/your-framework";
-
-const config: StorybookConfig = {
-  framework: "@storybook/your-framework",
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
-  addons: [
-    // Other Storybook addons
-    "@chromatic-com/storybook",
-    {
-      name: "@chromatic-com/storybook",
-      options: {
-        projectId: "Project:64cbcde96f99841e8b007d75",
-        buildScriptName: "build-storybook",
-        zip: true,
-        debug: true,
-      },
-    },
-  ],
-};
-
-export default config;
-```
+By default, the addon offers zero-config support to run visual tests with Storybook and Chromatic. However, you can extend your configuration via a `chromatic.config.json` file and provide additional options to control how tests are run. Check out the [docs](https://www.chromatic.com/docs/visual-tests-addon/) to learn about the various options that can be configured.
 
 ### Updating the GraphQL schema
 

--- a/src/components/BrowserSelector.tsx
+++ b/src/components/BrowserSelector.tsx
@@ -57,7 +57,7 @@ export const BrowserSelector = ({
   if (!aggregate) return null;
 
   let icon = browserIcons[selectedBrowser.key];
-  if (!isAccepted && aggregate !== ComparisonResult.Equal) {
+  if (!isAccepted && aggregate !== ComparisonResult.Equal && browserResults.length >= 2) {
     icon = <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>;
   }
 

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -48,7 +48,7 @@ export const ModeSelector = ({
   if (!aggregate) return null;
 
   let icon = <DiamondIcon />;
-  if (!isAccepted && aggregate !== ComparisonResult.Equal) {
+  if (!isAccepted && aggregate !== ComparisonResult.Equal && modeResults.length >= 2) {
     icon = <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>;
   }
 


### PR DESCRIPTION
We should only show the status dot for the Mode and Browser selectors when there is more than one browser or mode. 

To test
1. View the Browser Selector and Mode Selector Stories.
2. Run a build with multiple browsers enabled. You should see status dots on errors or changes on the Browser Selector.
3. Run a build with a story that has multiple modes. You should see status dots on errors or changes on the Modes Selector.
4. Run a build with a single browser enabled. You should **_not_** see status dots on errors or changes on the Browser Selector.
5. Run a build with a story with a single mode enabled. You should **_not_** see status dots on errors or changes on the Modes Selector.

Note: I also updated the readme to remove config info and point people at the hosted docs.