### PR TITLE
Align changed story count in notification and sidebar

### DIFF
--- a/src/SidebarTop.tsx
+++ b/src/SidebarTop.tsx
@@ -1,4 +1,4 @@
-import { type API, useChannel } from "@storybook/manager-api";
+import { type API, useChannel, useStorybookState } from "@storybook/manager-api";
 import { color } from "@storybook/theming";
 import pluralize from "pluralize";
 import React, { useEffect, useRef } from "react";
@@ -37,6 +37,11 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
   const [gitInfoError] = useSharedState<Error>(GIT_INFO_ERROR);
 
   const lastStep = useRef(localBuildProgress?.currentStep);
+  const { status } = useStorybookState();
+  const changedStoryCount = Object.values(status).filter(
+    (value) => value[ADDON_ID]?.status === "warn"
+  );
+
   useEffect(() => {
     if (localBuildProgress?.currentStep === lastStep.current) return;
     lastStep.current = localBuildProgress?.currentStep;
@@ -83,8 +88,11 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
           // eslint-disable-next-line no-nested-ternary
           subHeadline: localBuildProgress.errorCount
             ? `Encountered ${pluralize("component error", localBuildProgress.errorCount, true)}`
-            : localBuildProgress.changeCount
-            ? `Found ${pluralize("change", localBuildProgress.changeCount, true)}`
+            : changedStoryCount.length
+            ? `Found ${pluralize("story", changedStoryCount.length, true)} with ${pluralize(
+                "change",
+                changedStoryCount.length
+              )}`
             : "No visual changes detected",
         },
         icon: {
@@ -118,6 +126,7 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
     localBuildProgress?.currentStep,
     localBuildProgress?.errorCount,
     localBuildProgress?.changeCount,
+    changedStoryCount.length,
   ]);
 
   const emit = useChannel({});


### PR DESCRIPTION
There was a discrepancy in the change count used in the notification and the sidebar. The Sidebar showed the number of stories with changes. The notification showed the number of changes across all modes and browsers. So, this PR adjusts the count shown in the notification to align with the sidebar.

To QA
1. Run a build with multiple changes.
2. Verify that the count in sidebar and notification align.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.11--canary.189.4207700.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.1.11--canary.189.4207700.0
  # or 
  yarn add @chromatic-com/storybook@1.1.11--canary.189.4207700.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
