### PR TITLE
Minor copy changes and visual tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@typescript-eslint/parser": "^5.59.11",
     "@urql/exchange-auth": "^2.1.6",
     "@vitejs/plugin-react": "^3.1.0",
-    "auto": "^10.3.0",
+    "auto": "^11.0.5",
     "boxen": "^5.0.1",
     "date-fns": "^2.30.0",
     "dedent": "^0.7.0",

--- a/src/components/SidebarTopButton.stories.tsx
+++ b/src/components/SidebarTopButton.stories.tsx
@@ -24,7 +24,6 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     const button = await canvas.findByRole("button", { name: "Run tests" });
     await userEvent.click(button);
-    await screen.findAllByRole("button", { name: "Rerun tests" });
   }),
 };
 

--- a/src/components/SidebarTopButton.tsx
+++ b/src/components/SidebarTopButton.tsx
@@ -142,15 +142,7 @@ export const SidebarTopButton = ({
     <WithTooltip
       trigger="click"
       closeOnOutsideClick
-      tooltip={
-        <TooltipContent>
-          <div>No code changes detected. Rerun tests to take new snapshots.</div>
-          <IconButton onClick={() => startBuild()} aria-label="Rerun tests">
-            <SyncIcon />
-            Rerun tests
-          </IconButton>
-        </TooltipContent>
-      }
+      tooltip={<TooltipNote note="No code changes detected. Rerun tests to take new snapshots." />}
     >
       <SidebarIconButton id="button-run-tests" aria-label="Run tests">
         <PlayIcon />

--- a/src/components/SidebarTopButton.tsx
+++ b/src/components/SidebarTopButton.tsx
@@ -140,11 +140,11 @@ export const SidebarTopButton = ({
     </WithTooltip>
   ) : (
     <WithTooltip
-      trigger="click"
-      closeOnOutsideClick
+      trigger="hover"
+      hasChrome={false}
       tooltip={<TooltipNote note="No code changes detected. Rerun tests to take new snapshots." />}
     >
-      <SidebarIconButton id="button-run-tests" aria-label="Run tests">
+      <SidebarIconButton id="button-run-tests" aria-label="Run tests" onClick={() => startBuild()}>
         <PlayIcon />
       </SidebarIconButton>
     </WithTooltip>

--- a/src/screens/GitNotFound/GitNotFound.tsx
+++ b/src/screens/GitNotFound/GitNotFound.tsx
@@ -55,7 +55,7 @@ export const GitNotFound = () => {
             <Icon icon="lock" />
             <InfoSectionText>
               <InfoSectionTextTitle>Git not detected</InfoSectionTextTitle>
-              This addon requires Git to associate test results with commits and branches.
+              This addon requires Git to associate test results with commits and branches. Run{" "}
               <Code>git init</Code> and make your first commit
               <Code>git commit -m</Code> to get started!
             </InfoSectionText>

--- a/src/screens/LinkProject/LinkProject.tsx
+++ b/src/screens/LinkProject/LinkProject.tsx
@@ -259,7 +259,7 @@ function SelectProject({
                             openDialog(selectedAccount.newProjectUrl);
                           }}
                         >
-                          Create project
+                          Create new project
                         </Link>
                       }
                     />

--- a/src/screens/LinkProject/LinkedProject.tsx
+++ b/src/screens/LinkProject/LinkedProject.tsx
@@ -85,8 +85,9 @@ export const LinkedProject = ({
               <div>
                 <Heading>Project linked!</Heading>
                 <Text style={{ maxWidth: 500 }}>
-                  <Code>projectId</Code> for {data.project.name} was added in {configFile} to sync
-                  tests with Chromatic. Please commit this change to continue using this addon.
+                  The <Code>projectId</Code> for {data.project.name} was added in{" "}
+                  <Code>{configFile}</Code> to sync tests with Chromatic. Please commit this change
+                  to continue using this addon.
                 </Text>
               </div>
               <ButtonStack>

--- a/src/screens/Uninstalled/Uninstalled.tsx
+++ b/src/screens/Uninstalled/Uninstalled.tsx
@@ -14,8 +14,8 @@ export const Uninstalled = () => {
         <Stack>
           <div>
             <VisualTestsIcon />
-            <Heading>Visual tests</Heading>
-            <Text>Visual tests has been uninstalled. Please restart your Storybook.</Text>
+            <Heading>Uninstall complete</Heading>
+            <Text>Visual Tests will vanish the next time you restart your Storybook.</Text>
           </div>
         </Stack>
       </Container>

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -152,7 +152,6 @@ export const NoBuild = ({
               <CenterText>You may not have access to this project or it may not exist.</CenterText>
             </div>
 
-            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
             <ButtonStackLink isButton onClick={() => setAccessToken(null)} withArrow>
               Switch account
             </ButtonStackLink>

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -98,7 +98,6 @@ export const NoBuild = ({
               <CenterText>{queryError.networkError.message}</CenterText>
             </div>
 
-            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
             <Button size="medium" variant="solid" onClick={() => setAccessToken(null)}>
               Log out
             </Button>
@@ -120,7 +119,6 @@ export const NoBuild = ({
               </CenterText>
             </div>
             <ButtonStack>
-              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
               <Button size="medium" variant="solid" onClick={() => setAccessToken(null)}>
                 Log out
               </Button>

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -99,9 +99,9 @@ export const NoBuild = ({
             </div>
 
             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-            <Link isButton onClick={() => setAccessToken(null)} withArrow>
+            <Button size="medium" variant="solid" onClick={() => setAccessToken(null)}>
               Log out
-            </Link>
+            </Button>
           </Stack>
         </Container>
       );
@@ -121,9 +121,9 @@ export const NoBuild = ({
             </div>
             <ButtonStack>
               {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-              <Link isButton onClick={() => setAccessToken(null)} withArrow>
+              <Button size="medium" variant="solid" onClick={() => setAccessToken(null)}>
                 Log out
-              </Link>
+              </Button>
               <Link
                 withArrow
                 href="https://www.chromatic.com/docs/visual-tests-addon#troubleshooting"

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -34,6 +34,10 @@ const ErrorContainer = styled.pre(({ theme }) => ({
   textAlign: "left",
 }));
 
+const ButtonStackLink = styled(Link)(() => ({
+  marginTop: 5,
+}));
+
 interface NoBuildProps {
   queryError?: CombinedError;
   hasData: boolean;
@@ -122,13 +126,13 @@ export const NoBuild = ({
               <Button size="medium" variant="solid" onClick={() => setAccessToken(null)}>
                 Log out
               </Button>
-              <Link
+              <ButtonStackLink
                 withArrow
                 href="https://www.chromatic.com/docs/visual-tests-addon#troubleshooting"
                 target="_blank"
               >
                 Troubleshoot
-              </Link>
+              </ButtonStackLink>
             </ButtonStack>
           </Stack>
         </Container>
@@ -149,9 +153,9 @@ export const NoBuild = ({
             </div>
 
             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-            <Link isButton onClick={() => setAccessToken(null)} withArrow>
+            <ButtonStackLink isButton onClick={() => setAccessToken(null)} withArrow>
               Switch account
-            </Link>
+            </ButtonStackLink>
           </Stack>
         </Container>
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,17 +55,17 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@auto-it/bot-list@10.46.0":
-  version "10.46.0"
-  resolved "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-10.46.0.tgz"
-  integrity sha512-QkkBgQVi1g/1Tpxcs3Hm3zTzaaM0xjiIRt5xEA6TRM/ULdgEqY+Jk/w1fJZe9GVF+53mwRfqGtQeJirilMBH6g==
+"@auto-it/bot-list@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-11.1.0.tgz#ecb35bc2c4b283e3243f4eecd9a45ec0fbf28f72"
+  integrity sha512-NXUnaBVYk4ykg/haqOWVVjkCq8Ru1yXsKsgxx6nEa7vz0JUjWDWJgmvHh2MDNsScF35evhmQ/E96NwyU/sKh8g==
 
-"@auto-it/core@10.46.0":
-  version "10.46.0"
-  resolved "https://registry.npmjs.org/@auto-it/core/-/core-10.46.0.tgz"
-  integrity sha512-68jWcUuQBFCjgUvEWa64ENeRPULFYiaFpo37H6SUuLcZ2XBD+Bt4Y0yqHWjs6F5g19S7pzOYe25SxWf+U0J4LQ==
+"@auto-it/core@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-11.1.0.tgz#73ba2e8f3a698103639423fb463f2f9417e9b6e0"
+  integrity sha512-mHcRAn5makaT8eO53HuvuNFwFhLA7bwYiNgocwhhcNwCM2/JCvA7wsApsWVMYpui+lkaR5SyI7bcOAMbPgYuWA==
   dependencies:
-    "@auto-it/bot-list" "10.46.0"
+    "@auto-it/bot-list" "11.1.0"
     "@endemolshinegroup/cosmiconfig-typescript-loader" "^3.0.2"
     "@octokit/core" "^3.5.1"
     "@octokit/plugin-enterprise-compatibility" "1.3.0"
@@ -106,13 +106,13 @@
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
-"@auto-it/npm@10.46.0":
-  version "10.46.0"
-  resolved "https://registry.npmjs.org/@auto-it/npm/-/npm-10.46.0.tgz"
-  integrity sha512-hvwXxRJE70ay4/CMEDtILZvefXqmo+jp/w8FEu4Bo1Kq96AREfH9cO+mgj1nPon5yg353SCcupGV3OyoZt18iw==
+"@auto-it/npm@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-11.1.0.tgz#3a8fb83a6548f5fbb165a45fc868a3ae2efd8810"
+  integrity sha512-VJIQNp2qokED7ptLCYTtLMcVsM/V9scvzEU5WBOlEH7CW5mXerj0BIoU4uO2rHQTMXtK5n6Mv8kFCduwwqWRqQ==
   dependencies:
-    "@auto-it/core" "10.46.0"
-    "@auto-it/package-json-utils" "10.46.0"
+    "@auto-it/core" "11.1.0"
+    "@auto-it/package-json-utils" "11.1.0"
     await-to-js "^3.0.0"
     endent "^2.1.0"
     env-ci "^5.0.1"
@@ -126,32 +126,32 @@
     url-join "^4.0.0"
     user-home "^2.0.0"
 
-"@auto-it/package-json-utils@10.46.0":
-  version "10.46.0"
-  resolved "https://registry.npmjs.org/@auto-it/package-json-utils/-/package-json-utils-10.46.0.tgz"
-  integrity sha512-dl0VW3oJ/JfyuXlVucLlsBaQH69GTkTXLSq9JZ723hT55/owcywDpSlD4YH158hm7Lv5CdHw2u3z60XUlqa6xQ==
+"@auto-it/package-json-utils@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/package-json-utils/-/package-json-utils-11.1.0.tgz#dafc3dd0b7c786c5f98ceeb667e118c3798b3351"
+  integrity sha512-OS9iZAKNchcEAjH/hjFL2eXe2M6YFYWnbHamJB9XhXyFAH+QewCcAKpD7pmSDp0av8B3m98ZlAdElKTyra7PIA==
   dependencies:
     parse-author "^2.0.0"
     parse-github-url "1.0.2"
 
-"@auto-it/released@10.46.0":
-  version "10.46.0"
-  resolved "https://registry.npmjs.org/@auto-it/released/-/released-10.46.0.tgz"
-  integrity sha512-U0XYvkcPoO4c4WiJz6PQ8jUOMEH1EjxXRGyvaaZWfZOtr2vquvGDIAs6ntekURcNs75H780K49es18mTLgz9/g==
+"@auto-it/released@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-11.1.0.tgz#a8b552cb8d45cba324ac85f5c6c9c76979e60864"
+  integrity sha512-Uxt4LNQSORI3dMiUhyyq8BLnX5Ho/GjVhYFfZLRG9VXbUEMD2eTDqK9HOO7IdJenPEgpJEbLUgAI25rLj3y1Yw==
   dependencies:
-    "@auto-it/bot-list" "10.46.0"
-    "@auto-it/core" "10.46.0"
+    "@auto-it/bot-list" "11.1.0"
+    "@auto-it/core" "11.1.0"
     deepmerge "^4.0.0"
     fp-ts "^2.5.3"
     io-ts "^2.1.2"
     tslib "2.1.0"
 
-"@auto-it/version-file@10.46.0":
-  version "10.46.0"
-  resolved "https://registry.npmjs.org/@auto-it/version-file/-/version-file-10.46.0.tgz"
-  integrity sha512-V5HEQyGHPCFzH8Fj7RlBebgZ83P0QYXpNTtzPF6az4NLoNvaeZmqkirhx7WEasggVvyfX56GlM6df5jwXXfi7g==
+"@auto-it/version-file@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/version-file/-/version-file-11.1.0.tgz#3f3f6f1fb833c733cc75d09f59893443aadecbca"
+  integrity sha512-F78y+pNAImkQGWmR+WA9d1MMQU5QPal1AD4Hzvf21rwVmkmxxCklVAqZjq5aVa3687I2zLLKX8hebEBfROuZHQ==
   dependencies:
-    "@auto-it/core" "10.46.0"
+    "@auto-it/core" "11.1.0"
     fp-ts "^2.5.3"
     io-ts "^2.1.2"
     semver "^7.0.0"
@@ -4581,15 +4581,15 @@ auto-bind@~4.0.0:
   resolved "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz"
   integrity sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==
 
-auto@^10.3.0:
-  version "10.46.0"
-  resolved "https://registry.npmjs.org/auto/-/auto-10.46.0.tgz"
-  integrity sha512-LUsn5SWyM6Qdz2i1h4YyDpBYlOUQ0Z+ZcQhDTu8DLLoUuUP4cGf79MCdpRpM1LQVbkqZ2WWi8s/QM4it/FmRjw==
+auto@^11.0.5:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/auto/-/auto-11.1.0.tgz#6fd51635764ab8f5b42685c1329ae0f48f96064f"
+  integrity sha512-UgqhuO6RCC1AMpeFEBh8psgOu0v71b08hjF/V+w252rHgxdW0tDrkLah99OC+NMElCb341MxD1+CITXmair8uA==
   dependencies:
-    "@auto-it/core" "10.46.0"
-    "@auto-it/npm" "10.46.0"
-    "@auto-it/released" "10.46.0"
-    "@auto-it/version-file" "10.46.0"
+    "@auto-it/core" "11.1.0"
+    "@auto-it/npm" "11.1.0"
+    "@auto-it/released" "11.1.0"
+    "@auto-it/version-file" "11.1.0"
     await-to-js "^3.0.0"
     chalk "^4.0.0"
     command-line-application "^0.10.1"


### PR DESCRIPTION
Just a handful of minor changes:
* Removed warning that prevented users from rerunning builds in the sidebar and replaced it with hover text.
* Minor copy changes
* Switched from Links to buttons on a couple edge case states
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.11--canary.188.41c932d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.1.11--canary.188.41c932d.0
  # or 
  yarn add @chromatic-com/storybook@1.1.11--canary.188.41c932d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
