### PR TITLE
Only throw errors for Git messages after a Project ID has been set

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -83,12 +83,6 @@ export const Panel = ({ active, api }: PanelProps) => {
     return withProviders(<Uninstalled />);
   }
 
-  if (gitInfoError) {
-    // eslint-disable-next-line no-console
-    console.error(gitInfoError);
-    return withProviders(<GitNotFound gitInfoError={gitInfoError} />);
-  }
-
   // Render the Authentication flow if the user is not signed in.
   if (!accessToken) {
     return withProviders(
@@ -102,7 +96,7 @@ export const Panel = ({ active, api }: PanelProps) => {
   }
 
   // Momentarily wait on addonState (should be very fast)
-  if (projectInfoLoading || !gitInfo) {
+  if (projectInfoLoading) {
     return active ? <Spinner /> : null;
   }
 
@@ -114,6 +108,12 @@ export const Panel = ({ active, api }: PanelProps) => {
         onUpdateProject={updateProject}
       />
     );
+
+  if (gitInfoError || !gitInfo) {
+    // eslint-disable-next-line no-console
+    console.error(gitInfoError);
+    return withProviders(<GitNotFound />);
+  }
 
   if (projectUpdatingFailed) {
     // These should always be set when we get this error

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ function managerEntries(entry: string[] = []) {
 const observeGitInfo = async (
   interval: number,
   callback: (info: GitInfo, prevInfo?: GitInfo) => void,
-  errorCallback: (e: Error) => void
+  errorCallback: (e: Error) => void,
+  projectId?: string
 ) => {
   let prev: GitInfo | undefined;
   let prevError: Error | undefined;
@@ -47,12 +48,12 @@ const observeGitInfo = async (
       prevError = undefined;
       timer = setTimeout(act, interval);
     } catch (e: any) {
-      if (prevError?.message !== e.message) {
+      errorCallback(e);
+      if (projectId && prevError?.message !== e.message) {
         console.error(`Failed to fetch git info, with error:\n${e}`);
-        errorCallback(e);
+        prev = undefined;
+        prevError = e;
       }
-      prev = undefined;
-      prevError = e;
       timer = setTimeout(act, interval);
     }
   };

--- a/src/screens/GitNotFound/GitNotFound.tsx
+++ b/src/screens/GitNotFound/GitNotFound.tsx
@@ -12,10 +12,6 @@ import { Stack } from "../../components/Stack";
 import { Text } from "../../components/Text";
 import { useUninstallAddon } from "../Uninstalled/UninstallContext";
 
-interface GitNotFoundProps {
-  gitInfoError: Error;
-}
-
 const InfoSection = styled(Section)(({ theme }) => ({
   display: "flex",
   flexDirection: "row",
@@ -42,7 +38,7 @@ const StyledCode = styled(Code)(({ theme }) => ({
   fontSize: "12px",
 }));
 
-export const GitNotFound = ({ gitInfoError }: GitNotFoundProps) => {
+export const GitNotFound = () => {
   const { uninstallAddon } = useUninstallAddon();
   return (
     <Screen footer={null}>


### PR DESCRIPTION
The Git Errors are currently shown to the user before they have had a chance to configure a project ID for running builds. This ens

To QA:

1. Install this canary.
2. Ensure the git message does not show before a project ID is configured.
3. Ensure the git message shows after the project ID is configured.
4. Ensure it goes away after initializing git and making a few commits!

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.7--canary.186.1f27e41.0  </code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.1.7--canary.186.1f27e41.0
  # or 
  yarn add @chromatic-com/storybook@1.1.7--canary.186.1f27e41.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
