### PR TITLE
Require PR labels before merging

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,18 @@
+name: Check PR Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: chromaui/pr-label-checker-action@main
+        with:
+          one-of: |
+            major, minor, patch
+            release, skip-release
+          none-of: DO NOT MERGE


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.18--canary.215.02563b8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.2.18--canary.215.02563b8.0
  # or 
  yarn add @chromatic-com/storybook@1.2.18--canary.215.02563b8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
