### PR TITLE
Avoid passing invalid attributes to `img` element

### DIFF
--- a/src/components/SnapshotImageThumb.tsx
+++ b/src/components/SnapshotImageThumb.tsx
@@ -44,11 +44,10 @@ export const SnapshotImageThumb = ({
   backgroundColor,
   status,
   thumbnailUrl,
-  ...imgProps
 }: SnapshotImageThumbProps & React.ImgHTMLAttributes<HTMLImageElement>) => {
   return (
     <Wrapper status={status} style={backgroundColor ? { backgroundColor } : {}}>
-      <img alt="Snapshot thumbnail" src={thumbnailUrl} {...imgProps} />
+      <img alt="Snapshot thumbnail" src={thumbnailUrl} />
       {status === "positive" && <CheckIcon />}
     </Wrapper>
   );


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.14--canary.213.ae0cfa4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.2.14--canary.213.ae0cfa4.0
  # or 
  yarn add @chromatic-com/storybook@1.2.14--canary.213.ae0cfa4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
