### PR TITLE
Show shorter label on very small viewports

### DIFF
--- a/src/screens/VisualTests/SnapshotControls.tsx
+++ b/src/screens/VisualTests/SnapshotControls.tsx
@@ -116,7 +116,8 @@ export const SnapshotControls = ({ isOutdated }: { isOutdated: boolean }) => {
         <Label>
           <Text>
             <b>
-              {baselineImageVisible ? <span>Baseline snapshot</span> : <span>Latest snapshot</span>}
+              {baselineImageVisible ? "Baseline" : "Latest"}
+              <span> snapshot</span>
             </b>
           </Text>
         </Label>


### PR DESCRIPTION
Rather than no label at all.

https://github.com/chromaui/addon-visual-tests/assets/321738/9a5e951c-cd15-4e5b-a033-14b7be899025


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.14--canary.211.0a33c66.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.2.14--canary.211.0a33c66.0
  # or 
  yarn add @chromatic-com/storybook@1.2.14--canary.211.0a33c66.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
