### PR TITLE
Ensure onboarding is triggered when query param is set

### DIFF
--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -114,10 +114,13 @@ const useOnboarding = (
 
   const [hasCompletedWalkthrough, setHasCompletedWalkthrough] = React.useState(true);
   React.useEffect(() => {
+    // Force the onboarding to show by adding ?vtaOnboarding=true to the URL
+    if (managerApi?.getUrlState?.().queryParams.vtaOnboarding === "true") {
+      setHasCompletedWalkthrough(false);
+      return;
+    }
     setHasCompletedWalkthrough(
-      // Force the onboarding to show by adding ?vtaOnboarding=true to the URL
-      managerApi?.getUrlState?.().queryParams.vtaOnboarding === "true" ||
-        vtaOnboarding === VtaOnboardingPreference.Completed ||
+      vtaOnboarding === VtaOnboardingPreference.Completed ||
         vtaOnboarding === VtaOnboardingPreference.Dismissed
     );
   }, [managerApi, vtaOnboarding]);


### PR DESCRIPTION
This ensures that onboarding  is triggered when the query param is set.
To QA
1. Install the Canary
2. Add the vtaOnboarding=true query param.
3. Run through the Onboarding,.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.7--canary.198.b38a526.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.2.7--canary.198.b38a526.0
  # or 
  yarn add @chromatic-com/storybook@1.2.7--canary.198.b38a526.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
