### PR TITLE
Prevent flashing wrong screen by increasing timeout

### DIFF
--- a/src/screens/Onboarding/Onboarding.stories.tsx
+++ b/src/screens/Onboarding/Onboarding.stories.tsx
@@ -251,7 +251,7 @@ export const RanFirstTestNoChanges = {
   parameters: {
     chromatic: {
       // Delay to wait for git hash to reset.
-      delay: 1001,
+      delay: 10001,
     },
   },
   render: (args) => {

--- a/src/screens/Onboarding/Onboarding.tsx
+++ b/src/screens/Onboarding/Onboarding.tsx
@@ -335,10 +335,11 @@ export const Onboarding = ({
               onClick={() => {
                 setRunningSecondBuild(true);
                 startDevBuild();
-                // In case the build does not have changes, reset gitHash to the current value to show Make A Change again. Timeout 1s to prevent Make a Change reappearing briefly before build starts.
+                // In case the build does not have changes, reset gitHash to the current value to show Make A Change again.
+                // A timeout is used to prevent "Make a Change" from reappearing briefly before the build starts.
                 setTimeout(() => {
                   setInitialGitHash(gitInfo.uncommittedHash);
-                }, 1000);
+                }, 10000);
               }}
             >
               <PlayIcon />


### PR DESCRIPTION
We already had a timeout in place to prevent flashing the wrong screen, but it wasn't long enough. Extending it to 10 seconds ensures we only reset the `uncommittedHash` while the new build is underway, thereby preventing the wrong screen from appearing. Arguably this is not the most reliable solution but a proper fix would be way more involved and this is likely good enough.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.4--canary.195.ca78be3.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.2.4--canary.195.ca78be3.0
  # or 
  yarn add @chromatic-com/storybook@1.2.4--canary.195.ca78be3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
