### PR TITLE
Refactor UI architecture to avoid repetition

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,7 @@
-import { action } from "@storybook/addon-actions"
-import { API, ManagerContext, State } from "@storybook/manager-api";
-import type { Decorator, Loader, Preview } from "@storybook/react";
-import { fn } from "@storybook/test"
+import { action } from "@storybook/addon-actions";
+import { ManagerContext } from "@storybook/manager-api";
+import type { Loader, Preview } from "@storybook/react";
+import { fn } from "@storybook/test";
 import {
   Global,
   ThemeProvider,
@@ -15,9 +15,11 @@ import { HttpResponse, graphql } from "msw";
 import { initialize, mswLoader } from "msw-storybook-addon";
 import React from "react";
 
+import { AuthProvider } from "../src/AuthContext";
 import { baseModes } from "../src/modes";
-import { UninstallProvider } from "../src/screens/Uninstalled/UninstallContext"
-
+import { UninstallProvider } from "../src/screens/Uninstalled/UninstallContext";
+import { GraphQLClientProvider } from "../src/utils/graphQLClient";
+import { storyWrapper } from "../src/utils/storyWrapper";
 
 // Initialize MSW
 initialize({
@@ -117,24 +119,23 @@ const withTheme = (StoryFn, { globals, parameters }) => {
   );
 };
 
-const withManagerApi: Decorator = (Story, { argsByTarget }) => (
-  <ManagerContext.Provider
-    value={{
-      api: { ...argsByTarget["manager-api"] } as API,
-      state: {} as State,
-    }}
-  >
-    <Story />
-  </ManagerContext.Provider>
-);
+const withGraphQLClient = storyWrapper(GraphQLClientProvider);
 
-const withUninstall: Decorator = (Story) => {
-  return (
-  <UninstallProvider>
-    <Story />
-  </UninstallProvider>
-  )
-}
+const withAuth = storyWrapper(AuthProvider, () => ({
+  value: {
+    accessToken: "token",
+    setAccessToken: fn(),
+  },
+}));
+
+const withManagerApi = storyWrapper(ManagerContext.Provider, ({ argsByTarget }) => ({
+  value: {
+    api: { ...argsByTarget["manager-api"] },
+    state: {},
+  },
+}));
+
+const withUninstall = storyWrapper(UninstallProvider);
 
 /**
  * An experiment with targeted args for GraphQL. This loader will serve a graphql
@@ -180,7 +181,7 @@ export const graphQLArgLoader: Loader = async ({ argTypes, argsByTarget, paramet
 };
 
 const preview: Preview = {
-  decorators: [withTheme, withUninstall, withManagerApi ],
+  decorators: [withTheme, withGraphQLClient, withAuth, withUninstall, withManagerApi],
   loaders: [graphQLArgLoader],
   parameters: {
     actions: {
@@ -210,7 +211,7 @@ const preview: Preview = {
     getChannel: { type: "function", target: "manager-api" },
   },
   args: {
-    getChannel: () => ({on: fn(), off: fn(), emit: action("channel.emit")}),
+    getChannel: () => ({ on: fn(), off: fn(), emit: action("channel.emit") }),
   },
   globalTypes: {
     theme: {

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,0 +1,22 @@
+import React, { createContext } from "react";
+
+import { useRequiredContext } from "./utils/useRequiredContext";
+
+interface AuthState {
+  accessToken: string | null;
+  setAccessToken: (accessToken: string | null) => void;
+}
+
+export const AuthContext = createContext<AuthState | null>(null);
+
+export const AuthProvider = ({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: AuthState;
+}) => {
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuthState = () => useRequiredContext(AuthContext, "AuthState");

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -2,6 +2,7 @@ import type { API } from "@storybook/manager-api";
 import { useChannel, useStorybookState } from "@storybook/manager-api";
 import React, { useCallback, useState } from "react";
 
+import { AuthProvider } from "./AuthContext";
 import { Spinner } from "./components/design-system";
 import { Sections } from "./components/layout";
 import {
@@ -64,56 +65,38 @@ export const Panel = ({ active, api }: PanelProps) => {
   const [createdProjectId, setCreatedProjectId] = useState<Project["id"]>();
   const [addonUninstalled, setAddonUninstalled] = useSharedState<boolean>(REMOVE_ADDON);
 
-  if (addonUninstalled) {
-    return (
-      <Provider key={PANEL_ID} value={client}>
+  const withProviders = (children: React.ReactNode) => (
+    <Provider key={PANEL_ID} value={client}>
+      <AuthProvider value={{ accessToken, setAccessToken }}>
         <UninstallProvider
           addonUninstalled={addonUninstalled}
           setAddonUninstalled={setAddonUninstalled}
         >
-          <Sections hidden={!active}>
-            <Uninstalled />
-          </Sections>
+          <Sections hidden={!active}>{children}</Sections>
         </UninstallProvider>
-      </Provider>
-    );
+      </AuthProvider>
+    </Provider>
+  );
+
+  if (addonUninstalled) {
+    return withProviders(<Uninstalled />);
   }
 
   if (gitInfoError) {
     // eslint-disable-next-line no-console
     console.error(gitInfoError);
-    return (
-      <Provider key={PANEL_ID} value={client}>
-        <UninstallProvider
-          addonUninstalled={addonUninstalled}
-          setAddonUninstalled={setAddonUninstalled}
-        >
-          <Sections hidden={!active}>
-            <GitNotFound gitInfoError={gitInfoError} setAccessToken={setAccessToken} />
-          </Sections>
-        </UninstallProvider>
-      </Provider>
-    );
+    return withProviders(<GitNotFound gitInfoError={gitInfoError} />);
   }
 
   // Render the Authentication flow if the user is not signed in.
   if (!accessToken) {
-    return (
-      <Provider key={PANEL_ID} value={client}>
-        <UninstallProvider
-          addonUninstalled={addonUninstalled}
-          setAddonUninstalled={setAddonUninstalled}
-        >
-          <Sections hidden={!active}>
-            <Authentication
-              key={PANEL_ID}
-              setAccessToken={setAccessToken}
-              setCreatedProjectId={setCreatedProjectId}
-              hasProjectId={!!projectId}
-            />
-          </Sections>
-        </UninstallProvider>
-      </Provider>
+    return withProviders(
+      <Authentication
+        key={PANEL_ID}
+        setAccessToken={setAccessToken}
+        setCreatedProjectId={setCreatedProjectId}
+        hasProjectId={!!projectId}
+      />
     );
   }
 
@@ -123,93 +106,47 @@ export const Panel = ({ active, api }: PanelProps) => {
   }
 
   if (!projectId)
-    return (
-      <Provider key={PANEL_ID} value={client}>
-        <UninstallProvider
-          addonUninstalled={addonUninstalled}
-          setAddonUninstalled={setAddonUninstalled}
-        >
-          <Sections hidden={!active}>
-            <LinkProject
-              createdProjectId={createdProjectId}
-              setCreatedProjectId={setCreatedProjectId}
-              onUpdateProject={updateProject}
-              setAccessToken={setAccessToken}
-            />
-          </Sections>
-        </UninstallProvider>
-      </Provider>
+    return withProviders(
+      <LinkProject
+        createdProjectId={createdProjectId}
+        setCreatedProjectId={setCreatedProjectId}
+        onUpdateProject={updateProject}
+      />
     );
 
   if (projectUpdatingFailed) {
     // These should always be set when we get this error
-    if (!configFile) {
-      throw new Error(`Missing config file after configuration failure`);
-    }
-
-    return (
-      <UninstallProvider
-        addonUninstalled={addonUninstalled}
-        setAddonUninstalled={setAddonUninstalled}
-      >
-        <Sections hidden={!active}>
-          <LinkingProjectFailed
-            projectId={projectId}
-            configFile={configFile}
-            setAccessToken={setAccessToken}
-          />
-        </Sections>
-      </UninstallProvider>
-    );
+    if (!configFile) throw new Error(`Missing config file after configuration failure`);
+    return withProviders(<LinkingProjectFailed projectId={projectId} configFile={configFile} />);
   }
 
   if (projectIdUpdated) {
     // This should always be set when we succeed
     if (!configFile) throw new Error(`Missing config file after configuration success`);
 
-    return (
-      <Provider key={PANEL_ID} value={client}>
-        <UninstallProvider
-          addonUninstalled={addonUninstalled}
-          setAddonUninstalled={setAddonUninstalled}
-        >
-          <Sections hidden={!active}>
-            <LinkedProject
-              projectId={projectId}
-              configFile={configFile}
-              goToNext={clearProjectIdUpdated}
-              setAccessToken={setAccessToken}
-            />
-          </Sections>
-        </UninstallProvider>
-      </Provider>
+    return withProviders(
+      <LinkedProject
+        projectId={projectId}
+        configFile={configFile}
+        goToNext={clearProjectIdUpdated}
+      />
     );
   }
 
   const localBuildIsRightBranch = gitInfo.branch === localBuildProgress?.branch;
-  return (
-    <Provider key={PANEL_ID} value={client}>
-      <UninstallProvider
-        addonUninstalled={addonUninstalled}
-        setAddonUninstalled={setAddonUninstalled}
-      >
-        <Sections hidden={!active}>
-          <ControlsProvider>
-            <VisualTests
-              dismissBuildError={() => setLocalBuildProgress(undefined)}
-              isOutdated={!!isOutdated}
-              localBuildProgress={localBuildIsRightBranch ? localBuildProgress : undefined}
-              startDevBuild={() => emit(START_BUILD, { accessToken })}
-              setAccessToken={setAccessToken}
-              setOutdated={setOutdated}
-              updateBuildStatus={updateBuildStatus}
-              projectId={projectId}
-              gitInfo={gitInfo}
-              storyId={storyId}
-            />
-          </ControlsProvider>
-        </Sections>
-      </UninstallProvider>
-    </Provider>
+  return withProviders(
+    <ControlsProvider>
+      <VisualTests
+        dismissBuildError={() => setLocalBuildProgress(undefined)}
+        isOutdated={!!isOutdated}
+        localBuildProgress={localBuildIsRightBranch ? localBuildProgress : undefined}
+        startDevBuild={() => emit(START_BUILD, { accessToken })}
+        setOutdated={setOutdated}
+        updateBuildStatus={updateBuildStatus}
+        projectId={projectId}
+        gitInfo={gitInfo}
+        storyId={storyId}
+      />
+    </ControlsProvider>
   );
 };

--- a/src/SidebarBottom.tsx
+++ b/src/SidebarBottom.tsx
@@ -27,10 +27,7 @@ export const SidebarBottom = ({ api }: SidebarBottomProps) => {
   if (!warnings.length) return null;
 
   return (
-    <span
-      id="sidebar-bottom-wrapper"
-      style={{ width: "calc(100% + 10px)", height: "calc(100% + 10px)", margin: "-5px" }}
-    >
+    <span id="sidebar-bottom-wrapper">
       <SidebarToggleButton count={warnings.length} onEnable={onEnable} onDisable={onDisable} />
     </span>
   );

--- a/src/components/BrowserSelector.tsx
+++ b/src/components/BrowserSelector.tsx
@@ -31,12 +31,13 @@ const IconWrapper = styled.div(({ theme }) => ({
   },
 }));
 
-const Label = styled.span({
+const Label = styled.span(({ theme }) => ({
   display: "none",
+  fontSize: theme.typography.size.s2 - 1,
   "@container (min-width: 300px)": {
     display: "inline-block",
   },
-});
+}));
 
 type BrowserData = Pick<BrowserInfo, "id" | "key" | "name">;
 

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -20,12 +20,13 @@ const IconWrapper = styled.div(({ theme }) => ({
   },
 }));
 
-const Label = styled.span({
+const Label = styled.span(({ theme }) => ({
   display: "none",
+  fontSize: theme.typography.size.s2 - 1,
   "@container (min-width: 300px)": {
     display: "inline-block",
   },
-});
+}));
 
 type ModeData = Pick<TestMode, "name">;
 

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -1,0 +1,22 @@
+import React, { ReactNode } from "react";
+
+import { useAuthState } from "../AuthContext";
+import { FooterSection } from "./FooterSection";
+import { Sections } from "./layout";
+
+interface ScreenProps {
+  children: ReactNode;
+  header?: () => ReactNode;
+  footer?: ({ menu }: { menu: ReactNode }) => ReactNode;
+}
+
+export const Screen = ({ children, footer, header }: ScreenProps) => {
+  const { setAccessToken } = useAuthState();
+  return (
+    <Sections>
+      {header?.()}
+      {children}
+      <FooterSection render={footer} setAccessToken={setAccessToken} />
+    </Sections>
+  );
+};

--- a/src/components/SidebarToggleButton.tsx
+++ b/src/components/SidebarToggleButton.tsx
@@ -11,13 +11,14 @@ const Badge = styled(BaseBadge)(({ theme }) => ({
 }));
 
 const Button = styled(IconButton)(
-  {
+  ({ theme }) => ({
+    fontSize: theme.typography.size.s2 - 1,
     "&:hover [data-badge], [data-badge=true]": {
       background: "#E3F3FF",
       borderColor: "rgba(2, 113, 182, 0.1)",
       color: "#0271B6",
     },
-  },
+  }),
   ({ active, theme }) =>
     !active &&
     css({

--- a/src/components/SidebarTopButton.tsx
+++ b/src/components/SidebarTopButton.tsx
@@ -143,7 +143,7 @@ export const SidebarTopButton = ({
       tooltip={
         <TooltipContent>
           <div>No code changes detected. Rerun tests to take new snapshots.</div>
-          <IconButton secondary onClick={() => startBuild()} aria-label="Rerun tests">
+          <IconButton onClick={() => startBuild()} aria-label="Rerun tests">
             <SyncIcon />
             Rerun tests
           </IconButton>

--- a/src/screens/GitNotFound/GitNotFound.stories.tsx
+++ b/src/screens/GitNotFound/GitNotFound.stories.tsx
@@ -1,18 +1,10 @@
 // @ts-nocheck TODO: Address SB 8 type errors
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
 
-import { AuthProvider } from "../../AuthContext";
-import { GraphQLClientProvider } from "../../utils/graphQLClient";
-import { storyWrapper } from "../../utils/storyWrapper";
 import { GitNotFound } from "./GitNotFound";
 
 const meta = {
   component: GitNotFound,
-  decorators: [
-    storyWrapper(GraphQLClientProvider),
-    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
-  ],
   args: {
     gitInfoError: new Error("Git info not found"),
   },

--- a/src/screens/GitNotFound/GitNotFound.stories.tsx
+++ b/src/screens/GitNotFound/GitNotFound.stories.tsx
@@ -1,13 +1,18 @@
 // @ts-nocheck TODO: Address SB 8 type errors
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 
+import { AuthProvider } from "../../AuthContext";
 import { GraphQLClientProvider } from "../../utils/graphQLClient";
 import { storyWrapper } from "../../utils/storyWrapper";
 import { GitNotFound } from "./GitNotFound";
 
 const meta = {
   component: GitNotFound,
-  decorators: [storyWrapper(GraphQLClientProvider)],
+  decorators: [
+    storyWrapper(GraphQLClientProvider),
+    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
+  ],
   args: {
     gitInfoError: new Error("Git info not found"),
   },

--- a/src/screens/GitNotFound/GitNotFound.tsx
+++ b/src/screens/GitNotFound/GitNotFound.tsx
@@ -4,17 +4,16 @@ import React from "react";
 
 import { Container } from "../../components/Container";
 import { Icon, Link } from "../../components/design-system";
-import { FooterSection } from "../../components/FooterSection";
 import { Heading } from "../../components/Heading";
 import { VisualTestsIcon } from "../../components/icons/VisualTestsIcon";
-import { Section, Sections } from "../../components/layout";
+import { Section } from "../../components/layout";
+import { Screen } from "../../components/Screen";
 import { Stack } from "../../components/Stack";
 import { Text } from "../../components/Text";
 import { useUninstallAddon } from "../Uninstalled/UninstallContext";
 
 interface GitNotFoundProps {
   gitInfoError: Error;
-  setAccessToken: (accessToken: string | null) => void;
 }
 
 const InfoSection = styled(Section)(({ theme }) => ({
@@ -43,10 +42,10 @@ const StyledCode = styled(Code)(({ theme }) => ({
   fontSize: "12px",
 }));
 
-export const GitNotFound = ({ gitInfoError, setAccessToken }: GitNotFoundProps) => {
+export const GitNotFound = ({ gitInfoError }: GitNotFoundProps) => {
   const { uninstallAddon } = useUninstallAddon();
   return (
-    <Sections>
+    <Screen>
       <Section grow>
         <Container>
           <Stack>
@@ -82,7 +81,6 @@ export const GitNotFound = ({ gitInfoError, setAccessToken }: GitNotFoundProps) 
           </Stack>
         </Container>
       </Section>
-      <FooterSection setAccessToken={setAccessToken} />
-    </Sections>
+    </Screen>
   );
 };

--- a/src/screens/LinkProject/LinkProject.stories.ts
+++ b/src/screens/LinkProject/LinkProject.stories.ts
@@ -1,25 +1,17 @@
 // @ts-nocheck TODO: Address SB 8 type errors
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
 import { findByTestId } from "@storybook/testing-library";
 import { delay, graphql, HttpResponse } from "msw";
 
-import { AuthProvider } from "../../AuthContext";
 import { SelectProjectsQueryQuery } from "../../gql/graphql";
 import { panelModes } from "../../modes";
-import { GraphQLClientProvider } from "../../utils/graphQLClient";
 import { playAll } from "../../utils/playAll";
-import { storyWrapper } from "../../utils/storyWrapper";
 import { withFigmaDesign } from "../../utils/withFigmaDesign";
 import { LinkProject } from "./LinkProject";
 
 const meta = {
   component: LinkProject,
-  decorators: [
-    storyWrapper(GraphQLClientProvider),
-    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
-  ],
   args: {
     createdProjectId: undefined,
     onUpdateProject: action("updateProject"),

--- a/src/screens/LinkProject/LinkProject.stories.ts
+++ b/src/screens/LinkProject/LinkProject.stories.ts
@@ -1,9 +1,11 @@
 // @ts-nocheck TODO: Address SB 8 type errors
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 import { findByTestId } from "@storybook/testing-library";
 import { delay, graphql, HttpResponse } from "msw";
 
+import { AuthProvider } from "../../AuthContext";
 import { SelectProjectsQueryQuery } from "../../gql/graphql";
 import { panelModes } from "../../modes";
 import { GraphQLClientProvider } from "../../utils/graphQLClient";
@@ -14,7 +16,10 @@ import { LinkProject } from "./LinkProject";
 
 const meta = {
   component: LinkProject,
-  decorators: [storyWrapper(GraphQLClientProvider)],
+  decorators: [
+    storyWrapper(GraphQLClientProvider),
+    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
+  ],
   args: {
     createdProjectId: undefined,
     onUpdateProject: action("updateProject"),

--- a/src/screens/LinkProject/LinkProject.tsx
+++ b/src/screens/LinkProject/LinkProject.tsx
@@ -6,9 +6,9 @@ import { useQuery } from "urql";
 
 import { Container } from "../../components/Container";
 import { Avatar, ListItem } from "../../components/design-system";
-import { FooterSection } from "../../components/FooterSection";
 import { Heading } from "../../components/Heading";
-import { Section, Sections, Text } from "../../components/layout";
+import { Section, Text } from "../../components/layout";
+import { Screen } from "../../components/Screen";
 import { Stack } from "../../components/Stack";
 import { graphql } from "../../gql";
 import type { Account, Project, SelectProjectsQueryQuery } from "../../gql/graphql";
@@ -40,12 +40,10 @@ export const LinkProject = ({
   createdProjectId,
   setCreatedProjectId,
   onUpdateProject,
-  setAccessToken,
 }: {
   createdProjectId: Project["id"] | undefined;
   setCreatedProjectId: (projectId: Project["id"]) => void;
   onUpdateProject: (projectId: string) => void;
-  setAccessToken: (accessToken: string | null) => void;
 }) => {
   const onSelectProjectId = React.useCallback(
     async (selectedProjectId: string) => {
@@ -59,7 +57,6 @@ export const LinkProject = ({
       createdProjectId={createdProjectId}
       setCreatedProjectId={setCreatedProjectId}
       onSelectProjectId={onSelectProjectId}
-      setAccessToken={setAccessToken}
     />
   );
 };
@@ -113,12 +110,10 @@ function SelectProject({
   createdProjectId,
   setCreatedProjectId,
   onSelectProjectId,
-  setAccessToken,
 }: {
   createdProjectId: Project["id"] | undefined;
   setCreatedProjectId: (projectId: Project["id"]) => void;
   onSelectProjectId: (projectId: string) => Promise<void>;
-  setAccessToken: (accessToken: string | null) => void;
 }) {
   const [{ data, fetching, error }, rerunProjectsQuery] = useQuery<SelectProjectsQueryQuery>({
     query: SelectProjectsQuery,
@@ -192,7 +187,7 @@ function SelectProject({
   }, [createdProject, handleSelectProject, closeDialog]);
 
   return (
-    <Sections>
+    <Screen>
       <Section grow>
         <Container>
           <Stack>
@@ -265,7 +260,6 @@ function SelectProject({
           </Stack>
         </Container>
       </Section>
-      <FooterSection setAccessToken={setAccessToken} />
-    </Sections>
+    </Screen>
   );
 }

--- a/src/screens/LinkProject/LinkedProject.stories.ts
+++ b/src/screens/LinkProject/LinkedProject.stories.ts
@@ -1,7 +1,9 @@
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 import { graphql, HttpResponse } from "msw";
 
+import { AuthProvider } from "../../AuthContext";
 import { ProjectQueryQuery } from "../../gql/graphql";
 import { panelModes } from "../../modes";
 import { GraphQLClientProvider } from "../../utils/graphQLClient";
@@ -21,9 +23,11 @@ const meta = {
     projectId: "Project:abc123",
     configFile: "chromatic.config.json",
     goToNext: action("goToNext"),
-    setAccessToken: action("setAccessToken"),
   },
-  decorators: [storyWrapper(GraphQLClientProvider)],
+  decorators: [
+    storyWrapper(GraphQLClientProvider),
+    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
+  ],
   parameters: {
     chromatic: {
       modes: panelModes,

--- a/src/screens/LinkProject/LinkedProject.stories.ts
+++ b/src/screens/LinkProject/LinkedProject.stories.ts
@@ -1,13 +1,9 @@
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
 import { graphql, HttpResponse } from "msw";
 
-import { AuthProvider } from "../../AuthContext";
 import { ProjectQueryQuery } from "../../gql/graphql";
 import { panelModes } from "../../modes";
-import { GraphQLClientProvider } from "../../utils/graphQLClient";
-import { storyWrapper } from "../../utils/storyWrapper";
 import { withFigmaDesign } from "../../utils/withFigmaDesign";
 import { LinkedProject } from "./LinkedProject";
 
@@ -24,10 +20,6 @@ const meta = {
     configFile: "chromatic.config.json",
     goToNext: action("goToNext"),
   },
-  decorators: [
-    storyWrapper(GraphQLClientProvider),
-    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
-  ],
   parameters: {
     chromatic: {
       modes: panelModes,

--- a/src/screens/LinkProject/LinkedProject.tsx
+++ b/src/screens/LinkProject/LinkedProject.tsx
@@ -6,9 +6,9 @@ import { useQuery } from "urql";
 
 import { Button } from "../../components/Button";
 import { Container } from "../../components/Container";
-import { FooterSection } from "../../components/FooterSection";
 import { Heading } from "../../components/Heading";
-import { Col, Section, Sections, Text } from "../../components/layout";
+import { Col, Section, Text } from "../../components/layout";
+import { Screen } from "../../components/Screen";
 import { Stack } from "../../components/Stack";
 import { graphql } from "../../gql";
 import { ProjectQueryQuery } from "../../gql/graphql";
@@ -40,12 +40,10 @@ export const LinkedProject = ({
   projectId,
   configFile,
   goToNext,
-  setAccessToken,
 }: {
   projectId: string;
   configFile: string;
   goToNext: () => void;
-  setAccessToken: (accessToken: string | null) => void;
 }) => {
   const [{ data, fetching, error }] = useQuery<ProjectQueryQuery>({
     query: ProjectQuery,
@@ -53,7 +51,21 @@ export const LinkedProject = ({
   });
 
   return (
-    <Sections>
+    <Screen
+      footer={({ menu }) => (
+        <>
+          <Col>
+            {data?.project?.lastBuild && (
+              <Text style={{ marginLeft: 5 }}>
+                Last build: {data.project.lastBuild.number} on branch{" "}
+                {data.project.lastBuild.branch}
+              </Text>
+            )}
+          </Col>
+          <Col push>{menu}</Col>
+        </>
+      )}
+    >
       <Section grow>
         <Container>
           <Stack>
@@ -82,22 +94,6 @@ export const LinkedProject = ({
           </Stack>
         </Container>
       </Section>
-      <FooterSection
-        setAccessToken={setAccessToken}
-        render={({ menu }) => (
-          <>
-            <Col>
-              {data?.project?.lastBuild && (
-                <Text style={{ marginLeft: 5 }}>
-                  Last build: {data.project.lastBuild.number} on branch{" "}
-                  {data.project.lastBuild.branch}
-                </Text>
-              )}
-            </Col>
-            <Col push>{menu}</Col>
-          </>
-        )}
-      />
-    </Sections>
+    </Screen>
   );
 };

--- a/src/screens/LinkProject/LinkingProjectFailed.stories.ts
+++ b/src/screens/LinkProject/LinkingProjectFailed.stories.ts
@@ -1,10 +1,7 @@
 // @ts-nocheck TODO: Address SB 8 type errors
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
 
-import { AuthProvider } from "../../AuthContext";
 import { panelModes } from "../../modes";
-import { storyWrapper } from "../../utils/storyWrapper";
 import { LinkingProjectFailed } from "./LinkingProjectFailed";
 
 const meta = {
@@ -13,9 +10,6 @@ const meta = {
     projectId: "Project:abc123",
     configFile: "chromatic.config.json",
   },
-  decorators: [
-    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
-  ],
   parameters: {
     chromatic: {
       modes: panelModes,

--- a/src/screens/LinkProject/LinkingProjectFailed.stories.ts
+++ b/src/screens/LinkProject/LinkingProjectFailed.stories.ts
@@ -1,7 +1,10 @@
 // @ts-nocheck TODO: Address SB 8 type errors
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 
+import { AuthProvider } from "../../AuthContext";
 import { panelModes } from "../../modes";
+import { storyWrapper } from "../../utils/storyWrapper";
 import { LinkingProjectFailed } from "./LinkingProjectFailed";
 
 const meta = {
@@ -10,6 +13,9 @@ const meta = {
     projectId: "Project:abc123",
     configFile: "chromatic.config.json",
   },
+  decorators: [
+    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
+  ],
   parameters: {
     chromatic: {
       modes: panelModes,

--- a/src/screens/LinkProject/LinkingProjectFailed.tsx
+++ b/src/screens/LinkProject/LinkingProjectFailed.tsx
@@ -3,26 +3,21 @@ import React from "react";
 import { dedent } from "ts-dedent";
 
 import { Container } from "../../components/Container";
-import { FooterSection } from "../../components/FooterSection";
 import { Heading } from "../../components/Heading";
-import { Section, Sections } from "../../components/layout";
+import { Section } from "../../components/layout";
+import { Screen } from "../../components/Screen";
 import { Text as CenterText } from "../../components/Text";
 
 type LinkingProjectFailedProps = {
   projectId: string;
   configFile: string;
-  setAccessToken: (accessToken: string | null) => void;
 };
 
 const configureDocsLink = "https://www.chromatic.com/docs/addon-visual-tests#configure";
 
-export function LinkingProjectFailed({
-  projectId,
-  configFile,
-  setAccessToken,
-}: LinkingProjectFailedProps) {
+export function LinkingProjectFailed({ projectId, configFile }: LinkingProjectFailedProps) {
   return (
-    <Sections>
+    <Screen>
       <Section grow>
         <Container>
           <CenterText>
@@ -46,7 +41,6 @@ export function LinkingProjectFailed({
           </CenterText>
         </Container>
       </Section>
-      <FooterSection setAccessToken={setAccessToken} />
-    </Sections>
+    </Screen>
   );
 }

--- a/src/screens/VisualTests/BuildResults.tsx
+++ b/src/screens/VisualTests/BuildResults.tsx
@@ -7,9 +7,9 @@ import { BuildProgressInline } from "../../components/BuildProgressBarInline";
 import { Button } from "../../components/Button";
 import { Container } from "../../components/Container";
 import { Eyebrow } from "../../components/Eyebrow";
-import { FooterSection } from "../../components/FooterSection";
 import { Heading } from "../../components/Heading";
 import { Section, Sections } from "../../components/layout";
+import { Screen } from "../../components/Screen";
 import { Text as CenterText } from "../../components/Text";
 import { BuildStatus, TestResult } from "../../gql/graphql";
 import { LocalBuildProgress } from "../../types";
@@ -29,7 +29,6 @@ interface BuildResultsProps {
   switchToLastBuildOnBranch?: () => void;
   storyId: string;
   startDevBuild: () => void;
-  setAccessToken: (accessToken: string | null) => void;
 }
 
 export const Warning = styled.div(({ theme }) => ({
@@ -48,7 +47,6 @@ export const BuildResults = ({
   switchToLastBuildOnBranch,
   startDevBuild,
   storyId,
-  setAccessToken,
 }: BuildResultsProps) => {
   const { settingsVisible, warningsVisible } = useControlsState();
   const { toggleSettings, toggleWarnings } = useControlsDispatch();
@@ -103,7 +101,7 @@ export const BuildResults = ({
 
   if (isNewStory) {
     return (
-      <Sections>
+      <Screen>
         <Section grow>
           <Container>
             <Heading>New story found</Heading>
@@ -130,15 +128,14 @@ export const BuildResults = ({
             )}
           </Container>
         </Section>
-        <FooterSection setAccessToken={setAccessToken} />
-      </Sections>
+      </Screen>
     );
   }
   // It shouldn't be possible for one test to be skipped but not all of them
   const isSkipped = !!selectedStory?.tests?.find((t) => t.result === TestResult.Skipped);
   if (isSkipped) {
     return (
-      <Sections>
+      <Screen>
         {buildStatus}
         <Section grow>
           <Container>
@@ -161,8 +158,7 @@ export const BuildResults = ({
             </Button>
           </Container>
         </Section>
-        <FooterSection setAccessToken={setAccessToken} />
-      </Sections>
+      </Screen>
     );
   }
 
@@ -209,7 +205,6 @@ export const BuildResults = ({
             shouldSwitchToLastBuildOnBranch,
             switchToLastBuildOnBranch,
             selectedBuild,
-            setAccessToken,
             storyId,
           }}
         />

--- a/src/screens/VisualTests/Configuration.tsx
+++ b/src/screens/VisualTests/Configuration.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+import {
+  Accordion,
+  Accordions,
+  CloseButton,
+  CloseIcon,
+  ContrastIcon,
+  Heading,
+  InfoIcon,
+  ParagraphIcon,
+  StopIcon,
+  TimerIcon,
+} from "../../components/Accordions";
+
+interface ConfigurationProps {
+  onClose: () => void;
+}
+
+export const Configuration = ({ onClose }: ConfigurationProps) => {
+  return (
+    <Accordions>
+      <Accordion>
+        <Heading>
+          Configuration
+          <InfoIcon />
+          <CloseButton onClick={onClose}>
+            <CloseIcon aria-label="Close" />
+          </CloseButton>
+        </Heading>
+        <p>
+          <TimerIcon />
+          Delay: 300ms
+        </p>
+        <p>
+          <StopIcon />
+          Animation pause: Ends
+        </p>
+        <p>
+          <ContrastIcon />
+          Threshold: 0.2
+        </p>
+        <p>
+          <ParagraphIcon />
+          Anti-alias: Included
+        </p>
+      </Accordion>
+    </Accordions>
+  );
+};

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -4,12 +4,13 @@ import { styled } from "@storybook/theming";
 import React from "react";
 import { CombinedError } from "urql";
 
+import { useAuthState } from "../../AuthContext";
 import { BuildProgressInline } from "../../components/BuildProgressBarInline";
 import { Button } from "../../components/Button";
 import { Container } from "../../components/Container";
-import { FooterSection } from "../../components/FooterSection";
 import { Heading } from "../../components/Heading";
-import { Bar, Col, Row, Section, Sections, Text } from "../../components/layout";
+import { Col, Section, Text } from "../../components/layout";
+import { Screen } from "../../components/Screen";
 import { Text as CenterText } from "../../components/Text";
 import { LocalBuildProgress } from "../../types";
 
@@ -34,7 +35,6 @@ interface NoBuildProps {
   startDevBuild: () => void;
   localBuildProgress?: LocalBuildProgress;
   branch: string;
-  setAccessToken: (accessToken: string | null) => void;
 }
 
 export const NoBuild = ({
@@ -45,8 +45,8 @@ export const NoBuild = ({
   startDevBuild,
   localBuildProgress,
   branch,
-  setAccessToken,
 }: NoBuildProps) => {
+  const { setAccessToken } = useAuthState();
   const getDetails = () => {
     const button = (
       <Button size="medium" variant="solid" onClick={startDevBuild}>
@@ -153,21 +153,19 @@ export const NoBuild = ({
   };
 
   return (
-    <Sections>
+    <Screen
+      footer={({ menu }) => (
+        <>
+          <Col>
+            {hasData && !queryError && hasProject && (
+              <Text style={{ marginLeft: 5 }}>Waiting for build on {branch}</Text>
+            )}
+          </Col>
+          <Col push>{menu}</Col>
+        </>
+      )}
+    >
       <Section grow>{getContent()}</Section>
-      <FooterSection
-        setAccessToken={setAccessToken}
-        render={({ menu }) => (
-          <>
-            <Col>
-              {hasData && !queryError && hasProject && (
-                <Text style={{ marginLeft: 5 }}>Waiting for build on {branch}</Text>
-              )}
-            </Col>
-            <Col push>{menu}</Col>
-          </>
-        )}
-      />
-    </Sections>
+    </Screen>
   );
 };

--- a/src/screens/VisualTests/SnapshotComparison.stories.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.stories.tsx
@@ -1,13 +1,11 @@
 // @ts-nocheck TODO: Address SB 8 type errors
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
 import { findByRole, fireEvent, screen, userEvent, within } from "@storybook/testing-library";
 import type { StoryContext } from "@storybook/types";
 import { delay, http } from "msw";
 import React, { ComponentProps } from "react";
 
-import { AuthProvider } from "../../AuthContext";
 import { Browser, ComparisonResult, TestResult, TestStatus } from "../../gql/graphql";
 import { panelModes } from "../../modes";
 import { playAll } from "../../utils/playAll";
@@ -24,7 +22,6 @@ const build = { ...pendingBuild, startedAt: new Date() };
 const meta = {
   component: SnapshotComparison,
   decorators: [
-    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
     storyWrapper(ReviewTestProvider, (ctx) => ({
       watchState: {
         isReviewing: false,

--- a/src/screens/VisualTests/SnapshotComparison.stories.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.stories.tsx
@@ -1,18 +1,14 @@
 // @ts-nocheck TODO: Address SB 8 type errors
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 import { findByRole, fireEvent, screen, userEvent, within } from "@storybook/testing-library";
 import type { StoryContext } from "@storybook/types";
 import { delay, http } from "msw";
 import React, { ComponentProps } from "react";
 
-import {
-  Browser,
-  ComparisonResult,
-  SelectedBuildFieldsFragment,
-  TestResult,
-  TestStatus,
-} from "../../gql/graphql";
+import { AuthProvider } from "../../AuthContext";
+import { Browser, ComparisonResult, TestResult, TestStatus } from "../../gql/graphql";
 import { panelModes } from "../../modes";
 import { playAll } from "../../utils/playAll";
 import { makeComparison, makeTest, makeTests } from "../../utils/storyData";
@@ -28,6 +24,7 @@ const build = { ...pendingBuild, startedAt: new Date() };
 const meta = {
   component: SnapshotComparison,
   decorators: [
+    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
     storyWrapper(ReviewTestProvider, (ctx) => ({
       watchState: {
         isReviewing: false,

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -2,6 +2,7 @@ import { Loader } from "@storybook/components";
 import { styled } from "@storybook/theming";
 import React, { useEffect } from "react";
 
+import { useAuthState } from "../../AuthContext";
 import { Link } from "../../components/design-system";
 import { Text } from "../../components/layout";
 import { SnapshotImage } from "../../components/SnapshotImage";
@@ -121,7 +122,6 @@ interface SnapshotComparisonProps {
   isBuildFailed: boolean;
   shouldSwitchToLastBuildOnBranch: boolean;
   switchToLastBuildOnBranch?: () => void;
-  setAccessToken: (accessToken: string | null) => void;
   hidden?: boolean;
   storyId: string;
 }
@@ -133,10 +133,10 @@ export const SnapshotComparison = ({
   isBuildFailed,
   shouldSwitchToLastBuildOnBranch,
   switchToLastBuildOnBranch,
-  setAccessToken,
   hidden,
   storyId,
 }: SnapshotComparisonProps) => {
+  const { setAccessToken } = useAuthState();
   const { baselineImageVisible, diffVisible, focusVisible } = useControlsState();
   const { toggleBaselineImage, toggleSettings, toggleWarnings } = useControlsDispatch();
 

--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -124,8 +124,6 @@ const meta = {
   component: VisualTestsWithoutSelectedBuildId,
   decorators: [
     storyWrapper(ControlsProvider),
-    storyWrapper(GraphQLClientProvider),
-    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
     (Story) => {
       // TODO: Need to replace this mocking when completing AP-3586 - mock the graphql query instead
       // localStorage.setItem(WALKTHROUGH_COMPLETED_KEY, "true");

--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -16,6 +16,7 @@ import {
 import { delay, HttpResponse } from "msw";
 import React from "react";
 
+import { AuthProvider } from "../../AuthContext";
 import { INITIAL_BUILD_PAYLOAD } from "../../buildSteps";
 // TODO: Remove after completing AP-3586
 // import { WALKTHROUGH_COMPLETED_KEY } from "../../constants";
@@ -124,6 +125,7 @@ const meta = {
   decorators: [
     storyWrapper(ControlsProvider),
     storyWrapper(GraphQLClientProvider),
+    storyWrapper(AuthProvider, () => ({ value: { accessToken: "token", setAccessToken: fn() } })),
     (Story) => {
       // TODO: Need to replace this mocking when completing AP-3586 - mock the graphql query instead
       // localStorage.setItem(WALKTHROUGH_COMPLETED_KEY, "true");
@@ -160,7 +162,6 @@ const meta = {
     storyId: "button--primary",
     projectId: "Project:id123",
     startDevBuild: fn(),
-    setAccessToken: fn(),
     setOutdated: fn(),
     updateBuildStatus: fn(),
     addNotification: fn(),

--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -16,7 +16,6 @@ import {
 import { delay, HttpResponse } from "msw";
 import React from "react";
 
-import { AuthProvider } from "../../AuthContext";
 import { INITIAL_BUILD_PAYLOAD } from "../../buildSteps";
 // TODO: Remove after completing AP-3586
 // import { WALKTHROUGH_COMPLETED_KEY } from "../../constants";
@@ -31,7 +30,6 @@ import {
   withGraphQLMutationParameters,
   withGraphQLQueryParameters,
 } from "../../utils/gqlStoryHelpers";
-import { GraphQLClientProvider } from "../../utils/graphQLClient";
 import { playAll } from "../../utils/playAll";
 import { makeComparison, makeTest, makeTests } from "../../utils/storyData";
 import { storyWrapper } from "../../utils/storyWrapper";

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -36,7 +36,6 @@ interface VisualTestsProps {
   dismissBuildError: () => void;
   localBuildProgress?: LocalBuildProgress;
   startDevBuild: () => void;
-  setAccessToken: (accessToken: string | null) => void;
   setOutdated: (isOutdated: boolean) => void;
   updateBuildStatus: UpdateStatusFunction;
   projectId: string;
@@ -162,7 +161,6 @@ export const VisualTestsWithoutSelectedBuildId = ({
   dismissBuildError,
   localBuildProgress,
   startDevBuild,
-  setAccessToken,
   setOutdated,
   updateBuildStatus,
   projectId,
@@ -277,7 +275,6 @@ export const VisualTestsWithoutSelectedBuildId = ({
               {...{
                 gitInfo,
                 projectId,
-                setAccessToken,
                 startDevBuild,
                 updateBuildStatus,
                 localBuildProgress,
@@ -308,7 +305,6 @@ export const VisualTestsWithoutSelectedBuildId = ({
             localBuildProgress,
             ...(lastBuildOnBranchIsSelectable && { switchToLastBuildOnBranch }),
             startDevBuild,
-            setAccessToken,
           }}
         />
       ) : (
@@ -324,7 +320,6 @@ export const VisualTestsWithoutSelectedBuildId = ({
                 ...(lastBuildOnBranchIsSelectable && { switchToLastBuildOnBranch }),
                 startDevBuild,
                 userCanReview,
-                setAccessToken,
                 storyId,
               }}
             />


### PR DESCRIPTION
Introduces a Screen component that wraps every screen so that we don't need to repeat the footer in every place, among other things. I also fixed some UI bugs that came with Storybook 8's updated component library.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.5--canary.184.5d57486.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.1.5--canary.184.5d57486.0
  # or 
  yarn add @chromatic-com/storybook@1.1.5--canary.184.5d57486.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
