### PR TITLE
Fix 'Rerun tests' button sizing

### DIFF
--- a/src/screens/VisualTests/StoryInfo.tsx
+++ b/src/screens/VisualTests/StoryInfo.tsx
@@ -4,7 +4,7 @@ import { styled } from "@storybook/theming";
 import pluralize from "pluralize";
 import React from "react";
 
-import { Button } from "../../components/Button";
+import { ActionButton } from "../../components/ActionButton";
 import { AlertIcon } from "../../components/icons/AlertIcon";
 import { ProgressIcon } from "../../components/icons/ProgressIcon";
 import { StatusIcon } from "../../components/icons/StatusIcon";
@@ -200,10 +200,10 @@ export const StoryInfo = ({
 
       {showButton && (
         <Actions>
-          <Button size="medium" variant="solid" onClick={startBuild} disabled={isRunning}>
+          <ActionButton onClick={startBuild} disabled={isRunning}>
             {isRunning ? <ProgressIcon parentComponent="Button" /> : <PlayIcon />}
             {isErrored ? "Rerun tests" : "Run tests"}
-          </Button>
+          </ActionButton>
         </Actions>
       )}
     </>


### PR DESCRIPTION
It was too large on the "wide" viewport mode.