### PR TITLE
Fix inlineGlow animation

### DIFF
--- a/src/components/design-system/tooltip/ListItem.tsx
+++ b/src/components/design-system/tooltip/ListItem.tsx
@@ -2,6 +2,8 @@ import weakMemoize from "@emotion/weak-memoize";
 import { styled, type Theme, useTheme } from "@storybook/theming";
 import React, { ComponentProps, ReactNode } from "react";
 
+import { inlineGlow } from "../shared/animation";
+
 const Left = styled.span({});
 const Title = styled.span(({ theme }) => ({
   fontWeight: theme.typography.weight.bold,
@@ -116,10 +118,7 @@ const linkStyles = ({
 
   ...(isLoading && {
     ".sbds-list-item-title": {
-      animation: `${theme.animation.inlineGlow} 1.5s ease-in-out infinite`,
-      background: "rgba(0, 0, 0, 0.05)", // theme.color.tr5,
-      color: "transparent",
-      cursor: "progress",
+      ...inlineGlow,
       flex: "0 1 auto",
       display: "inline-block",
     },


### PR DESCRIPTION
This should fix this Emotion error which causes a `cursor:pointer` to be applied to Storybook's `html` element.

![image](https://github.com/chromaui/addon-visual-tests/assets/321738/d0ba90f4-ae0c-4e14-bf63-05b25fc0d8fb)
