### PR TITLE
Fix kebab-case `box-shadow` to proper `boxShadow`

### DIFF
--- a/src/components/design-system/shared/styles.ts
+++ b/src/components/design-system/shared/styles.ts
@@ -115,7 +115,7 @@ export const hoverEffect = css({
   "&:hover, &.__hover": {
     borderColor: `${rgba(color.secondary, 0.5)}`,
     transform: "translate3d(0, -3px, 0)",
-    "box-shadow": "rgba(0, 0, 0, 0.08) 0 3px 10px 0",
+    boxShadow: "rgba(0, 0, 0, 0.08) 0 3px 10px 0",
   },
 
   "&:active, &.__active": {


### PR DESCRIPTION
There's currently an error in the console of any Storybook with VTA about using `box-shadow` while only `boxShadow` is allowed:

![image](https://github.com/chromaui/addon-visual-tests/assets/5678122/da35e59b-6627-4e03-b973-835238a2f66f)

The kebab-cased style won't be applied so the warning is valid.

This was probably an oversight during the hectic transformation of CSS styles to JS object styles at https://github.com/chromaui/addon-visual-tests/commit/76466a58b444a16906317ce5e7493c3926cc4ad0#diff-6670cf4c6d5074d9ed37d761697fbbc372e5aa961f0907c7b305a1bd7f1e0e2aR118