### PR TITLE
Implement snapshot zooming and panning

### DIFF
--- a/src/components/SnapshotImage.stories.tsx
+++ b/src/components/SnapshotImage.stories.tsx
@@ -11,8 +11,8 @@ const meta = {
   args: {
     componentName: "Shapes",
     storyName: "Primary",
-    baselineImage: { imageUrl: "/A.png", imageWidth: 880 },
-    latestImage: { imageUrl: "/B.png", imageWidth: 880 },
+    baselineImage: { imageUrl: "/A.png", imageWidth: 880, imageHeight: 280 },
+    latestImage: { imageUrl: "/B.png", imageWidth: 880, imageHeight: 280 },
     diffImage: { imageUrl: "/B-comparison.png", imageWidth: 880 },
     focusImage: { imageUrl: "/B-focus.png", imageWidth: 880 },
     comparisonResult: ComparisonResult.Changed,
@@ -51,7 +51,8 @@ export const BothVisible = {
 
 export const Wider = {
   args: {
-    latestImage: { imageUrl: "/shapes-wider.png", imageWidth: 768 },
+    baselineImage: { imageUrl: "/shapes-taller.png", imageWidth: 588, imageHeight: 684 },
+    latestImage: { imageUrl: "/shapes-wider.png", imageWidth: 768, imageHeight: 472 },
     diffImage: { imageUrl: "/shapes-comparison.png", imageWidth: 768 },
     focusImage: { imageUrl: "/shapes-focus.png", imageWidth: 768 },
     diffVisible: true,
@@ -68,7 +69,8 @@ export const WiderConstrained = {
 
 export const Taller = {
   args: {
-    latestImage: { imageUrl: "/shapes-taller.png", imageWidth: 588 },
+    baselineImage: { imageUrl: "/shapes-wider.png", imageWidth: 768, imageHeight: 472 },
+    latestImage: { imageUrl: "/shapes-taller.png", imageWidth: 588, imageHeight: 684 },
     diffImage: { imageUrl: "/shapes-comparison.png", imageWidth: 768 },
     focusImage: { imageUrl: "/shapes-focus.png", imageWidth: 768 },
     diffVisible: true,
@@ -83,8 +85,22 @@ export const TallerConstrained = {
   },
 } satisfies Story;
 
+export const NoBaseline = {
+  args: {
+    baselineImage: undefined,
+  },
+} satisfies Story;
+
+export const NoLatest = {
+  args: {
+    latestImage: undefined,
+    baselineImageVisible: true,
+  },
+} satisfies Story;
+
 export const CaptureError = {
   args: {
+    baselineImage: undefined,
     latestImage: undefined,
     comparisonResult: ComparisonResult.CaptureError,
   },

--- a/src/components/SnapshotImage.tsx
+++ b/src/components/SnapshotImage.tsx
@@ -6,63 +6,49 @@ import { CaptureImage, CaptureOverlayImage, ComparisonResult, Test } from "../gq
 import { Stack } from "./Stack";
 import { Text } from "./Text";
 
-export const Container = styled.div<{ href?: string; target?: string }>(
-  ({ theme }) => ({
-    position: "relative",
-    display: "flex",
-    background: "transparent",
-    overflow: "hidden",
-    margin: 2,
+export const Container = styled.div(({ theme }) => ({
+  position: "relative",
+  display: "flex",
+  width: "max-content",
+  background: "transparent",
+  overflow: "hidden",
+  margin: 2,
 
-    img: {
-      maxWidth: "100%",
-      transition: "filter 0.1s ease-in-out",
+  img: {
+    maxWidth: "100%",
+    transition: "filter 0.1s ease-in-out",
+  },
+  "img[data-overlay]": {
+    position: "absolute",
+    opacity: 0.7,
+    pointerEvents: "none",
+  },
+  div: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    width: "100%",
+    p: {
+      maxWidth: 380,
+      textAlign: "center",
     },
-    "img[data-overlay]": {
-      position: "absolute",
-      opacity: 0.7,
-      pointerEvents: "none",
+    svg: {
+      width: 24,
+      height: 24,
     },
-    div: {
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "center",
-      width: "100%",
-      p: {
-        maxWidth: 380,
-        textAlign: "center",
-      },
-      svg: {
-        width: 24,
-        height: 24,
-      },
-    },
-    "& > svg": {
-      position: "absolute",
-      left: "calc(50% - 14px)",
-      top: "calc(50% - 14px)",
-      width: 20,
-      height: 20,
-      color: theme.color.lightest,
-      opacity: 0,
-      transition: "opacity 0.1s ease-in-out",
-      pointerEvents: "none",
-    },
-  }),
-  ({ href }) =>
-    href && {
-      display: "inline-flex",
-      cursor: "pointer",
-      "&:hover": {
-        "& > svg": {
-          opacity: 1,
-        },
-        img: {
-          filter: "brightness(85%)",
-        },
-      },
-    }
-);
+  },
+  "& > svg": {
+    position: "absolute",
+    left: "calc(50% - 14px)",
+    top: "calc(50% - 14px)",
+    width: 20,
+    height: 20,
+    color: theme.color.lightest,
+    opacity: 0,
+    transition: "opacity 0.1s ease-in-out",
+    pointerEvents: "none",
+  },
+}));
 
 const StyledStack = styled(Stack)(({ theme }) => ({
   margin: "30px 15px",
@@ -71,7 +57,6 @@ const StyledStack = styled(Stack)(({ theme }) => ({
 interface SnapshotImageProps {
   componentName?: NonNullable<NonNullable<Test["story"]>["component"]>["name"];
   storyName?: NonNullable<Test["story"]>["name"];
-  testUrl: Test["webUrl"];
   comparisonResult?: ComparisonResult;
   latestImage?: Pick<CaptureImage, "imageUrl" | "imageWidth">;
   baselineImage?: Pick<CaptureImage, "imageUrl" | "imageWidth">;
@@ -85,7 +70,6 @@ interface SnapshotImageProps {
 export const SnapshotImage = ({
   componentName,
   storyName,
-  testUrl,
   comparisonResult,
   latestImage,
   baselineImage,
@@ -100,20 +84,16 @@ export const SnapshotImage = ({
   const hasDiff = !!latestImage && !!diffImage && comparisonResult === ComparisonResult.Changed;
   const hasError = comparisonResult === ComparisonResult.CaptureError;
   const hasFocus = hasDiff && !!focusImage;
-  const containerProps = hasDiff
-    ? { as: "a" as any, href: testUrl, target: "_blank", title: "View on Chromatic.com" }
-    : {};
   const showDiff = hasDiff && diffVisible;
   const showFocus = hasFocus && focusVisible;
 
   return (
-    <Container {...props} {...containerProps}>
+    <Container {...props}>
       {latestImage && (
         <img
           alt={`Latest snapshot for the '${storyName}' story of the '${componentName}' component`}
           src={latestImage.imageUrl}
           style={{
-            opacity: showDiff && !showFocus ? 0.7 : 1,
             display: baselineImageVisible ? "none" : "block",
           }}
         />
@@ -123,8 +103,10 @@ export const SnapshotImage = ({
           alt={`Baseline snapshot for the '${storyName}' story of the '${componentName}' component`}
           src={baselineImage.imageUrl}
           style={{
-            opacity: showDiff && !showFocus ? 0.7 : 1,
             display: baselineImageVisible ? "block" : "none",
+            maxWidth: latestImage
+              ? `${(baselineImage.imageWidth / latestImage.imageWidth) * 100}%`
+              : "100%",
           }}
         />
       )}
@@ -135,7 +117,7 @@ export const SnapshotImage = ({
           src={diffImage.imageUrl}
           style={{
             maxWidth: `${(diffImage.imageWidth / latestImage.imageWidth) * 100}%`,
-            opacity: showDiff ? 1 : 0,
+            opacity: showDiff ? 0.7 : 0,
           }}
         />
       )}
@@ -146,12 +128,11 @@ export const SnapshotImage = ({
           src={focusImage.imageUrl}
           style={{
             maxWidth: `${(focusImage.imageWidth / latestImage.imageWidth) * 100}%`,
-            opacity: showFocus ? 1 : 0,
+            opacity: showFocus ? 0.7 : 0,
             filter: showFocus ? "blur(2px)" : "none",
           }}
         />
       )}
-      {hasDiff && <ShareAltIcon />}
       {hasError && !latestImage && (
         <StyledStack>
           <PhotoIcon color={theme.base === "light" ? "currentColor" : theme.color.medium} />

--- a/src/components/ZoomContainer.stories.tsx
+++ b/src/components/ZoomContainer.stories.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { ZoomContainer } from "./ZoomContainer";
+
+export default {
+  component: ZoomContainer,
+};
+
+export const Default = {
+  args: {
+    children: (
+      <>
+        <img src="/A.png" alt="" />
+        <br />
+        <img src="/A.png" alt="" />
+      </>
+    ),
+  },
+};
+
+export const Wide = {
+  args: {
+    children: (
+      <>
+        <img src="/A.png" alt="" />
+        <img src="/A.png" alt="" />
+      </>
+    ),
+  },
+};
+
+export const Tall = {
+  args: {
+    children: (
+      <>
+        <img src="/A.png" alt="" />
+        <br />
+        <img src="/A.png" alt="" />
+        <br />
+        <img src="/A.png" alt="" />
+        <br />
+        <img src="/A.png" alt="" />
+      </>
+    ),
+  },
+};

--- a/src/components/ZoomContainer.tsx
+++ b/src/components/ZoomContainer.tsx
@@ -1,0 +1,186 @@
+import { styled } from "@storybook/theming";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const TRANSITION_DURATION_MS = 200;
+
+const Container = styled.div({
+  margin: "auto",
+  width: "max-content",
+  maxWidth: "100%",
+  maxHeight: "100%",
+  overflow: "hidden",
+  img: {
+    verticalAlign: "top",
+  },
+});
+
+const Content = styled.div({
+  width: "max-content",
+});
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+export const useZoom = () => {
+  const [state, setState] = useState({
+    containerHeight: 0,
+    containerWidth: 0,
+    contentHeight: 0,
+    contentWidth: 0,
+    contentScale: 1,
+    translateX: 0,
+    translateY: 0,
+    multiplierX: 1,
+    multiplierY: 1,
+    zoomed: false,
+    transition: "none",
+    transitionTimeout: 0,
+  });
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const updateState = useCallback(() => {
+    const { current: container } = containerRef;
+    const { current: content } = contentRef;
+    if (!container || !content) return;
+
+    const contentWidth = content.offsetWidth;
+    const contentHeight = content.offsetHeight;
+    const containerWidth = Math.min(contentWidth, container.offsetWidth);
+    const containerHeight = Math.min(contentHeight, container.offsetHeight);
+
+    const contentScale = Math.min(
+      1,
+      contentWidth ? containerWidth / contentWidth : 1,
+      contentHeight ? containerHeight / contentHeight : 1
+    );
+    const translateX =
+      contentWidth > containerWidth
+        ? (contentWidth - containerWidth) / -2
+        : (containerWidth - contentWidth * contentScale) / -2;
+    const translateY =
+      contentHeight > containerHeight
+        ? (contentHeight - containerHeight) / -2
+        : (containerHeight - contentHeight * contentScale) / -2;
+
+    setState((currentState) => ({
+      ...currentState,
+      containerHeight,
+      containerWidth,
+      contentHeight,
+      contentWidth,
+      contentScale,
+      translateX,
+      translateY,
+    }));
+  }, [containerRef, contentRef]);
+
+  const onMouseEvent = useCallback(
+    (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      const { x, y } = containerRef.current.getBoundingClientRect();
+
+      setState((currentState) => {
+        const { containerHeight, containerWidth, contentHeight, contentWidth } = currentState;
+        const ratioX = contentWidth < containerWidth ? contentWidth / contentHeight + 1 : 1;
+        const ratioY = contentHeight < containerHeight ? contentHeight / contentWidth + 1 : 1;
+        const multiplierX = ((e.clientX - x) / containerWidth) * 2 * 1.2 * ratioX - 0.2 * ratioX;
+        const multiplierY = ((e.clientY - y) / containerHeight) * 2 * 1.2 * ratioY - 0.2 * ratioY;
+
+        const clicked = e.type === "click";
+        const zoomed = clicked ? !currentState.zoomed : currentState.zoomed;
+        const update = {
+          ...currentState,
+          multiplierX: zoomed ? multiplierX : 1,
+          multiplierY: zoomed ? multiplierY : 1,
+          zoomed,
+        };
+        if (!clicked) return update;
+
+        window.clearTimeout(currentState.transitionTimeout);
+        return {
+          ...update,
+          transition: `transform ${TRANSITION_DURATION_MS}ms`,
+          transitionTimeout: window.setTimeout(
+            () => setState((s) => ({ ...s, transition: "none", transitionTimeout: 0 })),
+            TRANSITION_DURATION_MS
+          ),
+        };
+      });
+    },
+    [containerRef]
+  );
+
+  const onToggleZoom = useCallback(
+    (e: React.MouseEvent) => onMouseEvent(e.nativeEvent),
+    [onMouseEvent]
+  );
+
+  useEffect(() => {
+    window.addEventListener("mousemove", onMouseEvent);
+    return () => window.removeEventListener("mousemove", onMouseEvent);
+  }, [onMouseEvent]);
+
+  const resizeObserver = useMemo(() => new ResizeObserver(() => updateState()), [updateState]);
+
+  useEffect(() => {
+    const { current: container } = containerRef;
+    const { current: content } = contentRef;
+    if (!container || !content) return () => {};
+
+    resizeObserver.observe(container);
+    resizeObserver.observe(content);
+
+    return () => {
+      resizeObserver.unobserve(container);
+      resizeObserver.unobserve(content);
+    };
+  }, [containerRef, contentRef, resizeObserver]);
+
+  const translateX = clamp(
+    state.multiplierX * state.translateX,
+    -(state.contentWidth - state.containerWidth),
+    0
+  );
+  const translateY = clamp(
+    state.multiplierY * state.translateY,
+    -(state.contentHeight - state.containerHeight),
+    0
+  );
+  const scale = state.zoomed ? 1 : state.contentScale;
+  const contentStyle = {
+    transform: `translate(${translateX}px, ${translateY}px) scale(${scale})`,
+    transition: state.transition,
+  };
+
+  return {
+    containerProps: {
+      ref: containerRef,
+    },
+    contentProps: {
+      ref: contentRef,
+      style: contentStyle,
+      onClick: onToggleZoom,
+    },
+    renderProps: {
+      isZoomed: state.zoomed,
+      toggleZoom: onToggleZoom,
+    },
+  };
+};
+
+export const ZoomContainer = ({
+  children,
+  render,
+}: {
+  children?: React.ReactNode;
+  render?: (props: ReturnType<typeof useZoom>["renderProps"]) => React.ReactChild;
+}) => {
+  const { containerProps, contentProps, renderProps } = useZoom();
+
+  return (
+    <Container {...containerProps}>
+      <Content {...contentProps}>{render ? render(renderProps) : children}</Content>
+    </Container>
+  );
+};

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -5,6 +5,7 @@ import React, { useEffect } from "react";
 import { Link } from "../../components/design-system";
 import { Text } from "../../components/layout";
 import { SnapshotImage } from "../../components/SnapshotImage";
+import { ZoomContainer } from "../../components/ZoomContainer";
 import { ComparisonResult, TestResult, TestStatus } from "../../gql/graphql";
 import { summarizeTests } from "../../utils/summarizeTests";
 import { useSelectedBuildState, useSelectedStoryState } from "./BuildContext";
@@ -286,19 +287,23 @@ export const SnapshotComparison = ({
           </Warning>
         )}
         {!isInProgress && selectedComparison && (
-          <SnapshotImage
-            key={selectedComparison.id}
-            componentName={selectedTest.story?.component?.name}
-            storyName={selectedTest.story?.name}
-            testUrl={selectedTest.webUrl}
-            comparisonResult={selectedComparison.result ?? undefined}
-            latestImage={selectedComparison.headCapture?.captureImage ?? undefined}
-            baselineImage={selectedComparison.baseCapture?.captureImage ?? undefined}
-            baselineImageVisible={baselineImageVisible}
-            diffImage={selectedComparison.captureDiff?.diffImage ?? undefined}
-            focusImage={selectedComparison.captureDiff?.focusImage ?? undefined}
-            diffVisible={diffVisible}
-            focusVisible={focusVisible}
+          <ZoomContainer
+            render={(zoomProps) => (
+              <SnapshotImage
+                key={selectedComparison.id}
+                componentName={selectedTest.story?.component?.name}
+                storyName={selectedTest.story?.name}
+                comparisonResult={selectedComparison.result ?? undefined}
+                latestImage={selectedComparison.headCapture?.captureImage ?? undefined}
+                baselineImage={selectedComparison.baseCapture?.captureImage ?? undefined}
+                baselineImageVisible={baselineImageVisible}
+                diffImage={selectedComparison.captureDiff?.diffImage ?? undefined}
+                focusImage={selectedComparison.captureDiff?.focusImage ?? undefined}
+                diffVisible={diffVisible}
+                focusVisible={focusVisible}
+                {...zoomProps}
+              />
+            )}
           />
         )}
 

--- a/src/screens/VisualTests/SnapshotControls.tsx
+++ b/src/screens/VisualTests/SnapshotControls.tsx
@@ -103,6 +103,7 @@ export const SnapshotControls = ({ isOutdated }: { isOutdated: boolean }) => {
         <Placeholder />
         <Placeholder />
         <Placeholder />
+        {/* <Placeholder /> */}
       </Controls>
     );
 


### PR DESCRIPTION
Allows zooming the snapshot image to 100% on click, and panning the zoomed image by moving the mouse. Originally from #151, but without the diff slider and other tweaks.

https://github.com/chromaui/addon-visual-tests/assets/321738/1b1249d1-ba1a-4061-89ed-536e9509d428

(note this PR doesn't include the diff slider)