### PR TITLE
UI for when Account Exceeds Snapshot Threshold

### DIFF
--- a/src/screens/BillingLimitReached/BillingLimitReached.stories.tsx
+++ b/src/screens/BillingLimitReached/BillingLimitReached.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { GraphQLClientProvider } from "../../utils/graphQLClient";
+import { storyWrapper } from "../../utils/storyWrapper";
+import { BillingLimitReached } from "./BillingLimitReached";
+
+const meta = {
+  component: BillingLimitReached,
+  decorators: [storyWrapper(GraphQLClientProvider)],
+  args: {accountId: 'ab124'},
+} satisfies Meta<typeof BillingLimitReached>;
+
+export const Default = {} satisfies StoryObj<typeof meta>;
+
+export default meta;

--- a/src/screens/BillingLimitReached/BillingLimitReached.tsx
+++ b/src/screens/BillingLimitReached/BillingLimitReached.tsx
@@ -1,0 +1,32 @@
+import { Link } from "@storybook/components";
+import { StopIcon } from "@storybook/icons";
+import React from "react";
+
+import { Container } from "../../components/Container";
+import { Heading } from "../../components/Heading";
+import { Section, Sections } from "../../components/layout";
+import { Stack } from "../../components/Stack";
+import { Text } from "../../components/Text";
+
+interface BillingLimitReachedProps {
+    accountId: string
+}
+
+export const BillingLimitReached = ({accountId}: BillingLimitReachedProps) => {
+  return (
+    <Sections>
+      <Section grow>
+        <Container>
+          <Stack>
+            <StopIcon size={42} opacity={0.5} />
+            <Heading>Tests did not run</Heading>
+            <Text>Tests did not run because hichroma's account was over the free snapshot limit. Visit your account’s billing page to find out more.</Text>
+            <Link isButton withArrow target="_blank" href={`https://www.chromatic.com/billing?accountId=${accountId}`}>
+              Go to billing
+            </Link>
+          </Stack>
+        </Container>
+      </Section>
+    </Sections>
+  );
+};


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.4--canary.182.b9b016b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.1.4--canary.182.b9b016b.0
  # or 
  yarn add @chromatic-com/storybook@1.1.4--canary.182.b9b016b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
