### PR TITLE
Fix snapshot image opacity

### DIFF
--- a/src/components/SnapshotImage.tsx
+++ b/src/components/SnapshotImage.tsx
@@ -113,7 +113,6 @@ export const SnapshotImage = ({
           alt={`Latest snapshot for the '${storyName}' story of the '${componentName}' component`}
           src={latestImage.imageUrl}
           style={{
-            opacity: showDiff && !showFocus ? 0.7 : 1,
             display: baselineImageVisible ? "none" : "block",
           }}
         />
@@ -123,7 +122,6 @@ export const SnapshotImage = ({
           alt={`Baseline snapshot for the '${storyName}' story of the '${componentName}' component`}
           src={baselineImage.imageUrl}
           style={{
-            opacity: showDiff && !showFocus ? 0.7 : 1,
             display: baselineImageVisible ? "block" : "none",
           }}
         />
@@ -135,7 +133,7 @@ export const SnapshotImage = ({
           src={diffImage.imageUrl}
           style={{
             maxWidth: `${(diffImage.imageWidth / latestImage.imageWidth) * 100}%`,
-            opacity: showDiff ? 1 : 0,
+            opacity: showDiff ? 0.7 : 0,
           }}
         />
       )}
@@ -146,7 +144,7 @@ export const SnapshotImage = ({
           src={focusImage.imageUrl}
           style={{
             maxWidth: `${(focusImage.imageWidth / latestImage.imageWidth) * 100}%`,
-            opacity: showFocus ? 1 : 0,
+            opacity: showFocus ? 0.7 : 0,
             filter: showFocus ? "blur(2px)" : "none",
           }}
         />


### PR DESCRIPTION
Keeps the snapshots at 100% opacity, while the overlays get 70% opacity. This is the same as the webapp.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.14--canary.212.59af0ef.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.2.14--canary.212.59af0ef.0
  # or 
  yarn add @chromatic-com/storybook@1.2.14--canary.212.59af0ef.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
