### PR TITLE
Remove @storybook/icons from externals

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -36,6 +36,8 @@ export default defineConfig(async (options) => {
 
   const configs: Options[] = [];
 
+  const globalManagerPackagesNoIcons = globalManagerPackages.filter(packageJson => packageJson !== "@storybook/icons")
+
   // export entries are entries meant to be manually imported by the user
   // they are not meant to be loaded by the manager or preview
   // they'll be usable in both node and browser environments, depending on which features and modules they depend on
@@ -48,7 +50,7 @@ export default defineConfig(async (options) => {
       },
       format: ["esm", "cjs"],
       platform: "neutral",
-      external: [...globalManagerPackages, ...globalPreviewPackages],
+      external: [...globalManagerPackagesNoIcons, ...globalPreviewPackages],
     });
   }
 
@@ -68,7 +70,7 @@ export default defineConfig(async (options) => {
           ".png": "dataurl",
         };
       },
-      external: globalManagerPackages,
+      external: globalManagerPackagesNoIcons,
     });
   }
 


### PR DESCRIPTION
This removes @storybook/icons from externals so that the addon successfully runs in SB 7.6

To QA:
Canary: `@chromatic-com/storybook@1.1.1--canary.8181fc2.0`
1. Install the Canary in a 7.6 project and confirm that a build can be run.