### PR TITLE
Hide 'Skip' button on last step of onboarding

### DIFF
--- a/src/screens/GuidedTour/Tooltip.tsx
+++ b/src/screens/GuidedTour/Tooltip.tsx
@@ -1,5 +1,5 @@
-import { css, styled } from "@storybook/theming";
-import React, { MouseEventHandler, SyntheticEvent } from "react";
+import { styled } from "@storybook/theming";
+import React, { SyntheticEvent } from "react";
 import { TooltipRenderProps } from "react-joyride";
 
 import { Button } from "../../components/Button";
@@ -54,7 +54,7 @@ export type TooltipProps = TooltipRenderProps & {
   };
 };
 
-export const Tooltip = ({ step, primaryProps, tooltipProps }: TooltipProps) => {
+export const Tooltip = ({ isLastStep, step, primaryProps, tooltipProps }: TooltipProps) => {
   return (
     <TooltipBody {...tooltipProps}>
       <Wrapper>
@@ -63,7 +63,7 @@ export const Tooltip = ({ step, primaryProps, tooltipProps }: TooltipProps) => {
       </Wrapper>
       {(step.hideNextButton || step.hideBackButton) && (
         <TooltipFooter id="buttonNext">
-          {!step.hideSkipButton && (
+          {!step.hideSkipButton && !isLastStep && (
             <Button
               onClick={step.onSkipWalkthroughButtonClick}
               link


### PR DESCRIPTION
Avoid showing both "Skip" and "Done" button. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.17--canary.214.2b452b9.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.2.17--canary.214.2b452b9.0
  # or 
  yarn add @chromatic-com/storybook@1.2.17--canary.214.2b452b9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
