### PR TITLE
Update Time Ago Shorthand Notation

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,7 +13,7 @@ import {
 } from "@storybook/theming";
 import { HttpResponse, graphql } from "msw";
 import { initialize, mswLoader } from "msw-storybook-addon";
-import React from "react";
+import React, { useState } from "react";
 
 import { baseModes } from "../src/modes";
 import { UninstallProvider } from "../src/screens/Uninstalled/UninstallContext"
@@ -129,8 +129,9 @@ const withManagerApi: Decorator = (Story, { argsByTarget }) => (
 );
 
 const withUninstall: Decorator = (Story) => {
+  const [addonInstalled, setAddonInstalled] = useState(false)
   return (
-  <UninstallProvider>
+  <UninstallProvider addonUninstalled={addonInstalled} setAddonUninstalled={setAddonInstalled}>
     <Story />
   </UninstallProvider>
   )

--- a/src/screens/VisualTests/StoryInfo.stories.tsx
+++ b/src/screens/VisualTests/StoryInfo.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
   component: StoryInfo,
   args: {
     isStarting: false,
-    startedAt: new Date(Date.now() - 1000 * 60 * 2), // 2 minutes ago
+    startedAt: new Date(Date.now() - 1000 * 60 * 2), // 2m ago
     startDevBuild: action("startDevBuild"),
     shouldSwitchToLastBuildOnBranch: false,
     isBuildFailed: false,

--- a/src/screens/VisualTests/StoryInfo.tsx
+++ b/src/screens/VisualTests/StoryInfo.tsx
@@ -1,7 +1,6 @@
 import { Link } from "@storybook/components";
 import { PlayIcon } from "@storybook/icons";
 import { styled } from "@storybook/theming";
-import { formatDistance } from "date-fns";
 import pluralize from "pluralize";
 import React from "react";
 
@@ -10,6 +9,7 @@ import { AlertIcon } from "../../components/icons/AlertIcon";
 import { ProgressIcon } from "../../components/icons/ProgressIcon";
 import { StatusIcon } from "../../components/icons/StatusIcon";
 import { StoryTestFieldsFragment, TestStatus } from "../../gql/graphql";
+import { formatDate } from "../../utils/formatDate";
 import { summarizeTests } from "../../utils/summarizeTests";
 
 const Info = styled.div(({ theme }) => ({
@@ -94,10 +94,7 @@ export const StoryInfo = ({
   const { status, isInProgress, changeCount, brokenCount, modeResults, browserResults } =
     summarizeTests(tests ?? []);
 
-  const startedAgo =
-    !isStarting &&
-    startedAt &&
-    formatDistance(new Date(startedAt), new Date(), { addSuffix: true });
+  const startedAgo = !isStarting && startedAt && formatDate(new Date(startedAt).getTime());
   // isRunning means either we have no tests or they are unfinished
   const isRunning = isStarting || isInProgress;
   // isFailed means either the whole build failed or the story did

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,54 @@
+import { formatDistanceToNowStrict } from "date-fns";
+import locale from "date-fns/locale/en-US";
+
+const formatDistanceLocale: Record<string, string> = {
+  lessThanXSeconds: "just now",
+  xSeconds: "just now",
+  halfAMinute: "just now",
+  lessThanXMinutes: "{{count}}m",
+  xMinutes: "{{count}}m",
+  aboutXHours: "{{count}}h",
+  xHours: "{{count}}h",
+  xDays: "{{count}}d",
+  aboutXWeeks: "{{count}}w",
+  xWeeks: "{{count}}w",
+  aboutXMonths: "{{count}}mo",
+  xMonths: "{{count}}mo",
+  aboutXYears: "{{count}}y",
+  xYears: "{{count}}y",
+  overXYears: "{{count}}y",
+  almostXYears: "{{count}}y",
+};
+
+function formatDistance(
+  token: string,
+  count: string,
+  options: { addSuffix: boolean; comparison: number } = {
+    addSuffix: false,
+    comparison: 0,
+  }
+) {
+  const result = formatDistanceLocale[token].replace("{{count}}", count);
+
+  if (["lessThanXSeconds", "xSeconds", "halfAMinute"].includes(token)) {
+    return `${result}`;
+  }
+
+  if (options.addSuffix) {
+    if (options.comparison > 0) {
+      return `in ${result}`;
+    }
+    return `${result} ago`;
+  }
+
+  return result;
+}
+
+export const formatDate = (date: number) =>
+  formatDistanceToNowStrict(date, {
+    addSuffix: true,
+    locale: {
+      ...locale,
+      formatDistance,
+    },
+  });


### PR DESCRIPTION
This PR updates our date formatting to use a similar algorithm, which was pulled from the monorepo. This implementation uses `date-fns` instead of `moment`, since `moment` is no longer recommended.

TO QA:
1. Run a build and look a the time info in the Addon area.
2. Visit the StoryInfo story (what a mouthful lol) and use the controls to adjust the time info.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.3--canary.178.c2a97b7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.1.3--canary.178.c2a97b7.0
  # or 
  yarn add @chromatic-com/storybook@1.1.3--canary.178.c2a97b7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
