### PR TITLE
Only use criteria to select mode when story first loads

### DIFF
--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -1,498 +1,500 @@
 /* eslint-disable */
-import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
+  [_ in K]?: never;
+};
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
   /** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
-  DateTime: { input: any; output: any; }
+  DateTime: { input: any; output: any };
   /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
-  JSONObject: { input: any; output: any; }
+  JSONObject: { input: any; output: any };
   /** A MongoDB ObjectId. */
-  ObjID: { input: any; output: any; }
+  ObjID: { input: any; output: any };
   /** A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt. */
-  URL: { input: any; output: any; }
+  URL: { input: any; output: any };
 };
 
 export enum AccessLevel {
-  Developer = 'DEVELOPER',
-  None = 'NONE',
-  Owner = 'OWNER',
-  Reviewer = 'REVIEWER',
-  Viewer = 'VIEWER'
+  Developer = "DEVELOPER",
+  None = "NONE",
+  Owner = "OWNER",
+  Reviewer = "REVIEWER",
+  Viewer = "VIEWER",
 }
 
-export type Account = Node & Temporal & {
-  __typename?: 'Account';
-  avatarUrl?: Maybe<Scalars['String']['output']>;
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  /** Is this a personal account? */
-  isPersonal: Scalars['Boolean']['output'];
-  /** Account name, typically the repository owner. */
-  name: Scalars['String']['output'];
-  newProjectUrl?: Maybe<Scalars['String']['output']>;
-  projects?: Maybe<Array<Maybe<Project>>>;
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-};
-
+export type Account = Node &
+  Temporal & {
+    __typename?: "Account";
+    avatarUrl?: Maybe<Scalars["String"]["output"]>;
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    /** Is this a personal account? */
+    isPersonal: Scalars["Boolean"]["output"];
+    /** Account name, typically the repository owner. */
+    name: Scalars["String"]["output"];
+    newProjectUrl?: Maybe<Scalars["String"]["output"]>;
+    projects?: Maybe<Array<Maybe<Project>>>;
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+  };
 
 export type AccountProjectsArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 /** A build that has been pre-announced but not published yet. */
-export type AnnouncedBuild = Build & Node & Temporal & {
-  __typename?: 'AnnouncedBuild';
-  /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
-  branch: Scalars['String']['output'];
-  /** Set of browsers against which the build was executed. */
-  browsers: Array<BrowserInfo>;
-  /** Git commit hash (unshortened). */
-  commit: Scalars['String']['output'];
-  /** Link to the commit details at the Git provider linked to the project. */
-  commitUrl?: Maybe<Scalars['String']['output']>;
-  /** When the commit was created in Git. */
-  committedAt: Scalars['DateTime']['output'];
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
-  isLimited: Scalars['Boolean']['output'];
-  /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
-  isSuperseded: Scalars['Boolean']['output'];
-  /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
-  number: Scalars['Int']['output'];
-  /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
-  slug?: Maybe<Scalars['String']['output']>;
-  /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
-  status: BuildStatus;
-  /** Hash of uncommitted changes, or empty string for no changes. */
-  uncommittedHash?: Maybe<Scalars['String']['output']>;
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-};
+export type AnnouncedBuild = Build &
+  Node &
+  Temporal & {
+    __typename?: "AnnouncedBuild";
+    /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
+    branch: Scalars["String"]["output"];
+    /** Set of browsers against which the build was executed. */
+    browsers: Array<BrowserInfo>;
+    /** Git commit hash (unshortened). */
+    commit: Scalars["String"]["output"];
+    /** Link to the commit details at the Git provider linked to the project. */
+    commitUrl?: Maybe<Scalars["String"]["output"]>;
+    /** When the commit was created in Git. */
+    committedAt: Scalars["DateTime"]["output"];
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
+    isLimited: Scalars["Boolean"]["output"];
+    /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
+    isSuperseded: Scalars["Boolean"]["output"];
+    /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
+    number: Scalars["Int"]["output"];
+    /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
+    slug?: Maybe<Scalars["String"]["output"]>;
+    /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
+    status: BuildStatus;
+    /** Hash of uncommitted changes, or empty string for no changes. */
+    uncommittedHash?: Maybe<Scalars["String"]["output"]>;
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+  };
 
 export enum Browser {
-  Chrome = 'CHROME',
-  Edge = 'EDGE',
-  Firefox = 'FIREFOX',
-  Safari = 'SAFARI'
+  Chrome = "CHROME",
+  Edge = "EDGE",
+  Firefox = "FIREFOX",
+  Safari = "SAFARI",
 }
 
 export type BrowserInfo = {
-  __typename?: 'BrowserInfo';
+  __typename?: "BrowserInfo";
   /** Identifier for this browser. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** Stable key for this browser. */
   key: Browser;
   /** Browser display name. */
-  name: Scalars['String']['output'];
+  name: Scalars["String"]["output"];
   /** Browser version. */
-  version: Scalars['String']['output'];
+  version: Scalars["String"]["output"];
 };
 
 export type Build = {
   /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
-  branch: Scalars['String']['output'];
+  branch: Scalars["String"]["output"];
   /** Set of browsers against which the build was executed. */
   browsers: Array<BrowserInfo>;
   /** Git commit hash (unshortened). */
-  commit: Scalars['String']['output'];
+  commit: Scalars["String"]["output"];
   /** Link to the commit details at the Git provider linked to the project. */
-  commitUrl?: Maybe<Scalars['String']['output']>;
+  commitUrl?: Maybe<Scalars["String"]["output"]>;
   /** When the commit was created in Git. */
-  committedAt: Scalars['DateTime']['output'];
+  committedAt: Scalars["DateTime"]["output"];
   /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars["DateTime"]["output"];
   /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
-  isLimited: Scalars['Boolean']['output'];
+  isLimited: Scalars["Boolean"]["output"];
   /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
-  isSuperseded: Scalars['Boolean']['output'];
+  isSuperseded: Scalars["Boolean"]["output"];
   /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
-  number: Scalars['Int']['output'];
+  number: Scalars["Int"]["output"];
   /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
-  slug?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars["String"]["output"]>;
   /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
   status: BuildStatus;
   /** Hash of uncommitted changes, or empty string for no changes. */
-  uncommittedHash?: Maybe<Scalars['String']['output']>;
+  uncommittedHash?: Maybe<Scalars["String"]["output"]>;
   /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
+  updatedAt: Scalars["DateTime"]["output"];
 };
 
 export enum BuildResult {
   /** At least one test on the build had a (user) error. */
-  CaptureError = 'CAPTURE_ERROR',
+  CaptureError = "CAPTURE_ERROR",
   /** The build successfully completed every test. */
-  Success = 'SUCCESS',
+  Success = "SUCCESS",
   /** At least one test on the build had a system error. */
-  SystemError = 'SYSTEM_ERROR',
+  SystemError = "SYSTEM_ERROR",
   /** The build did not complete in time. */
-  Timeout = 'TIMEOUT'
+  Timeout = "TIMEOUT",
 }
 
 export enum BuildStatus {
   /** All test changes were accepted. */
-  Accepted = 'ACCEPTED',
+  Accepted = "ACCEPTED",
   /** The build is announced but not yet published. */
-  Announced = 'ANNOUNCED',
+  Announced = "ANNOUNCED",
   /** There was a user (permanent) problem completing the build. */
-  Broken = 'BROKEN',
+  Broken = "BROKEN",
   /** The build was cancelled before it could complete. */
-  Cancelled = 'CANCELLED',
+  Cancelled = "CANCELLED",
   /** At least one test change was denied. */
-  Denied = 'DENIED',
+  Denied = "DENIED",
   /** There was a system (temporary) problem completing the build. */
-  Failed = 'FAILED',
+  Failed = "FAILED",
   /** The build is awaiting a result. */
-  InProgress = 'IN_PROGRESS',
+  InProgress = "IN_PROGRESS",
   /** All tests passed without changes. */
-  Passed = 'PASSED',
+  Passed = "PASSED",
   /** At least one test has unaccepted changes. */
-  Pending = 'PENDING',
+  Pending = "PENDING",
   /** The build is ready for testing but not yet started. */
-  Prepared = 'PREPARED',
+  Prepared = "PREPARED",
   /** The build is published but not yet ready for testing. */
-  Published = 'PUBLISHED'
+  Published = "PUBLISHED",
 }
 
 export type BuildSupersededError = UserError & {
-  __typename?: 'BuildSupersededError';
+  __typename?: "BuildSupersededError";
   build: Build;
-  message: Scalars['String']['output'];
+  message: Scalars["String"]["output"];
 };
 
 export type Capture = {
-  __typename?: 'Capture';
+  __typename?: "Capture";
   /** Metadata about the error if the capture failed. */
   captureError?: Maybe<CaptureError>;
   /** The screenshot capture image. Available if the capture was successful or was taken after an interaction error. */
   captureImage?: Maybe<CaptureImage>;
   /** The ID of the capture. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** Capture regions (bounding boxes) to ignore while diffing. */
   ignoredRegions?: Maybe<Array<CaptureRegion>>;
   /** The result of the capture. */
   result: CaptureResult;
 };
 
-
 export type CaptureCaptureImageArgs = {
-  signed?: InputMaybe<Scalars['Boolean']['input']>;
+  signed?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type CaptureDiff = {
-  __typename?: 'CaptureDiff';
+  __typename?: "CaptureDiff";
   /** The diff overlay image. Available if there are visual changes. */
   diffImage?: Maybe<CaptureOverlayImage>;
   /** The focus overlay image. Available if there are visual changes. */
   focusImage?: Maybe<CaptureOverlayImage>;
   /** The ID of the diff. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The result of comparing this capture against the baseline. */
   result: CaptureDiffResult;
 };
 
-
 export type CaptureDiffDiffImageArgs = {
-  signed?: InputMaybe<Scalars['Boolean']['input']>;
+  signed?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type CaptureDiffFocusImageArgs = {
-  signed?: InputMaybe<Scalars['Boolean']['input']>;
+  signed?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum CaptureDiffResult {
   /** The two captures were found to have differences. */
-  Changed = 'CHANGED',
+  Changed = "CHANGED",
   /** The two captures were found to be equal. */
-  Equal = 'EQUAL',
+  Equal = "EQUAL",
   /** The diff failed due to a system error. */
-  SystemError = 'SYSTEM_ERROR'
+  SystemError = "SYSTEM_ERROR",
 }
 
 export type CaptureError = {
   /** The ID of the capture error. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The kind of capture error. */
   kind: CaptureErrorKind;
 };
 
 export type CaptureErrorComponentOffPage = CaptureError & {
-  __typename?: 'CaptureErrorComponentOffPage';
+  __typename?: "CaptureErrorComponentOffPage";
   /** The ID of the capture error. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The kind of capture error. */
   kind: CaptureErrorKind;
 };
 
 export type CaptureErrorFailedJs = CaptureError & {
-  __typename?: 'CaptureErrorFailedJS';
+  __typename?: "CaptureErrorFailedJS";
   /** The original error that caused the capture to fail. Typically contains a name and message. */
-  error: Scalars['JSONObject']['output'];
+  error: Scalars["JSONObject"]["output"];
   /** The ID of the capture error. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The kind of capture error. */
   kind: CaptureErrorKind;
 };
 
 export type CaptureErrorImageTooLarge = CaptureError & {
-  __typename?: 'CaptureErrorImageTooLarge';
+  __typename?: "CaptureErrorImageTooLarge";
   /** The height of the image that was too large. */
-  height: Scalars['Int']['output'];
+  height: Scalars["Int"]["output"];
   /** The ID of the capture error. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The kind of capture error. */
   kind: CaptureErrorKind;
   /** The maximum number of pixels allowed for an image. */
-  maxImagePixels: Scalars['Int']['output'];
+  maxImagePixels: Scalars["Int"]["output"];
   /** The width of the image that was too large. */
-  width: Scalars['Int']['output'];
+  width: Scalars["Int"]["output"];
 };
 
 export type CaptureErrorInteractionFailure = CaptureError & {
-  __typename?: 'CaptureErrorInteractionFailure';
+  __typename?: "CaptureErrorInteractionFailure";
   /** The original error that caused the capture to fail. Typically contains a name and message. */
-  error: Scalars['JSONObject']['output'];
+  error: Scalars["JSONObject"]["output"];
   /** The ID of the capture error. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The kind of capture error. */
   kind: CaptureErrorKind;
 };
 
 export type CaptureErrorJsError = CaptureError & {
-  __typename?: 'CaptureErrorJSError';
+  __typename?: "CaptureErrorJSError";
   /** The original error that caused the capture to fail. Typically contains a name and message. */
-  error: Scalars['JSONObject']['output'];
+  error: Scalars["JSONObject"]["output"];
   /** The ID of the capture error. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The kind of capture error. */
   kind: CaptureErrorKind;
 };
 
 export enum CaptureErrorKind {
   /** The component was rendered off screen. */
-  ComponentOffPage = 'COMPONENT_OFF_PAGE',
+  ComponentOffPage = "COMPONENT_OFF_PAGE",
   /** A JavaScript error occurred during capture. */
-  FailedJs = 'FAILED_JS',
+  FailedJs = "FAILED_JS",
   /** The image was too large to capture. */
-  ImageTooLarge = 'IMAGE_TOO_LARGE',
+  ImageTooLarge = "IMAGE_TOO_LARGE",
   /** An interaction failed to complete, or encountered an assertion error. */
-  InteractionFailure = 'INTERACTION_FAILURE',
+  InteractionFailure = "INTERACTION_FAILURE",
   /** A JavaScript error occurred during capture. */
-  JsError = 'JS_ERROR',
+  JsError = "JS_ERROR",
   /** The page took too long to load. */
-  NavigationTimeout = 'NAVIGATION_TIMEOUT',
+  NavigationTimeout = "NAVIGATION_TIMEOUT",
   /** The page does not contain (valid) JavaScript. */
-  NoJs = 'NO_JS',
+  NoJs = "NO_JS",
   /** The story was not found. */
-  StoryMissing = 'STORY_MISSING'
+  StoryMissing = "STORY_MISSING",
 }
 
 export type CaptureErrorNavigationTimeout = CaptureError & {
-  __typename?: 'CaptureErrorNavigationTimeout';
+  __typename?: "CaptureErrorNavigationTimeout";
   /** The ID of the capture error. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The kind of capture error. */
   kind: CaptureErrorKind;
   /** The maximum number of milliseconds allowed for a page to load. */
-  navigationTimeoutMs: Scalars['Int']['output'];
+  navigationTimeoutMs: Scalars["Int"]["output"];
 };
 
 export type CaptureErrorNoJs = CaptureError & {
-  __typename?: 'CaptureErrorNoJS';
+  __typename?: "CaptureErrorNoJS";
   /** The ID of the capture error. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The kind of capture error. */
   kind: CaptureErrorKind;
 };
 
 export type CaptureErrorStoryMissing = CaptureError & {
-  __typename?: 'CaptureErrorStoryMissing';
+  __typename?: "CaptureErrorStoryMissing";
   /** The ID of the capture error. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The kind of capture error. */
   kind: CaptureErrorKind;
 };
 
 export type CaptureImage = Image & {
-  __typename?: 'CaptureImage';
+  __typename?: "CaptureImage";
   /** Computed CSS background color of the captured HTML body. */
-  backgroundColor?: Maybe<Scalars['String']['output']>;
+  backgroundColor?: Maybe<Scalars["String"]["output"]>;
   /** Pixel height of the image. */
-  imageHeight: Scalars['Int']['output'];
+  imageHeight: Scalars["Int"]["output"];
   /** URL of the image. */
-  imageUrl: Scalars['URL']['output'];
+  imageUrl: Scalars["URL"]["output"];
   /** Pixel width of the image. */
-  imageWidth: Scalars['Int']['output'];
+  imageWidth: Scalars["Int"]["output"];
   /** Computed CSS text direction of the captured root element. */
-  textDirection?: Maybe<Scalars['String']['output']>;
+  textDirection?: Maybe<Scalars["String"]["output"]>;
   /** URL of the thumbnail image. */
-  thumbnailUrl: Scalars['URL']['output'];
+  thumbnailUrl: Scalars["URL"]["output"];
 };
 
 export type CaptureOverlayImage = Image & {
-  __typename?: 'CaptureOverlayImage';
+  __typename?: "CaptureOverlayImage";
   /** Pixel height of the image. */
-  imageHeight: Scalars['Int']['output'];
+  imageHeight: Scalars["Int"]["output"];
   /** URL of the image. */
-  imageUrl: Scalars['URL']['output'];
+  imageUrl: Scalars["URL"]["output"];
   /** Pixel width of the image. */
-  imageWidth: Scalars['Int']['output'];
+  imageWidth: Scalars["Int"]["output"];
 };
 
 export type CaptureRegion = {
-  __typename?: 'CaptureRegion';
+  __typename?: "CaptureRegion";
   /** The height of the bounding box. */
-  height: Scalars['Int']['output'];
+  height: Scalars["Int"]["output"];
   /** The ID of the capture region. */
-  id: Scalars['String']['output'];
+  id: Scalars["String"]["output"];
   /** The left offset of the bounding box. */
-  left: Scalars['Int']['output'];
+  left: Scalars["Int"]["output"];
   /** The CSS selector used to find the element. */
-  selector?: Maybe<Scalars['String']['output']>;
+  selector?: Maybe<Scalars["String"]["output"]>;
   /** The top offset of the bounding box. */
-  top: Scalars['Int']['output'];
+  top: Scalars["Int"]["output"];
   /** The width of the bounding box. */
-  width: Scalars['Int']['output'];
+  width: Scalars["Int"]["output"];
 };
 
 export enum CaptureResult {
   /** The capture failed due to a problem with the story. */
-  CaptureError = 'CAPTURE_ERROR',
+  CaptureError = "CAPTURE_ERROR",
   /** The capture succeeded an took a screenshot. */
-  Success = 'SUCCESS',
+  Success = "SUCCESS",
   /** The capture failed due to a system error. */
-  SystemError = 'SYSTEM_ERROR'
+  SystemError = "SYSTEM_ERROR",
 }
 
 export enum ComparisonResult {
   /** The head capture succeeded but there is no base capture. */
-  Added = 'ADDED',
+  Added = "ADDED",
   /** The head capture failed because the story is broken. */
-  CaptureError = 'CAPTURE_ERROR',
+  CaptureError = "CAPTURE_ERROR",
   /** The head and base captures succeeded but are different. */
-  Changed = 'CHANGED',
+  Changed = "CHANGED",
   /** The head capture succeeded and was equal to the base capture. */
-  Equal = 'EQUAL',
+  Equal = "EQUAL",
   /** The base capture had an error but the head capture succeeded. */
-  Fixed = 'FIXED',
+  Fixed = "FIXED",
   /** There was a base capture, but no head capture. */
-  Removed = 'REMOVED',
+  Removed = "REMOVED",
   /** Either the head capture or the diff failed due to a system error. */
-  SystemError = 'SYSTEM_ERROR'
+  SystemError = "SYSTEM_ERROR",
 }
 
 /** A build that has completed testing. */
-export type CompletedBuild = Build & Node & Temporal & {
-  __typename?: 'CompletedBuild';
-  /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
-  branch: Scalars['String']['output'];
-  /** Set of browsers against which the build was executed. */
-  browsers: Array<BrowserInfo>;
-  /** Git commit hash (unshortened). */
-  commit: Scalars['String']['output'];
-  /** Link to the commit details at the Git provider linked to the project. */
-  commitUrl?: Maybe<Scalars['String']['output']>;
-  /** When the commit was created in Git. */
-  committedAt: Scalars['DateTime']['output'];
-  /** When the build was completed in Chromatic. */
-  completedAt: Scalars['DateTime']['output'];
-  /** The number of components in the published Storybook, excluding docsOnly components. */
-  componentCount: Scalars['Int']['output'];
-  componentRepresentations?: Maybe<CompletedBuildComponentRepresentationConnection>;
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** The number of docsOnly stories in the published Storybook */
-  docsCount: Scalars['Int']['output'];
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
-  isLimited: Scalars['Boolean']['output'];
-  /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
-  isSuperseded: Scalars['Boolean']['output'];
-  /** Link to the published Storybook's canvas (iframe.html). */
-  isolatorUrl: Scalars['URL']['output'];
-  /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
-  number: Scalars['Int']['output'];
-  /** When the build was prepared for testing on Chromatic. */
-  preparedAt: Scalars['DateTime']['output'];
-  /** When the Storybook was published on Chromatic. */
-  publishedAt: Scalars['DateTime']['output'];
-  /** Final (immutable) result of the build / capture process. Only available once the build has completed. */
-  result: BuildResult;
-  /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
-  slug?: Maybe<Scalars['String']['output']>;
-  /** The number of stories in the published Storybook, excluding docsOnly stories. */
-  specCount: Scalars['Int']['output'];
-  /** When the build was started in Chromatic. */
-  startedAt: Scalars['DateTime']['output'];
-  /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
-  status: BuildStatus;
-  /** Link to the published Storybook. */
-  storybookUrl: Scalars['URL']['output'];
-  /** Count the number of tests in the build. All provided filter arguments must match (AND). */
-  testCount: Scalars['Int']['output'];
-  tests?: Maybe<CompletedBuildTestConnection>;
-  /** Hash of uncommitted changes, or empty string for no changes. */
-  uncommittedHash?: Maybe<Scalars['String']['output']>;
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-  /** Link to the build details on Chromatic. */
-  webUrl: Scalars['URL']['output'];
-};
-
+export type CompletedBuild = Build &
+  Node &
+  Temporal & {
+    __typename?: "CompletedBuild";
+    /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
+    branch: Scalars["String"]["output"];
+    /** Set of browsers against which the build was executed. */
+    browsers: Array<BrowserInfo>;
+    /** Git commit hash (unshortened). */
+    commit: Scalars["String"]["output"];
+    /** Link to the commit details at the Git provider linked to the project. */
+    commitUrl?: Maybe<Scalars["String"]["output"]>;
+    /** When the commit was created in Git. */
+    committedAt: Scalars["DateTime"]["output"];
+    /** When the build was completed in Chromatic. */
+    completedAt: Scalars["DateTime"]["output"];
+    /** The number of components in the published Storybook, excluding docsOnly components. */
+    componentCount: Scalars["Int"]["output"];
+    componentRepresentations?: Maybe<CompletedBuildComponentRepresentationConnection>;
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** The number of docsOnly stories in the published Storybook */
+    docsCount: Scalars["Int"]["output"];
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
+    isLimited: Scalars["Boolean"]["output"];
+    /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
+    isSuperseded: Scalars["Boolean"]["output"];
+    /** Link to the published Storybook's canvas (iframe.html). */
+    isolatorUrl: Scalars["URL"]["output"];
+    /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
+    number: Scalars["Int"]["output"];
+    /** When the build was prepared for testing on Chromatic. */
+    preparedAt: Scalars["DateTime"]["output"];
+    /** When the Storybook was published on Chromatic. */
+    publishedAt: Scalars["DateTime"]["output"];
+    /** Final (immutable) result of the build / capture process. Only available once the build has completed. */
+    result: BuildResult;
+    /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
+    slug?: Maybe<Scalars["String"]["output"]>;
+    /** The number of stories in the published Storybook, excluding docsOnly stories. */
+    specCount: Scalars["Int"]["output"];
+    /** When the build was started in Chromatic. */
+    startedAt: Scalars["DateTime"]["output"];
+    /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
+    status: BuildStatus;
+    /** Link to the published Storybook. */
+    storybookUrl: Scalars["URL"]["output"];
+    /** Count the number of tests in the build. All provided filter arguments must match (AND). */
+    testCount: Scalars["Int"]["output"];
+    tests?: Maybe<CompletedBuildTestConnection>;
+    /** Hash of uncommitted changes, or empty string for no changes. */
+    uncommittedHash?: Maybe<Scalars["String"]["output"]>;
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+    /** Link to the build details on Chromatic. */
+    webUrl: Scalars["URL"]["output"];
+  };
 
 /** A build that has completed testing. */
 export type CompletedBuildComponentRepresentationsArgs = {
-  after?: InputMaybe<Scalars['ID']['input']>;
-  before?: InputMaybe<Scalars['ID']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars["ID"]["input"]>;
+  before?: InputMaybe<Scalars["ID"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
   orderBy?: InputMaybe<CompletedBuildComponentRepresentationsOrder>;
 };
-
 
 /** A build that has completed testing. */
 export type CompletedBuildTestCountArgs = {
   results?: InputMaybe<Array<TestResult>>;
-  reviewable?: InputMaybe<Scalars['Boolean']['input']>;
+  reviewable?: InputMaybe<Scalars["Boolean"]["input"]>;
   statuses?: InputMaybe<Array<TestStatus>>;
 };
 
-
 /** A build that has completed testing. */
 export type CompletedBuildTestsArgs = {
-  after?: InputMaybe<Scalars['ID']['input']>;
-  before?: InputMaybe<Scalars['ID']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars["ID"]["input"]>;
+  before?: InputMaybe<Scalars["ID"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
   orderBy?: InputMaybe<CompletedBuildTestsOrder>;
   statuses?: InputMaybe<Array<TestStatus>>;
-  storyId?: InputMaybe<Scalars['String']['input']>;
+  storyId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 /** Connection to a list of CompletedBuildComponentRepresentation. */
 export type CompletedBuildComponentRepresentationConnection = {
-  __typename?: 'CompletedBuildComponentRepresentationConnection';
+  __typename?: "CompletedBuildComponentRepresentationConnection";
   /** List of edges for CompletedBuildComponentRepresentationConnection. */
   edges: Array<CompletedBuildComponentRepresentationEdge>;
   /** List of nodes for CompletedBuildComponentRepresentationConnection. */
@@ -500,14 +502,14 @@ export type CompletedBuildComponentRepresentationConnection = {
   /** Pagination details for CompletedBuildComponentRepresentationConnection. */
   pageInfo: PageInfo;
   /** Total number of items for CompletedBuildComponentRepresentationConnection. */
-  totalCount: Scalars['Int']['output'];
+  totalCount: Scalars["Int"]["output"];
 };
 
 /** The edge type for CompletedBuildComponentRepresentation. */
 export type CompletedBuildComponentRepresentationEdge = {
-  __typename?: 'CompletedBuildComponentRepresentationEdge';
+  __typename?: "CompletedBuildComponentRepresentationEdge";
   /** Cursor to this item. */
-  cursor: Scalars['String']['output'];
+  cursor: Scalars["String"]["output"];
   /** The item at the edge. */
   node: ComponentRepresentation;
 };
@@ -518,15 +520,15 @@ export type CompletedBuildComponentRepresentationsOrder = {
 };
 
 export enum CompletedBuildComponentRepresentationsOrderField {
-  CreatedAt = 'createdAt',
-  ResultOrder = 'resultOrder',
-  StoryOrder = 'storyOrder',
-  UpdatedAt = 'updatedAt'
+  CreatedAt = "createdAt",
+  ResultOrder = "resultOrder",
+  StoryOrder = "storyOrder",
+  UpdatedAt = "updatedAt",
 }
 
 /** Connection to a list of CompletedBuildTest. */
 export type CompletedBuildTestConnection = {
-  __typename?: 'CompletedBuildTestConnection';
+  __typename?: "CompletedBuildTestConnection";
   /** List of edges for CompletedBuildTestConnection. */
   edges: Array<CompletedBuildTestEdge>;
   /** List of nodes for CompletedBuildTestConnection. */
@@ -534,14 +536,14 @@ export type CompletedBuildTestConnection = {
   /** Pagination details for CompletedBuildTestConnection. */
   pageInfo: PageInfo;
   /** Total number of items for CompletedBuildTestConnection. */
-  totalCount: Scalars['Int']['output'];
+  totalCount: Scalars["Int"]["output"];
 };
 
 /** The edge type for CompletedBuildTest. */
 export type CompletedBuildTestEdge = {
-  __typename?: 'CompletedBuildTestEdge';
+  __typename?: "CompletedBuildTestEdge";
   /** Cursor to this item. */
-  cursor: Scalars['String']['output'];
+  cursor: Scalars["String"]["output"];
   /** The item at the edge. */
   node: Test;
 };
@@ -552,46 +554,46 @@ export type CompletedBuildTestsOrder = {
 };
 
 export enum CompletedBuildTestsOrderField {
-  CreatedAt = 'createdAt',
-  ResultOrder = 'resultOrder',
-  StoryOrder = 'storyOrder',
-  UpdatedAt = 'updatedAt'
+  CreatedAt = "createdAt",
+  ResultOrder = "resultOrder",
+  StoryOrder = "storyOrder",
+  UpdatedAt = "updatedAt",
 }
 
-export type Component = Node & Temporal & {
-  __typename?: 'Component';
-  /** Story metadata `id` (default export) or slugified version of `title`. */
-  componentId: Scalars['String']['output'];
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** Same as componentId, but guaranteed to be unique within the project. */
-  csfId?: Maybe<Scalars['String']['output']>;
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  /** Display name of the component (last section of the title). */
-  name: Scalars['String']['output'];
-  /** Normalized hierarchy path, including component name as last item. */
-  path: Array<Scalars['String']['output']>;
-  representativeStory?: Maybe<Story>;
-  stories?: Maybe<StoryConnection>;
-  /** Title (hierarchy path) as specified on story metadata (default export) or autogenerated based on file path. */
-  title: Scalars['String']['output'];
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-};
-
+export type Component = Node &
+  Temporal & {
+    __typename?: "Component";
+    /** Story metadata `id` (default export) or slugified version of `title`. */
+    componentId: Scalars["String"]["output"];
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** Same as componentId, but guaranteed to be unique within the project. */
+    csfId?: Maybe<Scalars["String"]["output"]>;
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    /** Display name of the component (last section of the title). */
+    name: Scalars["String"]["output"];
+    /** Normalized hierarchy path, including component name as last item. */
+    path: Array<Scalars["String"]["output"]>;
+    representativeStory?: Maybe<Story>;
+    stories?: Maybe<StoryConnection>;
+    /** Title (hierarchy path) as specified on story metadata (default export) or autogenerated based on file path. */
+    title: Scalars["String"]["output"];
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+  };
 
 export type ComponentStoriesArgs = {
-  after?: InputMaybe<Scalars['ID']['input']>;
-  before?: InputMaybe<Scalars['ID']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars["ID"]["input"]>;
+  before?: InputMaybe<Scalars["ID"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
   orderBy?: InputMaybe<StoriesOrder>;
 };
 
 /** Connection to a list of Component. */
 export type ComponentConnection = {
-  __typename?: 'ComponentConnection';
+  __typename?: "ComponentConnection";
   /** List of edges for ComponentConnection. */
   edges: Array<ComponentEdge>;
   /** List of nodes for ComponentConnection. */
@@ -599,21 +601,21 @@ export type ComponentConnection = {
   /** Pagination details for ComponentConnection. */
   pageInfo: PageInfo;
   /** Total number of items for ComponentConnection. */
-  totalCount: Scalars['Int']['output'];
+  totalCount: Scalars["Int"]["output"];
 };
 
 /** The edge type for Component. */
 export type ComponentEdge = {
-  __typename?: 'ComponentEdge';
+  __typename?: "ComponentEdge";
   /** Cursor to this item. */
-  cursor: Scalars['String']['output'];
+  cursor: Scalars["String"]["output"];
   /** The item at the edge. */
   node: Component;
 };
 
 /** Represents a component in a build. */
 export type ComponentRepresentation = {
-  __typename?: 'ComponentRepresentation';
+  __typename?: "ComponentRepresentation";
   /** The component represented here. */
   component: Component;
   /** This test is the best representation of the first spec of the component on this build. */
@@ -626,91 +628,85 @@ export type ComponentsOrder = {
 };
 
 export enum ComponentsOrderField {
-  CreatedAt = 'createdAt',
-  UpdatedAt = 'updatedAt'
+  CreatedAt = "createdAt",
+  UpdatedAt = "updatedAt",
 }
 
 export type CreateFigmaMetadataInput = {
-  key: Scalars['String']['input'];
-  metadata: Scalars['JSONObject']['input'];
-  url: Scalars['String']['input'];
+  key: Scalars["String"]["input"];
+  metadata: Scalars["JSONObject"]["input"];
+  url: Scalars["String"]["input"];
 };
 
-export type FigmaMetadata = Node & Temporal & {
-  __typename?: 'FigmaMetadata';
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  key: Scalars['String']['output'];
-  metadata: Scalars['JSONObject']['output'];
-  owner?: Maybe<User>;
-  project?: Maybe<Project>;
-  story?: Maybe<Story>;
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-  url?: Maybe<Scalars['String']['output']>;
-};
+export type FigmaMetadata = Node &
+  Temporal & {
+    __typename?: "FigmaMetadata";
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    key: Scalars["String"]["output"];
+    metadata: Scalars["JSONObject"]["output"];
+    owner?: Maybe<User>;
+    project?: Maybe<Project>;
+    story?: Maybe<Story>;
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+    url?: Maybe<Scalars["String"]["output"]>;
+  };
 
 export type Image = {
   /** Pixel height of the image. */
-  imageHeight: Scalars['Int']['output'];
+  imageHeight: Scalars["Int"]["output"];
   /** URL of the image. */
-  imageUrl: Scalars['URL']['output'];
+  imageUrl: Scalars["URL"]["output"];
   /** Pixel width of the image. */
-  imageWidth: Scalars['Int']['output'];
+  imageWidth: Scalars["Int"]["output"];
 };
 
 export type LocalBuildsSpecifierInput = {
   /** If set, only return builds with isLocalBuild set to this value */
-  isLocalBuild?: InputMaybe<Scalars['Boolean']['input']>;
+  isLocalBuild?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** If set, return all global builds, and only local builds from this email hash */
-  localBuildEmailHash?: InputMaybe<Scalars['String']['input']>;
+  localBuildEmailHash?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
+  __typename?: "Mutation";
   bulkCreateFigmaMetadata: Array<FigmaMetadata>;
   bulkRemoveFigmaMetadata: Array<FigmaMetadata>;
-  createCLIToken: Scalars['String']['output'];
+  createCLIToken: Scalars["String"]["output"];
   createFigmaMetadata?: Maybe<FigmaMetadata>;
   removeFigmaMetadata?: Maybe<FigmaMetadata>;
   reviewTest?: Maybe<ReviewTestPayload>;
   updateUserPreferences?: Maybe<UpdateUserPreferencesPayload>;
 };
 
-
 export type MutationBulkCreateFigmaMetadataArgs = {
   input: Array<CreateFigmaMetadataInput>;
 };
 
-
 export type MutationBulkRemoveFigmaMetadataArgs = {
-  ids: Array<Scalars['ID']['input']>;
+  ids: Array<Scalars["ID"]["input"]>;
 };
-
 
 export type MutationCreateCliTokenArgs = {
-  projectId: Scalars['String']['input'];
+  projectId: Scalars["String"]["input"];
 };
-
 
 export type MutationCreateFigmaMetadataArgs = {
-  key: Scalars['String']['input'];
-  metadata: Scalars['JSONObject']['input'];
-  url: Scalars['String']['input'];
+  key: Scalars["String"]["input"];
+  metadata: Scalars["JSONObject"]["input"];
+  url: Scalars["String"]["input"];
 };
-
 
 export type MutationRemoveFigmaMetadataArgs = {
-  id: Scalars['ID']['input'];
+  id: Scalars["ID"]["input"];
 };
-
 
 export type MutationReviewTestArgs = {
   input: ReviewTestInput;
 };
-
 
 export type MutationUpdateUserPreferencesArgs = {
   input: UserPreferencesInput;
@@ -718,102 +714,102 @@ export type MutationUpdateUserPreferencesArgs = {
 
 export type Node = {
   /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
 };
 
 export enum OrderDirection {
   /** Ascending */
-  Asc = 'ASC',
+  Asc = "ASC",
   /** Descending */
-  Desc = 'DESC'
+  Desc = "DESC",
 }
 
 /** Information about pagination in a connection. */
 export type PageInfo = {
-  __typename?: 'PageInfo';
+  __typename?: "PageInfo";
   /** When paginating forwards, the cursor to continue. */
-  endCursor?: Maybe<Scalars['String']['output']>;
+  endCursor?: Maybe<Scalars["String"]["output"]>;
   /** When paginating forwards, are there more items? */
-  hasNextPage: Scalars['Boolean']['output'];
+  hasNextPage: Scalars["Boolean"]["output"];
   /** When paginating backwards, are there more items? */
-  hasPreviousPage: Scalars['Boolean']['output'];
+  hasPreviousPage: Scalars["Boolean"]["output"];
   /** When paginating backwards, the cursor to continue. */
-  startCursor?: Maybe<Scalars['String']['output']>;
+  startCursor?: Maybe<Scalars["String"]["output"]>;
 };
 
 /** A build that has been prepared for testing but not started yet. */
-export type PreparedBuild = Build & Node & Temporal & {
-  __typename?: 'PreparedBuild';
-  /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
-  branch: Scalars['String']['output'];
-  /** Set of browsers against which the build was executed. */
-  browsers: Array<BrowserInfo>;
-  /** Git commit hash (unshortened). */
-  commit: Scalars['String']['output'];
-  /** Link to the commit details at the Git provider linked to the project. */
-  commitUrl?: Maybe<Scalars['String']['output']>;
-  /** When the commit was created in Git. */
-  committedAt: Scalars['DateTime']['output'];
-  /** The number of components in the published Storybook, excluding docsOnly components. */
-  componentCount: Scalars['Int']['output'];
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** The number of docsOnly stories in the published Storybook */
-  docsCount: Scalars['Int']['output'];
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
-  isLimited: Scalars['Boolean']['output'];
-  /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
-  isSuperseded: Scalars['Boolean']['output'];
-  /** Link to the published Storybook's canvas (iframe.html). */
-  isolatorUrl: Scalars['URL']['output'];
-  /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
-  number: Scalars['Int']['output'];
-  /** When the build was prepared for testing on Chromatic. */
-  preparedAt: Scalars['DateTime']['output'];
-  /** When the Storybook was published on Chromatic. */
-  publishedAt: Scalars['DateTime']['output'];
-  /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
-  slug?: Maybe<Scalars['String']['output']>;
-  /** The number of stories in the published Storybook, excluding docsOnly stories. */
-  specCount: Scalars['Int']['output'];
-  /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
-  status: BuildStatus;
-  /** Link to the published Storybook. */
-  storybookUrl: Scalars['URL']['output'];
-  /** Count the number of tests in the build. All provided filter arguments must match (AND). */
-  testCount: Scalars['Int']['output'];
-  tests?: Maybe<PreparedBuildTestConnection>;
-  /** Hash of uncommitted changes, or empty string for no changes. */
-  uncommittedHash?: Maybe<Scalars['String']['output']>;
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-};
-
+export type PreparedBuild = Build &
+  Node &
+  Temporal & {
+    __typename?: "PreparedBuild";
+    /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
+    branch: Scalars["String"]["output"];
+    /** Set of browsers against which the build was executed. */
+    browsers: Array<BrowserInfo>;
+    /** Git commit hash (unshortened). */
+    commit: Scalars["String"]["output"];
+    /** Link to the commit details at the Git provider linked to the project. */
+    commitUrl?: Maybe<Scalars["String"]["output"]>;
+    /** When the commit was created in Git. */
+    committedAt: Scalars["DateTime"]["output"];
+    /** The number of components in the published Storybook, excluding docsOnly components. */
+    componentCount: Scalars["Int"]["output"];
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** The number of docsOnly stories in the published Storybook */
+    docsCount: Scalars["Int"]["output"];
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
+    isLimited: Scalars["Boolean"]["output"];
+    /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
+    isSuperseded: Scalars["Boolean"]["output"];
+    /** Link to the published Storybook's canvas (iframe.html). */
+    isolatorUrl: Scalars["URL"]["output"];
+    /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
+    number: Scalars["Int"]["output"];
+    /** When the build was prepared for testing on Chromatic. */
+    preparedAt: Scalars["DateTime"]["output"];
+    /** When the Storybook was published on Chromatic. */
+    publishedAt: Scalars["DateTime"]["output"];
+    /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
+    slug?: Maybe<Scalars["String"]["output"]>;
+    /** The number of stories in the published Storybook, excluding docsOnly stories. */
+    specCount: Scalars["Int"]["output"];
+    /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
+    status: BuildStatus;
+    /** Link to the published Storybook. */
+    storybookUrl: Scalars["URL"]["output"];
+    /** Count the number of tests in the build. All provided filter arguments must match (AND). */
+    testCount: Scalars["Int"]["output"];
+    tests?: Maybe<PreparedBuildTestConnection>;
+    /** Hash of uncommitted changes, or empty string for no changes. */
+    uncommittedHash?: Maybe<Scalars["String"]["output"]>;
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+  };
 
 /** A build that has been prepared for testing but not started yet. */
 export type PreparedBuildTestCountArgs = {
   results?: InputMaybe<Array<TestResult>>;
-  reviewable?: InputMaybe<Scalars['Boolean']['input']>;
+  reviewable?: InputMaybe<Scalars["Boolean"]["input"]>;
   statuses?: InputMaybe<Array<TestStatus>>;
 };
 
-
 /** A build that has been prepared for testing but not started yet. */
 export type PreparedBuildTestsArgs = {
-  after?: InputMaybe<Scalars['ID']['input']>;
-  before?: InputMaybe<Scalars['ID']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars["ID"]["input"]>;
+  before?: InputMaybe<Scalars["ID"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
   orderBy?: InputMaybe<PreparedBuildTestsOrder>;
   statuses?: InputMaybe<Array<TestStatus>>;
-  storyId?: InputMaybe<Scalars['String']['input']>;
+  storyId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 /** Connection to a list of PreparedBuildTest. */
 export type PreparedBuildTestConnection = {
-  __typename?: 'PreparedBuildTestConnection';
+  __typename?: "PreparedBuildTestConnection";
   /** List of edges for PreparedBuildTestConnection. */
   edges: Array<PreparedBuildTestEdge>;
   /** List of nodes for PreparedBuildTestConnection. */
@@ -821,14 +817,14 @@ export type PreparedBuildTestConnection = {
   /** Pagination details for PreparedBuildTestConnection. */
   pageInfo: PageInfo;
   /** Total number of items for PreparedBuildTestConnection. */
-  totalCount: Scalars['Int']['output'];
+  totalCount: Scalars["Int"]["output"];
 };
 
 /** The edge type for PreparedBuildTest. */
 export type PreparedBuildTestEdge = {
-  __typename?: 'PreparedBuildTestEdge';
+  __typename?: "PreparedBuildTestEdge";
   /** Cursor to this item. */
-  cursor: Scalars['String']['output'];
+  cursor: Scalars["String"]["output"];
   /** The item at the edge. */
   node: Test;
 };
@@ -839,120 +835,120 @@ export type PreparedBuildTestsOrder = {
 };
 
 export enum PreparedBuildTestsOrderField {
-  CreatedAt = 'createdAt',
-  ResultOrder = 'resultOrder',
-  StoryOrder = 'storyOrder',
-  UpdatedAt = 'updatedAt'
+  CreatedAt = "createdAt",
+  ResultOrder = "resultOrder",
+  StoryOrder = "storyOrder",
+  UpdatedAt = "updatedAt",
 }
 
-export type Project = Node & Temporal & {
-  __typename?: 'Project';
-  /** List of branches for which builds exist in the project. */
-  branchNames: Array<Scalars['String']['output']>;
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** This token is the Figma OAuth2 accessToken of whichever user assigned their Figma credentials to the project. */
-  figmaToken?: Maybe<Scalars['String']['output']>;
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  /** Retrieve the last build for the project which matches the (optionally) provided filters. All filter arguments must match (AND). */
-  lastBuild?: Maybe<Build>;
-  /** Project name, typically the repository name. */
-  name: Scalars['String']['output'];
-  /** Project token to start builds with Chromatic CLI. */
-  projectToken: Scalars['String']['output'];
-  /** Account information which does not require the `account` scope. */
-  publicAccountInfo: PublicAccountInfo;
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-  /** Link to the project on Chromatic. */
-  webUrl: Scalars['URL']['output'];
-};
-
+export type Project = Node &
+  Temporal & {
+    __typename?: "Project";
+    /** List of branches for which builds exist in the project. */
+    branchNames: Array<Scalars["String"]["output"]>;
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** This token is the Figma OAuth2 accessToken of whichever user assigned their Figma credentials to the project. */
+    figmaToken?: Maybe<Scalars["String"]["output"]>;
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    /** Retrieve the last build for the project which matches the (optionally) provided filters. All filter arguments must match (AND). */
+    lastBuild?: Maybe<Build>;
+    /** Project name, typically the repository name. */
+    name: Scalars["String"]["output"];
+    /** Project token to start builds with Chromatic CLI. */
+    projectToken: Scalars["String"]["output"];
+    /** Account information which does not require the `account` scope. */
+    publicAccountInfo: PublicAccountInfo;
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+    /** Link to the project on Chromatic. */
+    webUrl: Scalars["URL"]["output"];
+  };
 
 export type ProjectBranchNamesArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
-
 export type ProjectLastBuildArgs = {
-  branches?: InputMaybe<Array<Scalars['String']['input']>>;
-  defaultBranch?: InputMaybe<Scalars['Boolean']['input']>;
+  branches?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  defaultBranch?: InputMaybe<Scalars["Boolean"]["input"]>;
   localBuilds?: InputMaybe<LocalBuildsSpecifierInput>;
-  repositoryOwnerName?: InputMaybe<Scalars['String']['input']>;
+  repositoryOwnerName?: InputMaybe<Scalars["String"]["input"]>;
   results?: InputMaybe<Array<BuildResult>>;
-  slug?: InputMaybe<Scalars['String']['input']>;
+  slug?: InputMaybe<Scalars["String"]["input"]>;
   statuses?: InputMaybe<Array<BuildStatus>>;
 };
 
 export type ProjectMembership = {
-  __typename?: 'ProjectMembership';
+  __typename?: "ProjectMembership";
   accessLevel: AccessLevel;
   /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars["DateTime"]["output"];
   /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  meetsAccessLevel: Scalars['Boolean']['output'];
+  id: Scalars["ID"]["output"];
+  meetsAccessLevel: Scalars["Boolean"]["output"];
   project: Project;
   /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
+  updatedAt: Scalars["DateTime"]["output"];
   user?: Maybe<User>;
 };
-
 
 export type ProjectMembershipMeetsAccessLevelArgs = {
   minimumAccessLevel: AccessLevel;
 };
 
 export type PublicAccountInfo = {
-  __typename?: 'PublicAccountInfo';
+  __typename?: "PublicAccountInfo";
   /** Avatar URL of the repository owner or token holder. */
-  avatarUrl?: Maybe<Scalars['URL']['output']>;
+  avatarUrl?: Maybe<Scalars["URL"]["output"]>;
   /** Login name of the repository owner or token holder. */
-  name: Scalars['String']['output'];
+  name: Scalars["String"]["output"];
 };
 
 /** A build that has been published but not yet prepared for testing. */
-export type PublishedBuild = Build & Node & Temporal & {
-  __typename?: 'PublishedBuild';
-  /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
-  branch: Scalars['String']['output'];
-  /** Set of browsers against which the build was executed. */
-  browsers: Array<BrowserInfo>;
-  /** Git commit hash (unshortened). */
-  commit: Scalars['String']['output'];
-  /** Link to the commit details at the Git provider linked to the project. */
-  commitUrl?: Maybe<Scalars['String']['output']>;
-  /** When the commit was created in Git. */
-  committedAt: Scalars['DateTime']['output'];
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
-  isLimited: Scalars['Boolean']['output'];
-  /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
-  isSuperseded: Scalars['Boolean']['output'];
-  /** Link to the published Storybook's canvas (iframe.html). */
-  isolatorUrl: Scalars['URL']['output'];
-  /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
-  number: Scalars['Int']['output'];
-  /** When the Storybook was published on Chromatic. */
-  publishedAt: Scalars['DateTime']['output'];
-  /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
-  slug?: Maybe<Scalars['String']['output']>;
-  /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
-  status: BuildStatus;
-  /** Link to the published Storybook. */
-  storybookUrl: Scalars['URL']['output'];
-  /** Hash of uncommitted changes, or empty string for no changes. */
-  uncommittedHash?: Maybe<Scalars['String']['output']>;
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-};
+export type PublishedBuild = Build &
+  Node &
+  Temporal & {
+    __typename?: "PublishedBuild";
+    /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
+    branch: Scalars["String"]["output"];
+    /** Set of browsers against which the build was executed. */
+    browsers: Array<BrowserInfo>;
+    /** Git commit hash (unshortened). */
+    commit: Scalars["String"]["output"];
+    /** Link to the commit details at the Git provider linked to the project. */
+    commitUrl?: Maybe<Scalars["String"]["output"]>;
+    /** When the commit was created in Git. */
+    committedAt: Scalars["DateTime"]["output"];
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
+    isLimited: Scalars["Boolean"]["output"];
+    /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
+    isSuperseded: Scalars["Boolean"]["output"];
+    /** Link to the published Storybook's canvas (iframe.html). */
+    isolatorUrl: Scalars["URL"]["output"];
+    /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
+    number: Scalars["Int"]["output"];
+    /** When the Storybook was published on Chromatic. */
+    publishedAt: Scalars["DateTime"]["output"];
+    /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
+    slug?: Maybe<Scalars["String"]["output"]>;
+    /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
+    status: BuildStatus;
+    /** Link to the published Storybook. */
+    storybookUrl: Scalars["URL"]["output"];
+    /** Hash of uncommitted changes, or empty string for no changes. */
+    uncommittedHash?: Maybe<Scalars["String"]["output"]>;
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+  };
 
 export type Query = {
-  __typename?: 'Query';
+  __typename?: "Query";
   account?: Maybe<Account>;
   build?: Maybe<Build>;
   bulkFigmaMetadata?: Maybe<Array<Maybe<FigmaMetadata>>>;
@@ -963,45 +959,38 @@ export type Query = {
   viewer?: Maybe<User>;
 };
 
-
 export type QueryAccountArgs = {
-  id: Scalars['ID']['input'];
+  id: Scalars["ID"]["input"];
 };
-
 
 export type QueryBuildArgs = {
-  id: Scalars['ID']['input'];
+  id: Scalars["ID"]["input"];
 };
-
 
 export type QueryBulkFigmaMetadataArgs = {
-  keys: Array<Scalars['String']['input']>;
+  keys: Array<Scalars["String"]["input"]>;
 };
-
 
 export type QueryFigmaMetadataArgs = {
-  key?: InputMaybe<Scalars['String']['input']>;
+  key?: InputMaybe<Scalars["String"]["input"]>;
 };
-
 
 export type QueryFigmaMetadataByIdArgs = {
-  id: Scalars['ObjID']['input'];
+  id: Scalars["ObjID"]["input"];
 };
-
 
 export type QueryProjectArgs = {
-  id: Scalars['ID']['input'];
+  id: Scalars["ID"]["input"];
 };
 
-
 export type QueryStorybookArgs = {
-  url: Scalars['URL']['input'];
+  url: Scalars["URL"]["input"];
 };
 
 export enum ReviewTestBatch {
-  Build = 'BUILD',
-  Component = 'COMPONENT',
-  Spec = 'SPEC'
+  Build = "BUILD",
+  Component = "COMPONENT",
+  Spec = "SPEC",
 }
 
 export type ReviewTestError = BuildSupersededError | TestNotFoundError | TestUnreviewableError;
@@ -1012,20 +1001,20 @@ export type ReviewTestInput = {
   /** The new status of the test. */
   status: ReviewTestInputStatus;
   /** The ID of the test to review. */
-  testId: Scalars['ID']['input'];
+  testId: Scalars["ID"]["input"];
 };
 
 export enum ReviewTestInputStatus {
   /** Accept the changes on the test. */
-  Accepted = 'ACCEPTED',
+  Accepted = "ACCEPTED",
   /** Deny the changes on the test. */
-  Denied = 'DENIED',
+  Denied = "DENIED",
   /** Reset the test back to unreviewed. */
-  Pending = 'PENDING'
+  Pending = "PENDING",
 }
 
 export type ReviewTestPayload = {
-  __typename?: 'ReviewTestPayload';
+  __typename?: "ReviewTestPayload";
   /** The test(s) that were updated, if successful. */
   updatedTests?: Maybe<Array<Test>>;
   /** User errors preventing the test from being reviewed. Empty if successful. */
@@ -1033,82 +1022,82 @@ export type ReviewTestPayload = {
 };
 
 /** A build that has started but not completed testing. */
-export type StartedBuild = Build & Node & Temporal & {
-  __typename?: 'StartedBuild';
-  /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
-  branch: Scalars['String']['output'];
-  /** Set of browsers against which the build was executed. */
-  browsers: Array<BrowserInfo>;
-  /** Git commit hash (unshortened). */
-  commit: Scalars['String']['output'];
-  /** Link to the commit details at the Git provider linked to the project. */
-  commitUrl?: Maybe<Scalars['String']['output']>;
-  /** When the commit was created in Git. */
-  committedAt: Scalars['DateTime']['output'];
-  /** The number of components in the published Storybook, excluding docsOnly components. */
-  componentCount: Scalars['Int']['output'];
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** The number of docsOnly stories in the published Storybook */
-  docsCount: Scalars['Int']['output'];
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
-  isLimited: Scalars['Boolean']['output'];
-  /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
-  isSuperseded: Scalars['Boolean']['output'];
-  /** Link to the published Storybook's canvas (iframe.html). */
-  isolatorUrl: Scalars['URL']['output'];
-  /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
-  number: Scalars['Int']['output'];
-  /** When the build was prepared for testing on Chromatic. */
-  preparedAt: Scalars['DateTime']['output'];
-  /** When the Storybook was published on Chromatic. */
-  publishedAt: Scalars['DateTime']['output'];
-  /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
-  slug?: Maybe<Scalars['String']['output']>;
-  /** The number of stories in the published Storybook, excluding docsOnly stories. */
-  specCount: Scalars['Int']['output'];
-  /** When the build was started in Chromatic. */
-  startedAt: Scalars['DateTime']['output'];
-  /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
-  status: BuildStatus;
-  /** Link to the published Storybook. */
-  storybookUrl: Scalars['URL']['output'];
-  /** Count the number of tests in the build. All provided filter arguments must match (AND). */
-  testCount: Scalars['Int']['output'];
-  tests?: Maybe<StartedBuildTestConnection>;
-  /** Hash of uncommitted changes, or empty string for no changes. */
-  uncommittedHash?: Maybe<Scalars['String']['output']>;
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-  /** Link to the build details on Chromatic. */
-  webUrl: Scalars['URL']['output'];
-};
-
+export type StartedBuild = Build &
+  Node &
+  Temporal & {
+    __typename?: "StartedBuild";
+    /** Git branch name, possibly prefixed with the owner name (in case of a forked repository). */
+    branch: Scalars["String"]["output"];
+    /** Set of browsers against which the build was executed. */
+    browsers: Array<BrowserInfo>;
+    /** Git commit hash (unshortened). */
+    commit: Scalars["String"]["output"];
+    /** Link to the commit details at the Git provider linked to the project. */
+    commitUrl?: Maybe<Scalars["String"]["output"]>;
+    /** When the commit was created in Git. */
+    committedAt: Scalars["DateTime"]["output"];
+    /** The number of components in the published Storybook, excluding docsOnly components. */
+    componentCount: Scalars["Int"]["output"];
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** The number of docsOnly stories in the published Storybook */
+    docsCount: Scalars["Int"]["output"];
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    /** Whether the build is limited to just representative stories due to insufficient snapshot quota. */
+    isLimited: Scalars["Boolean"]["output"];
+    /** Whether there is a newer build on the same branch, and therefore this build can no longer be reviewed. */
+    isSuperseded: Scalars["Boolean"]["output"];
+    /** Link to the published Storybook's canvas (iframe.html). */
+    isolatorUrl: Scalars["URL"]["output"];
+    /** Incremental build number. Infrastructure upgrade builds have the same number as the original build. */
+    number: Scalars["Int"]["output"];
+    /** When the build was prepared for testing on Chromatic. */
+    preparedAt: Scalars["DateTime"]["output"];
+    /** When the Storybook was published on Chromatic. */
+    publishedAt: Scalars["DateTime"]["output"];
+    /** URL-safe Git repository identifier, consisting of the owner (organization or user) name and the repository name, separated by a slash (/). This is typically part of the Git repository URL. The value originates from the CLI runtime environment, not the linked Git provider / linked repository. */
+    slug?: Maybe<Scalars["String"]["output"]>;
+    /** The number of stories in the published Storybook, excluding docsOnly stories. */
+    specCount: Scalars["Int"]["output"];
+    /** When the build was started in Chromatic. */
+    startedAt: Scalars["DateTime"]["output"];
+    /** Current (mutable) status of the build, which changes as the build progresses or changes are reviewed. */
+    status: BuildStatus;
+    /** Link to the published Storybook. */
+    storybookUrl: Scalars["URL"]["output"];
+    /** Count the number of tests in the build. All provided filter arguments must match (AND). */
+    testCount: Scalars["Int"]["output"];
+    tests?: Maybe<StartedBuildTestConnection>;
+    /** Hash of uncommitted changes, or empty string for no changes. */
+    uncommittedHash?: Maybe<Scalars["String"]["output"]>;
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+    /** Link to the build details on Chromatic. */
+    webUrl: Scalars["URL"]["output"];
+  };
 
 /** A build that has started but not completed testing. */
 export type StartedBuildTestCountArgs = {
   results?: InputMaybe<Array<TestResult>>;
-  reviewable?: InputMaybe<Scalars['Boolean']['input']>;
+  reviewable?: InputMaybe<Scalars["Boolean"]["input"]>;
   statuses?: InputMaybe<Array<TestStatus>>;
 };
 
-
 /** A build that has started but not completed testing. */
 export type StartedBuildTestsArgs = {
-  after?: InputMaybe<Scalars['ID']['input']>;
-  before?: InputMaybe<Scalars['ID']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars["ID"]["input"]>;
+  before?: InputMaybe<Scalars["ID"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
   orderBy?: InputMaybe<StartedBuildTestsOrder>;
   statuses?: InputMaybe<Array<TestStatus>>;
-  storyId?: InputMaybe<Scalars['String']['input']>;
+  storyId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 /** Connection to a list of StartedBuildTest. */
 export type StartedBuildTestConnection = {
-  __typename?: 'StartedBuildTestConnection';
+  __typename?: "StartedBuildTestConnection";
   /** List of edges for StartedBuildTestConnection. */
   edges: Array<StartedBuildTestEdge>;
   /** List of nodes for StartedBuildTestConnection. */
@@ -1116,14 +1105,14 @@ export type StartedBuildTestConnection = {
   /** Pagination details for StartedBuildTestConnection. */
   pageInfo: PageInfo;
   /** Total number of items for StartedBuildTestConnection. */
-  totalCount: Scalars['Int']['output'];
+  totalCount: Scalars["Int"]["output"];
 };
 
 /** The edge type for StartedBuildTest. */
 export type StartedBuildTestEdge = {
-  __typename?: 'StartedBuildTestEdge';
+  __typename?: "StartedBuildTestEdge";
   /** Cursor to this item. */
-  cursor: Scalars['String']['output'];
+  cursor: Scalars["String"]["output"];
   /** The item at the edge. */
   node: Test;
 };
@@ -1134,10 +1123,10 @@ export type StartedBuildTestsOrder = {
 };
 
 export enum StartedBuildTestsOrderField {
-  CreatedAt = 'createdAt',
-  ResultOrder = 'resultOrder',
-  StoryOrder = 'storyOrder',
-  UpdatedAt = 'updatedAt'
+  CreatedAt = "createdAt",
+  ResultOrder = "resultOrder",
+  StoryOrder = "storyOrder",
+  UpdatedAt = "updatedAt",
 }
 
 export type StoriesOrder = {
@@ -1146,40 +1135,40 @@ export type StoriesOrder = {
 };
 
 export enum StoriesOrderField {
-  CreatedAt = 'createdAt',
-  UpdatedAt = 'updatedAt'
+  CreatedAt = "createdAt",
+  UpdatedAt = "updatedAt",
 }
 
-export type Story = Node & Temporal & {
-  __typename?: 'Story';
-  /** Image and snapshot display metadata for this story, if captured. */
-  captureImage?: Maybe<CaptureImage>;
-  /** Component that contains the story. */
-  component?: Maybe<Component>;
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** Same as storyId, but guaranteed to be unique within the project. */
-  csfId?: Maybe<Scalars['String']['output']>;
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  /** Story name as displayed in Storybook. */
-  name: Scalars['String']['output'];
-  /** Story ID as generated by Storybook, including componentId prefix. */
-  storyId: Scalars['String']['output'];
-  /** Permalink to the story in the published Storybook. */
-  storybookUrl?: Maybe<Scalars['URL']['output']>;
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-};
-
+export type Story = Node &
+  Temporal & {
+    __typename?: "Story";
+    /** Image and snapshot display metadata for this story, if captured. */
+    captureImage?: Maybe<CaptureImage>;
+    /** Component that contains the story. */
+    component?: Maybe<Component>;
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** Same as storyId, but guaranteed to be unique within the project. */
+    csfId?: Maybe<Scalars["String"]["output"]>;
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    /** Story name as displayed in Storybook. */
+    name: Scalars["String"]["output"];
+    /** Story ID as generated by Storybook, including componentId prefix. */
+    storyId: Scalars["String"]["output"];
+    /** Permalink to the story in the published Storybook. */
+    storybookUrl?: Maybe<Scalars["URL"]["output"]>;
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+  };
 
 export type StoryCaptureImageArgs = {
-  signed?: InputMaybe<Scalars['Boolean']['input']>;
+  signed?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 /** Connection to a list of Story. */
 export type StoryConnection = {
-  __typename?: 'StoryConnection';
+  __typename?: "StoryConnection";
   /** List of edges for StoryConnection. */
   edges: Array<StoryEdge>;
   /** List of nodes for StoryConnection. */
@@ -1187,75 +1176,75 @@ export type StoryConnection = {
   /** Pagination details for StoryConnection. */
   pageInfo: PageInfo;
   /** Total number of items for StoryConnection. */
-  totalCount: Scalars['Int']['output'];
+  totalCount: Scalars["Int"]["output"];
 };
 
 /** The edge type for Story. */
 export type StoryEdge = {
-  __typename?: 'StoryEdge';
+  __typename?: "StoryEdge";
   /** Cursor to this item. */
-  cursor: Scalars['String']['output'];
+  cursor: Scalars["String"]["output"];
   /** The item at the edge. */
   node: Story;
 };
 
 export type Storybook = {
-  __typename?: 'Storybook';
+  __typename?: "Storybook";
   /** Link to the build on Chromatic. */
-  buildUrl: Scalars['URL']['output'];
+  buildUrl: Scalars["URL"]["output"];
   /** List of components in the published Storybook. */
   components: ComponentConnection;
   /** Permalink to the published Storybook. */
-  storybookUrl: Scalars['URL']['output'];
+  storybookUrl: Scalars["URL"]["output"];
 };
 
-
 export type StorybookComponentsArgs = {
-  after?: InputMaybe<Scalars['ID']['input']>;
-  before?: InputMaybe<Scalars['ID']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars["ID"]["input"]>;
+  before?: InputMaybe<Scalars["ID"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
   orderBy?: InputMaybe<ComponentsOrder>;
 };
 
 /** Entity which tracks creation and update date/time. */
 export type Temporal = {
   /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars["DateTime"]["output"];
   /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
+  updatedAt: Scalars["DateTime"]["output"];
 };
 
 /** A set of captures for a story at a specific viewport, compared against the baseline. */
-export type Test = Node & Temporal & {
-  __typename?: 'Test';
-  /** The baseline test this test was compared against. */
-  baseline?: Maybe<Test>;
-  /** List of snapshot comparisons for this test, one for each tested browser. */
-  comparisons: Array<TestComparison>;
-  /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
-  /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  /** What test kinds is this test associated with. */
-  kinds: Array<TestKind>;
-  /** The mode applied to this test. If this test was not using modes, the viewport is set as the mode name (e.g. "[viewport]px") */
-  mode: TestMode;
-  /** Chromatic parameters configured on the story or automatically determined based on context. */
-  parameters: TestParameters;
-  /** Final (immutable) summary of the results of the comparisons on this test. Only available once the test has completed. */
-  result?: Maybe<TestResult>;
-  /** Current (mutable) user state of the test; has it been reviewed? */
-  status: TestStatus;
-  /** Reference to the story for this test in the published Storybook for this build. */
-  story?: Maybe<Story>;
-  /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-  webUrl: Scalars['URL']['output'];
-};
+export type Test = Node &
+  Temporal & {
+    __typename?: "Test";
+    /** The baseline test this test was compared against. */
+    baseline?: Maybe<Test>;
+    /** List of snapshot comparisons for this test, one for each tested browser. */
+    comparisons: Array<TestComparison>;
+    /** When the entity was first created in Chromatic. */
+    createdAt: Scalars["DateTime"]["output"];
+    /** GraphQL node identifier */
+    id: Scalars["ID"]["output"];
+    /** What test kinds is this test associated with. */
+    kinds: Array<TestKind>;
+    /** The mode applied to this test. If this test was not using modes, the viewport is set as the mode name (e.g. "[viewport]px") */
+    mode: TestMode;
+    /** Chromatic parameters configured on the story or automatically determined based on context. */
+    parameters: TestParameters;
+    /** Final (immutable) summary of the results of the comparisons on this test. Only available once the test has completed. */
+    result?: Maybe<TestResult>;
+    /** Current (mutable) user state of the test; has it been reviewed? */
+    status: TestStatus;
+    /** Reference to the story for this test in the published Storybook for this build. */
+    story?: Maybe<Story>;
+    /** When the entity was last updated or created in Chromatic. */
+    updatedAt: Scalars["DateTime"]["output"];
+    webUrl: Scalars["URL"]["output"];
+  };
 
 export type TestComparison = Node & {
-  __typename?: 'TestComparison';
+  __typename?: "TestComparison";
   /** The (head) capture of the baseline test which was compared against, for the same browser. */
   baseCapture?: Maybe<Capture>;
   /** Browser against which this comparison was captured and compared. */
@@ -1265,7 +1254,7 @@ export type TestComparison = Node & {
   /** The capture of the test this comparison belongs to. Available once the capture is complete. */
   headCapture?: Maybe<Capture>;
   /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** The result of comparing this test's (head) capture against the baseline. Only available once the test has completed. */
   result?: Maybe<ComparisonResult>;
   /** Viewport for which this comparison was captured and compared. */
@@ -1274,130 +1263,129 @@ export type TestComparison = Node & {
 
 export enum TestKind {
   /** At least one comparison contains an accessibility test */
-  Accessibility = 'ACCESSIBILITY',
+  Accessibility = "ACCESSIBILITY",
   /** At least one comparison contains an interaction test */
-  Interaction = 'INTERACTION',
+  Interaction = "INTERACTION",
   /** At least one comparison contains a visual test */
-  Visual = 'VISUAL'
+  Visual = "VISUAL",
 }
 
 export type TestMode = {
-  __typename?: 'TestMode';
+  __typename?: "TestMode";
   /** A map of Storybook globals with chosen values that defines how to render a spec (e.g. `{ "lang": "es", "theme": "dark", "viewport": 320 }`) */
-  globals: Scalars['JSONObject']['output'];
+  globals: Scalars["JSONObject"]["output"];
   /** The name of the mode (e.g. "Spanish Dark Mobile") */
-  name: Scalars['String']['output'];
+  name: Scalars["String"]["output"];
 };
 
 export type TestNotFoundError = UserError & {
-  __typename?: 'TestNotFoundError';
-  message: Scalars['String']['output'];
+  __typename?: "TestNotFoundError";
+  message: Scalars["String"]["output"];
 };
 
 export type TestParameters = {
-  __typename?: 'TestParameters';
+  __typename?: "TestParameters";
   /** Delay in milliseconds before taking the snapshot. */
-  delay?: Maybe<Scalars['Int']['output']>;
+  delay?: Maybe<Scalars["Int"]["output"]>;
   /** If true, disables detecting and ignoring anti-aliased pixels. */
-  diffIncludeAntiAliasing?: Maybe<Scalars['Boolean']['output']>;
+  diffIncludeAntiAliasing?: Maybe<Scalars["Boolean"]["output"]>;
   /** Threshold before a snapshot is considered visually different (0-1). */
-  diffThreshold?: Maybe<Scalars['Float']['output']>;
+  diffThreshold?: Maybe<Scalars["Float"]["output"]>;
   /** This test applies to a docs page. */
-  docsOnly?: Maybe<Scalars['Boolean']['output']>;
+  docsOnly?: Maybe<Scalars["Boolean"]["output"]>;
   /** Set the `forced-colors` media feature when capturing the story. */
-  forcedColors?: Maybe<Scalars['String']['output']>;
+  forcedColors?: Maybe<Scalars["String"]["output"]>;
   /** Set the media used when capturing the story. */
-  media?: Maybe<Scalars['String']['output']>;
+  media?: Maybe<Scalars["String"]["output"]>;
   /** Disallow scrolling in order to take a full page screenshot. */
-  noScroll?: Maybe<Scalars['Boolean']['output']>;
+  noScroll?: Maybe<Scalars["Boolean"]["output"]>;
   /** Reverse CSS animations so snapshots show the end state. */
-  pauseAnimationAtEnd?: Maybe<Scalars['Boolean']['output']>;
+  pauseAnimationAtEnd?: Maybe<Scalars["Boolean"]["output"]>;
   /** Set the `prefers-reduced-motion` media feature when capturing the story. */
-  prefersReducedMotion?: Maybe<Scalars['String']['output']>;
+  prefersReducedMotion?: Maybe<Scalars["String"]["output"]>;
   /** This test only contains representative snapshots. */
-  representativeOnly?: Maybe<Scalars['Boolean']['output']>;
+  representativeOnly?: Maybe<Scalars["Boolean"]["output"]>;
   /** Viewport information. */
   viewport: ViewportInfo;
 };
 
 export enum TestResult {
   /** Checks passed and no baseline was found. */
-  Added = 'ADDED',
+  Added = "ADDED",
   /** At least one comparison had a (user) error. */
-  CaptureError = 'CAPTURE_ERROR',
+  CaptureError = "CAPTURE_ERROR",
   /** Checks passed, but at least one comparison had a visual change. */
-  Changed = 'CHANGED',
+  Changed = "CHANGED",
   /** Checks passed and all snapshots are equal to their baselines. */
-  Equal = 'EQUAL',
+  Equal = "EQUAL",
   /** Checks passed and at least one comparison was fixed. */
-  Fixed = 'FIXED',
+  Fixed = "FIXED",
   /** Currently unused. Here for future use. */
-  Removed = 'REMOVED',
+  Removed = "REMOVED",
   /** This test was skipped. */
-  Skipped = 'SKIPPED',
+  Skipped = "SKIPPED",
   /** At least one comparison had a system error. */
-  SystemError = 'SYSTEM_ERROR'
+  SystemError = "SYSTEM_ERROR",
 }
 
 export enum TestStatus {
   /** The comparison succeeded and the changes have been accepted. */
-  Accepted = 'ACCEPTED',
+  Accepted = "ACCEPTED",
   /** Encountered a Storybook runtime error while testing. */
-  Broken = 'BROKEN',
+  Broken = "BROKEN",
   /** The comparison succeeded and the changes have been denied. */
-  Denied = 'DENIED',
+  Denied = "DENIED",
   /** Encountered a (temporary) system error while testing. */
-  Failed = 'FAILED',
+  Failed = "FAILED",
   /** We are waiting on comparisons. */
-  InProgress = 'IN_PROGRESS',
+  InProgress = "IN_PROGRESS",
   /** All comparisons were visually equal. */
-  Passed = 'PASSED',
+  Passed = "PASSED",
   /** The comparison succeeded with unconfirmed changes. */
-  Pending = 'PENDING'
+  Pending = "PENDING",
 }
 
 export type TestUnreviewableError = UserError & {
-  __typename?: 'TestUnreviewableError';
-  message: Scalars['String']['output'];
+  __typename?: "TestUnreviewableError";
+  message: Scalars["String"]["output"];
   test: Test;
 };
 
 export type UpdateUserPreferencesPayload = {
-  __typename?: 'UpdateUserPreferencesPayload';
+  __typename?: "UpdateUserPreferencesPayload";
   /** The updated preferences, if successful. */
   updatedPreferences?: Maybe<UserPreferences>;
 };
 
 export type User = Node & {
-  __typename?: 'User';
+  __typename?: "User";
   accounts: Array<Account>;
-  avatarUrl?: Maybe<Scalars['URL']['output']>;
+  avatarUrl?: Maybe<Scalars["URL"]["output"]>;
   /** When the entity was first created in Chromatic. */
-  createdAt: Scalars['DateTime']['output'];
+  createdAt: Scalars["DateTime"]["output"];
   /** GraphQL node identifier */
-  id: Scalars['ID']['output'];
-  name: Scalars['String']['output'];
+  id: Scalars["ID"]["output"];
+  name: Scalars["String"]["output"];
   preferences: UserPreferences;
   /** The number of projects this user is a member of. */
-  projectCount: Scalars['Int']['output'];
+  projectCount: Scalars["Int"]["output"];
   projectMembership?: Maybe<ProjectMembership>;
   /** When the entity was last updated or created in Chromatic. */
-  updatedAt: Scalars['DateTime']['output'];
-  username: Scalars['String']['output'];
+  updatedAt: Scalars["DateTime"]["output"];
+  username: Scalars["String"]["output"];
 };
 
-
 export type UserProjectMembershipArgs = {
-  projectId: Scalars['ID']['input'];
+  projectId: Scalars["ID"]["input"];
 };
 
 export type UserError = {
   /** A message describing the error. */
-  message: Scalars['String']['output'];
+  message: Scalars["String"]["output"];
 };
 
 export type UserPreferences = {
-  __typename?: 'UserPreferences';
+  __typename?: "UserPreferences";
   vtaOnboarding: VtaOnboardingPreference;
 };
 
@@ -1406,154 +1394,2325 @@ export type UserPreferencesInput = {
 };
 
 export enum VtaOnboardingPreference {
-  Completed = 'COMPLETED',
-  Dismissed = 'DISMISSED',
-  Unset = 'UNSET'
+  Completed = "COMPLETED",
+  Dismissed = "DISMISSED",
+  Unset = "UNSET",
 }
 
 export type ViewportInfo = {
-  __typename?: 'ViewportInfo';
+  __typename?: "ViewportInfo";
   /** Identifier for this viewport. */
-  id: Scalars['ID']['output'];
+  id: Scalars["ID"]["output"];
   /** Whether this is the default viewport. */
-  isDefault: Scalars['Boolean']['output'];
+  isDefault: Scalars["Boolean"]["output"];
   /** Viewport display name. */
-  name: Scalars['String']['output'];
+  name: Scalars["String"]["output"];
   /** Viewport width in pixels. */
-  width: Scalars['Int']['output'];
+  width: Scalars["Int"]["output"];
 };
 
-export type VisualTestsProjectCountQueryQueryVariables = Exact<{ [key: string]: never; }>;
+export type VisualTestsProjectCountQueryQueryVariables = Exact<{ [key: string]: never }>;
 
+export type VisualTestsProjectCountQueryQuery = {
+  __typename?: "Query";
+  viewer?: {
+    __typename?: "User";
+    projectCount: number;
+    accounts: Array<{ __typename?: "Account"; newProjectUrl?: string | null }>;
+  } | null;
+};
 
-export type VisualTestsProjectCountQueryQuery = { __typename?: 'Query', viewer?: { __typename?: 'User', projectCount: number, accounts: Array<{ __typename?: 'Account', newProjectUrl?: string | null }> } | null };
+export type SelectProjectsQueryQueryVariables = Exact<{ [key: string]: never }>;
 
-export type SelectProjectsQueryQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type SelectProjectsQueryQuery = { __typename?: 'Query', viewer?: { __typename?: 'User', accounts: Array<{ __typename?: 'Account', id: string, name: string, avatarUrl?: string | null, newProjectUrl?: string | null, projects?: Array<{ __typename?: 'Project', id: string, name: string, webUrl: any, lastBuild?: { __typename?: 'AnnouncedBuild', branch: string, number: number } | { __typename?: 'CompletedBuild', branch: string, number: number } | { __typename?: 'PreparedBuild', branch: string, number: number } | { __typename?: 'PublishedBuild', branch: string, number: number } | { __typename?: 'StartedBuild', branch: string, number: number } | null } | null> | null }> } | null };
+export type SelectProjectsQueryQuery = {
+  __typename?: "Query";
+  viewer?: {
+    __typename?: "User";
+    accounts: Array<{
+      __typename?: "Account";
+      id: string;
+      name: string;
+      avatarUrl?: string | null;
+      newProjectUrl?: string | null;
+      projects?: Array<{
+        __typename?: "Project";
+        id: string;
+        name: string;
+        webUrl: any;
+        lastBuild?:
+          | { __typename?: "AnnouncedBuild"; branch: string; number: number }
+          | { __typename?: "CompletedBuild"; branch: string; number: number }
+          | { __typename?: "PreparedBuild"; branch: string; number: number }
+          | { __typename?: "PublishedBuild"; branch: string; number: number }
+          | { __typename?: "StartedBuild"; branch: string; number: number }
+          | null;
+      } | null> | null;
+    }>;
+  } | null;
+};
 
 export type ProjectQueryQueryVariables = Exact<{
-  projectId: Scalars['ID']['input'];
+  projectId: Scalars["ID"]["input"];
 }>;
 
-
-export type ProjectQueryQuery = { __typename?: 'Query', project?: { __typename?: 'Project', id: string, name: string, webUrl: any, lastBuild?: { __typename?: 'AnnouncedBuild', branch: string, number: number } | { __typename?: 'CompletedBuild', branch: string, number: number } | { __typename?: 'PreparedBuild', branch: string, number: number } | { __typename?: 'PublishedBuild', branch: string, number: number } | { __typename?: 'StartedBuild', branch: string, number: number } | null } | null };
+export type ProjectQueryQuery = {
+  __typename?: "Query";
+  project?: {
+    __typename?: "Project";
+    id: string;
+    name: string;
+    webUrl: any;
+    lastBuild?:
+      | { __typename?: "AnnouncedBuild"; branch: string; number: number }
+      | { __typename?: "CompletedBuild"; branch: string; number: number }
+      | { __typename?: "PreparedBuild"; branch: string; number: number }
+      | { __typename?: "PublishedBuild"; branch: string; number: number }
+      | { __typename?: "StartedBuild"; branch: string; number: number }
+      | null;
+  } | null;
+};
 
 export type UpdateUserPreferencesMutationVariables = Exact<{
   input: UserPreferencesInput;
 }>;
 
-
-export type UpdateUserPreferencesMutation = { __typename?: 'Mutation', updateUserPreferences?: { __typename?: 'UpdateUserPreferencesPayload', updatedPreferences?: { __typename?: 'UserPreferences', vtaOnboarding: VtaOnboardingPreference } | null } | null };
+export type UpdateUserPreferencesMutation = {
+  __typename?: "Mutation";
+  updateUserPreferences?: {
+    __typename?: "UpdateUserPreferencesPayload";
+    updatedPreferences?: {
+      __typename?: "UserPreferences";
+      vtaOnboarding: VtaOnboardingPreference;
+    } | null;
+  } | null;
+};
 
 export type AddonVisualTestsBuildQueryVariables = Exact<{
-  projectId: Scalars['ID']['input'];
-  branch: Scalars['String']['input'];
-  gitUserEmailHash: Scalars['String']['input'];
-  repositoryOwnerName?: InputMaybe<Scalars['String']['input']>;
-  storyId: Scalars['String']['input'];
+  projectId: Scalars["ID"]["input"];
+  branch: Scalars["String"]["input"];
+  gitUserEmailHash: Scalars["String"]["input"];
+  repositoryOwnerName?: InputMaybe<Scalars["String"]["input"]>;
+  storyId: Scalars["String"]["input"];
   testStatuses: Array<TestStatus> | TestStatus;
-  selectedBuildId: Scalars['ID']['input'];
-  hasSelectedBuildId: Scalars['Boolean']['input'];
+  selectedBuildId: Scalars["ID"]["input"];
+  hasSelectedBuildId: Scalars["Boolean"]["input"];
 }>;
 
+export type AddonVisualTestsBuildQuery = {
+  __typename?: "Query";
+  project?: {
+    __typename?: "Project";
+    name: string;
+    lastBuildOnBranch?:
+      | ({ __typename?: "AnnouncedBuild" } & {
+          " $fragmentRefs"?: {
+            LastBuildOnBranchBuildFields_AnnouncedBuild_Fragment: LastBuildOnBranchBuildFields_AnnouncedBuild_Fragment;
+            SelectedBuildFields_AnnouncedBuild_Fragment: SelectedBuildFields_AnnouncedBuild_Fragment;
+          };
+        })
+      | ({ __typename?: "CompletedBuild" } & {
+          " $fragmentRefs"?: {
+            LastBuildOnBranchBuildFields_CompletedBuild_Fragment: LastBuildOnBranchBuildFields_CompletedBuild_Fragment;
+            SelectedBuildFields_CompletedBuild_Fragment: SelectedBuildFields_CompletedBuild_Fragment;
+          };
+        })
+      | ({ __typename?: "PreparedBuild" } & {
+          " $fragmentRefs"?: {
+            LastBuildOnBranchBuildFields_PreparedBuild_Fragment: LastBuildOnBranchBuildFields_PreparedBuild_Fragment;
+            SelectedBuildFields_PreparedBuild_Fragment: SelectedBuildFields_PreparedBuild_Fragment;
+          };
+        })
+      | ({ __typename?: "PublishedBuild" } & {
+          " $fragmentRefs"?: {
+            LastBuildOnBranchBuildFields_PublishedBuild_Fragment: LastBuildOnBranchBuildFields_PublishedBuild_Fragment;
+            SelectedBuildFields_PublishedBuild_Fragment: SelectedBuildFields_PublishedBuild_Fragment;
+          };
+        })
+      | ({ __typename?: "StartedBuild" } & {
+          " $fragmentRefs"?: {
+            LastBuildOnBranchBuildFields_StartedBuild_Fragment: LastBuildOnBranchBuildFields_StartedBuild_Fragment;
+            SelectedBuildFields_StartedBuild_Fragment: SelectedBuildFields_StartedBuild_Fragment;
+          };
+        })
+      | null;
+    lastBuild?:
+      | { __typename?: "AnnouncedBuild"; id: string; slug?: string | null; branch: string }
+      | { __typename?: "CompletedBuild"; id: string; slug?: string | null; branch: string }
+      | { __typename?: "PreparedBuild"; id: string; slug?: string | null; branch: string }
+      | { __typename?: "PublishedBuild"; id: string; slug?: string | null; branch: string }
+      | { __typename?: "StartedBuild"; id: string; slug?: string | null; branch: string }
+      | null;
+  } | null;
+  selectedBuild?:
+    | ({ __typename?: "AnnouncedBuild" } & {
+        " $fragmentRefs"?: {
+          SelectedBuildFields_AnnouncedBuild_Fragment: SelectedBuildFields_AnnouncedBuild_Fragment;
+        };
+      })
+    | ({ __typename?: "CompletedBuild" } & {
+        " $fragmentRefs"?: {
+          SelectedBuildFields_CompletedBuild_Fragment: SelectedBuildFields_CompletedBuild_Fragment;
+        };
+      })
+    | ({ __typename?: "PreparedBuild" } & {
+        " $fragmentRefs"?: {
+          SelectedBuildFields_PreparedBuild_Fragment: SelectedBuildFields_PreparedBuild_Fragment;
+        };
+      })
+    | ({ __typename?: "PublishedBuild" } & {
+        " $fragmentRefs"?: {
+          SelectedBuildFields_PublishedBuild_Fragment: SelectedBuildFields_PublishedBuild_Fragment;
+        };
+      })
+    | ({ __typename?: "StartedBuild" } & {
+        " $fragmentRefs"?: {
+          SelectedBuildFields_StartedBuild_Fragment: SelectedBuildFields_StartedBuild_Fragment;
+        };
+      })
+    | null;
+  viewer?: {
+    __typename?: "User";
+    preferences: { __typename?: "UserPreferences"; vtaOnboarding: VtaOnboardingPreference };
+    projectMembership?: { __typename?: "ProjectMembership"; userCanReview: boolean } | null;
+  } | null;
+};
 
-export type AddonVisualTestsBuildQuery = { __typename?: 'Query', project?: { __typename?: 'Project', name: string, lastBuildOnBranch?: (
-      { __typename?: 'AnnouncedBuild' }
-      & { ' $fragmentRefs'?: { 'LastBuildOnBranchBuildFields_AnnouncedBuild_Fragment': LastBuildOnBranchBuildFields_AnnouncedBuild_Fragment;'SelectedBuildFields_AnnouncedBuild_Fragment': SelectedBuildFields_AnnouncedBuild_Fragment } }
-    ) | (
-      { __typename?: 'CompletedBuild' }
-      & { ' $fragmentRefs'?: { 'LastBuildOnBranchBuildFields_CompletedBuild_Fragment': LastBuildOnBranchBuildFields_CompletedBuild_Fragment;'SelectedBuildFields_CompletedBuild_Fragment': SelectedBuildFields_CompletedBuild_Fragment } }
-    ) | (
-      { __typename?: 'PreparedBuild' }
-      & { ' $fragmentRefs'?: { 'LastBuildOnBranchBuildFields_PreparedBuild_Fragment': LastBuildOnBranchBuildFields_PreparedBuild_Fragment;'SelectedBuildFields_PreparedBuild_Fragment': SelectedBuildFields_PreparedBuild_Fragment } }
-    ) | (
-      { __typename?: 'PublishedBuild' }
-      & { ' $fragmentRefs'?: { 'LastBuildOnBranchBuildFields_PublishedBuild_Fragment': LastBuildOnBranchBuildFields_PublishedBuild_Fragment;'SelectedBuildFields_PublishedBuild_Fragment': SelectedBuildFields_PublishedBuild_Fragment } }
-    ) | (
-      { __typename?: 'StartedBuild' }
-      & { ' $fragmentRefs'?: { 'LastBuildOnBranchBuildFields_StartedBuild_Fragment': LastBuildOnBranchBuildFields_StartedBuild_Fragment;'SelectedBuildFields_StartedBuild_Fragment': SelectedBuildFields_StartedBuild_Fragment } }
-    ) | null, lastBuild?: { __typename?: 'AnnouncedBuild', id: string, slug?: string | null, branch: string } | { __typename?: 'CompletedBuild', id: string, slug?: string | null, branch: string } | { __typename?: 'PreparedBuild', id: string, slug?: string | null, branch: string } | { __typename?: 'PublishedBuild', id: string, slug?: string | null, branch: string } | { __typename?: 'StartedBuild', id: string, slug?: string | null, branch: string } | null } | null, selectedBuild?: (
-    { __typename?: 'AnnouncedBuild' }
-    & { ' $fragmentRefs'?: { 'SelectedBuildFields_AnnouncedBuild_Fragment': SelectedBuildFields_AnnouncedBuild_Fragment } }
-  ) | (
-    { __typename?: 'CompletedBuild' }
-    & { ' $fragmentRefs'?: { 'SelectedBuildFields_CompletedBuild_Fragment': SelectedBuildFields_CompletedBuild_Fragment } }
-  ) | (
-    { __typename?: 'PreparedBuild' }
-    & { ' $fragmentRefs'?: { 'SelectedBuildFields_PreparedBuild_Fragment': SelectedBuildFields_PreparedBuild_Fragment } }
-  ) | (
-    { __typename?: 'PublishedBuild' }
-    & { ' $fragmentRefs'?: { 'SelectedBuildFields_PublishedBuild_Fragment': SelectedBuildFields_PublishedBuild_Fragment } }
-  ) | (
-    { __typename?: 'StartedBuild' }
-    & { ' $fragmentRefs'?: { 'SelectedBuildFields_StartedBuild_Fragment': SelectedBuildFields_StartedBuild_Fragment } }
-  ) | null, viewer?: { __typename?: 'User', preferences: { __typename?: 'UserPreferences', vtaOnboarding: VtaOnboardingPreference }, projectMembership?: { __typename?: 'ProjectMembership', userCanReview: boolean } | null } | null };
+type LastBuildOnBranchBuildFields_AnnouncedBuild_Fragment = {
+  __typename: "AnnouncedBuild";
+  id: string;
+  status: BuildStatus;
+  committedAt: any;
+} & { " $fragmentName"?: "LastBuildOnBranchBuildFields_AnnouncedBuild_Fragment" };
 
-type LastBuildOnBranchBuildFields_AnnouncedBuild_Fragment = { __typename: 'AnnouncedBuild', id: string, status: BuildStatus, committedAt: any } & { ' $fragmentName'?: 'LastBuildOnBranchBuildFields_AnnouncedBuild_Fragment' };
+type LastBuildOnBranchBuildFields_CompletedBuild_Fragment = {
+  __typename: "CompletedBuild";
+  result: BuildResult;
+  id: string;
+  status: BuildStatus;
+  committedAt: any;
+  testsForStatus?: {
+    __typename?: "CompletedBuildTestConnection";
+    nodes: Array<
+      { __typename?: "Test" } & {
+        " $fragmentRefs"?: { StatusTestFieldsFragment: StatusTestFieldsFragment };
+      }
+    >;
+  } | null;
+  testsForStory?: {
+    __typename?: "CompletedBuildTestConnection";
+    nodes: Array<
+      { __typename?: "Test" } & {
+        " $fragmentRefs"?: {
+          LastBuildOnBranchTestFieldsFragment: LastBuildOnBranchTestFieldsFragment;
+        };
+      }
+    >;
+  } | null;
+} & { " $fragmentName"?: "LastBuildOnBranchBuildFields_CompletedBuild_Fragment" };
 
-type LastBuildOnBranchBuildFields_CompletedBuild_Fragment = { __typename: 'CompletedBuild', result: BuildResult, id: string, status: BuildStatus, committedAt: any, testsForStatus?: { __typename?: 'CompletedBuildTestConnection', nodes: Array<(
-      { __typename?: 'Test' }
-      & { ' $fragmentRefs'?: { 'StatusTestFieldsFragment': StatusTestFieldsFragment } }
-    )> } | null, testsForStory?: { __typename?: 'CompletedBuildTestConnection', nodes: Array<(
-      { __typename?: 'Test' }
-      & { ' $fragmentRefs'?: { 'LastBuildOnBranchTestFieldsFragment': LastBuildOnBranchTestFieldsFragment } }
-    )> } | null } & { ' $fragmentName'?: 'LastBuildOnBranchBuildFields_CompletedBuild_Fragment' };
+type LastBuildOnBranchBuildFields_PreparedBuild_Fragment = {
+  __typename: "PreparedBuild";
+  id: string;
+  status: BuildStatus;
+  committedAt: any;
+} & { " $fragmentName"?: "LastBuildOnBranchBuildFields_PreparedBuild_Fragment" };
 
-type LastBuildOnBranchBuildFields_PreparedBuild_Fragment = { __typename: 'PreparedBuild', id: string, status: BuildStatus, committedAt: any } & { ' $fragmentName'?: 'LastBuildOnBranchBuildFields_PreparedBuild_Fragment' };
+type LastBuildOnBranchBuildFields_PublishedBuild_Fragment = {
+  __typename: "PublishedBuild";
+  id: string;
+  status: BuildStatus;
+  committedAt: any;
+} & { " $fragmentName"?: "LastBuildOnBranchBuildFields_PublishedBuild_Fragment" };
 
-type LastBuildOnBranchBuildFields_PublishedBuild_Fragment = { __typename: 'PublishedBuild', id: string, status: BuildStatus, committedAt: any } & { ' $fragmentName'?: 'LastBuildOnBranchBuildFields_PublishedBuild_Fragment' };
+type LastBuildOnBranchBuildFields_StartedBuild_Fragment = {
+  __typename: "StartedBuild";
+  id: string;
+  status: BuildStatus;
+  committedAt: any;
+  testsForStatus?: {
+    __typename?: "StartedBuildTestConnection";
+    nodes: Array<
+      { __typename?: "Test" } & {
+        " $fragmentRefs"?: { StatusTestFieldsFragment: StatusTestFieldsFragment };
+      }
+    >;
+  } | null;
+  testsForStory?: {
+    __typename?: "StartedBuildTestConnection";
+    nodes: Array<
+      { __typename?: "Test" } & {
+        " $fragmentRefs"?: {
+          LastBuildOnBranchTestFieldsFragment: LastBuildOnBranchTestFieldsFragment;
+        };
+      }
+    >;
+  } | null;
+} & { " $fragmentName"?: "LastBuildOnBranchBuildFields_StartedBuild_Fragment" };
 
-type LastBuildOnBranchBuildFields_StartedBuild_Fragment = { __typename: 'StartedBuild', id: string, status: BuildStatus, committedAt: any, testsForStatus?: { __typename?: 'StartedBuildTestConnection', nodes: Array<(
-      { __typename?: 'Test' }
-      & { ' $fragmentRefs'?: { 'StatusTestFieldsFragment': StatusTestFieldsFragment } }
-    )> } | null, testsForStory?: { __typename?: 'StartedBuildTestConnection', nodes: Array<(
-      { __typename?: 'Test' }
-      & { ' $fragmentRefs'?: { 'LastBuildOnBranchTestFieldsFragment': LastBuildOnBranchTestFieldsFragment } }
-    )> } | null } & { ' $fragmentName'?: 'LastBuildOnBranchBuildFields_StartedBuild_Fragment' };
+export type LastBuildOnBranchBuildFieldsFragment =
+  | LastBuildOnBranchBuildFields_AnnouncedBuild_Fragment
+  | LastBuildOnBranchBuildFields_CompletedBuild_Fragment
+  | LastBuildOnBranchBuildFields_PreparedBuild_Fragment
+  | LastBuildOnBranchBuildFields_PublishedBuild_Fragment
+  | LastBuildOnBranchBuildFields_StartedBuild_Fragment;
 
-export type LastBuildOnBranchBuildFieldsFragment = LastBuildOnBranchBuildFields_AnnouncedBuild_Fragment | LastBuildOnBranchBuildFields_CompletedBuild_Fragment | LastBuildOnBranchBuildFields_PreparedBuild_Fragment | LastBuildOnBranchBuildFields_PublishedBuild_Fragment | LastBuildOnBranchBuildFields_StartedBuild_Fragment;
+type SelectedBuildFields_AnnouncedBuild_Fragment = {
+  __typename: "AnnouncedBuild";
+  id: string;
+  number: number;
+  branch: string;
+  commit: string;
+  committedAt: any;
+  uncommittedHash?: string | null;
+  status: BuildStatus;
+} & { " $fragmentName"?: "SelectedBuildFields_AnnouncedBuild_Fragment" };
 
-type SelectedBuildFields_AnnouncedBuild_Fragment = { __typename: 'AnnouncedBuild', id: string, number: number, branch: string, commit: string, committedAt: any, uncommittedHash?: string | null, status: BuildStatus } & { ' $fragmentName'?: 'SelectedBuildFields_AnnouncedBuild_Fragment' };
+type SelectedBuildFields_CompletedBuild_Fragment = {
+  __typename: "CompletedBuild";
+  startedAt: any;
+  id: string;
+  number: number;
+  branch: string;
+  commit: string;
+  committedAt: any;
+  uncommittedHash?: string | null;
+  status: BuildStatus;
+  testsForStory?: {
+    __typename?: "CompletedBuildTestConnection";
+    nodes: Array<
+      { __typename?: "Test" } & {
+        " $fragmentRefs"?: { StoryTestFieldsFragment: StoryTestFieldsFragment };
+      }
+    >;
+  } | null;
+} & { " $fragmentName"?: "SelectedBuildFields_CompletedBuild_Fragment" };
 
-type SelectedBuildFields_CompletedBuild_Fragment = { __typename: 'CompletedBuild', startedAt: any, id: string, number: number, branch: string, commit: string, committedAt: any, uncommittedHash?: string | null, status: BuildStatus, testsForStory?: { __typename?: 'CompletedBuildTestConnection', nodes: Array<(
-      { __typename?: 'Test' }
-      & { ' $fragmentRefs'?: { 'StoryTestFieldsFragment': StoryTestFieldsFragment } }
-    )> } | null } & { ' $fragmentName'?: 'SelectedBuildFields_CompletedBuild_Fragment' };
+type SelectedBuildFields_PreparedBuild_Fragment = {
+  __typename: "PreparedBuild";
+  id: string;
+  number: number;
+  branch: string;
+  commit: string;
+  committedAt: any;
+  uncommittedHash?: string | null;
+  status: BuildStatus;
+} & { " $fragmentName"?: "SelectedBuildFields_PreparedBuild_Fragment" };
 
-type SelectedBuildFields_PreparedBuild_Fragment = { __typename: 'PreparedBuild', id: string, number: number, branch: string, commit: string, committedAt: any, uncommittedHash?: string | null, status: BuildStatus } & { ' $fragmentName'?: 'SelectedBuildFields_PreparedBuild_Fragment' };
+type SelectedBuildFields_PublishedBuild_Fragment = {
+  __typename: "PublishedBuild";
+  id: string;
+  number: number;
+  branch: string;
+  commit: string;
+  committedAt: any;
+  uncommittedHash?: string | null;
+  status: BuildStatus;
+} & { " $fragmentName"?: "SelectedBuildFields_PublishedBuild_Fragment" };
 
-type SelectedBuildFields_PublishedBuild_Fragment = { __typename: 'PublishedBuild', id: string, number: number, branch: string, commit: string, committedAt: any, uncommittedHash?: string | null, status: BuildStatus } & { ' $fragmentName'?: 'SelectedBuildFields_PublishedBuild_Fragment' };
+type SelectedBuildFields_StartedBuild_Fragment = {
+  __typename: "StartedBuild";
+  startedAt: any;
+  id: string;
+  number: number;
+  branch: string;
+  commit: string;
+  committedAt: any;
+  uncommittedHash?: string | null;
+  status: BuildStatus;
+  testsForStory?: {
+    __typename?: "StartedBuildTestConnection";
+    nodes: Array<
+      { __typename?: "Test" } & {
+        " $fragmentRefs"?: { StoryTestFieldsFragment: StoryTestFieldsFragment };
+      }
+    >;
+  } | null;
+} & { " $fragmentName"?: "SelectedBuildFields_StartedBuild_Fragment" };
 
-type SelectedBuildFields_StartedBuild_Fragment = { __typename: 'StartedBuild', startedAt: any, id: string, number: number, branch: string, commit: string, committedAt: any, uncommittedHash?: string | null, status: BuildStatus, testsForStory?: { __typename?: 'StartedBuildTestConnection', nodes: Array<(
-      { __typename?: 'Test' }
-      & { ' $fragmentRefs'?: { 'StoryTestFieldsFragment': StoryTestFieldsFragment } }
-    )> } | null } & { ' $fragmentName'?: 'SelectedBuildFields_StartedBuild_Fragment' };
+export type SelectedBuildFieldsFragment =
+  | SelectedBuildFields_AnnouncedBuild_Fragment
+  | SelectedBuildFields_CompletedBuild_Fragment
+  | SelectedBuildFields_PreparedBuild_Fragment
+  | SelectedBuildFields_PublishedBuild_Fragment
+  | SelectedBuildFields_StartedBuild_Fragment;
 
-export type SelectedBuildFieldsFragment = SelectedBuildFields_AnnouncedBuild_Fragment | SelectedBuildFields_CompletedBuild_Fragment | SelectedBuildFields_PreparedBuild_Fragment | SelectedBuildFields_PublishedBuild_Fragment | SelectedBuildFields_StartedBuild_Fragment;
+export type StatusTestFieldsFragment = {
+  __typename?: "Test";
+  id: string;
+  status: TestStatus;
+  result?: TestResult | null;
+  story?: { __typename?: "Story"; storyId: string } | null;
+} & { " $fragmentName"?: "StatusTestFieldsFragment" };
 
-export type StatusTestFieldsFragment = { __typename?: 'Test', id: string, status: TestStatus, result?: TestResult | null, story?: { __typename?: 'Story', storyId: string } | null } & { ' $fragmentName'?: 'StatusTestFieldsFragment' };
+export type LastBuildOnBranchTestFieldsFragment = {
+  __typename?: "Test";
+  status: TestStatus;
+  result?: TestResult | null;
+} & { " $fragmentName"?: "LastBuildOnBranchTestFieldsFragment" };
 
-export type LastBuildOnBranchTestFieldsFragment = { __typename?: 'Test', status: TestStatus, result?: TestResult | null } & { ' $fragmentName'?: 'LastBuildOnBranchTestFieldsFragment' };
-
-export type StoryTestFieldsFragment = { __typename?: 'Test', id: string, status: TestStatus, result?: TestResult | null, webUrl: any, comparisons: Array<{ __typename?: 'TestComparison', id: string, result?: ComparisonResult | null, browser: { __typename?: 'BrowserInfo', id: string, key: Browser, name: string, version: string }, captureDiff?: { __typename?: 'CaptureDiff', diffImage?: { __typename?: 'CaptureOverlayImage', imageUrl: any, imageWidth: number } | null, focusImage?: { __typename?: 'CaptureOverlayImage', imageUrl: any, imageWidth: number } | null } | null, headCapture?: { __typename?: 'Capture', captureImage?: { __typename?: 'CaptureImage', backgroundColor?: string | null, imageUrl: any, imageWidth: number, thumbnailUrl: any } | null, captureError?: { __typename?: 'CaptureErrorComponentOffPage', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorFailedJS', error: any, kind: CaptureErrorKind } | { __typename?: 'CaptureErrorImageTooLarge', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorInteractionFailure', error: any, kind: CaptureErrorKind } | { __typename?: 'CaptureErrorJSError', error: any, kind: CaptureErrorKind } | { __typename?: 'CaptureErrorNavigationTimeout', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorNoJS', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorStoryMissing', kind: CaptureErrorKind } | null } | null, baseCapture?: { __typename?: 'Capture', captureImage?: { __typename?: 'CaptureImage', imageUrl: any, imageWidth: number } | null } | null }>, mode: { __typename?: 'TestMode', name: string, globals: any }, story?: { __typename?: 'Story', storyId: string, name: string, component?: { __typename?: 'Component', name: string } | null } | null } & { ' $fragmentName'?: 'StoryTestFieldsFragment' };
+export type StoryTestFieldsFragment = {
+  __typename?: "Test";
+  id: string;
+  status: TestStatus;
+  result?: TestResult | null;
+  webUrl: any;
+  comparisons: Array<{
+    __typename?: "TestComparison";
+    id: string;
+    result?: ComparisonResult | null;
+    browser: {
+      __typename?: "BrowserInfo";
+      id: string;
+      key: Browser;
+      name: string;
+      version: string;
+    };
+    captureDiff?: {
+      __typename?: "CaptureDiff";
+      diffImage?: { __typename?: "CaptureOverlayImage"; imageUrl: any; imageWidth: number } | null;
+      focusImage?: { __typename?: "CaptureOverlayImage"; imageUrl: any; imageWidth: number } | null;
+    } | null;
+    headCapture?: {
+      __typename?: "Capture";
+      captureImage?: {
+        __typename?: "CaptureImage";
+        backgroundColor?: string | null;
+        imageUrl: any;
+        imageWidth: number;
+        thumbnailUrl: any;
+      } | null;
+      captureError?:
+        | { __typename?: "CaptureErrorComponentOffPage"; kind: CaptureErrorKind }
+        | { __typename?: "CaptureErrorFailedJS"; error: any; kind: CaptureErrorKind }
+        | { __typename?: "CaptureErrorImageTooLarge"; kind: CaptureErrorKind }
+        | { __typename?: "CaptureErrorInteractionFailure"; error: any; kind: CaptureErrorKind }
+        | { __typename?: "CaptureErrorJSError"; error: any; kind: CaptureErrorKind }
+        | { __typename?: "CaptureErrorNavigationTimeout"; kind: CaptureErrorKind }
+        | { __typename?: "CaptureErrorNoJS"; kind: CaptureErrorKind }
+        | { __typename?: "CaptureErrorStoryMissing"; kind: CaptureErrorKind }
+        | null;
+    } | null;
+    baseCapture?: {
+      __typename?: "Capture";
+      captureImage?: { __typename?: "CaptureImage"; imageUrl: any; imageWidth: number } | null;
+    } | null;
+  }>;
+  mode: { __typename?: "TestMode"; name: string; globals: any };
+  story?: {
+    __typename?: "Story";
+    storyId: string;
+    name: string;
+    component?: { __typename?: "Component"; name: string } | null;
+  } | null;
+} & { " $fragmentName"?: "StoryTestFieldsFragment" };
 
 export type ReviewTestMutationVariables = Exact<{
   input: ReviewTestInput;
 }>;
 
+export type ReviewTestMutation = {
+  __typename?: "Mutation";
+  reviewTest?: {
+    __typename?: "ReviewTestPayload";
+    updatedTests?: Array<{ __typename?: "Test"; id: string; status: TestStatus }> | null;
+    userErrors: Array<
+      | {
+          __typename: "BuildSupersededError";
+          message: string;
+          build:
+            | { __typename?: "AnnouncedBuild"; id: string }
+            | { __typename?: "CompletedBuild"; id: string }
+            | { __typename?: "PreparedBuild"; id: string }
+            | { __typename?: "PublishedBuild"; id: string }
+            | { __typename?: "StartedBuild"; id: string };
+        }
+      | { __typename: "TestNotFoundError"; message: string }
+      | {
+          __typename: "TestUnreviewableError";
+          message: string;
+          test: { __typename?: "Test"; id: string };
+        }
+    >;
+  } | null;
+};
 
-export type ReviewTestMutation = { __typename?: 'Mutation', reviewTest?: { __typename?: 'ReviewTestPayload', updatedTests?: Array<{ __typename?: 'Test', id: string, status: TestStatus }> | null, userErrors: Array<{ __typename: 'BuildSupersededError', message: string, build: { __typename?: 'AnnouncedBuild', id: string } | { __typename?: 'CompletedBuild', id: string } | { __typename?: 'PreparedBuild', id: string } | { __typename?: 'PublishedBuild', id: string } | { __typename?: 'StartedBuild', id: string } } | { __typename: 'TestNotFoundError', message: string } | { __typename: 'TestUnreviewableError', message: string, test: { __typename?: 'Test', id: string } }> } | null };
-
-export const StatusTestFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"StatusTestFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Test"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","name":{"kind":"Name","value":"story"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"storyId"}}]}}]}}]} as unknown as DocumentNode<StatusTestFieldsFragment, unknown>;
-export const LastBuildOnBranchTestFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"LastBuildOnBranchTestFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Test"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"result"}}]}}]} as unknown as DocumentNode<LastBuildOnBranchTestFieldsFragment, unknown>;
-export const LastBuildOnBranchBuildFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"LastBuildOnBranchBuildFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Build"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"committedAt"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"StartedBuild"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"testsForStatus"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"1000"}},{"kind":"Argument","name":{"kind":"Name","value":"statuses"},"value":{"kind":"Variable","name":{"kind":"Name","value":"testStatuses"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"StatusTestFields"}}]}}]}},{"kind":"Field","alias":{"kind":"Name","value":"testsForStory"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"storyId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"storyId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"LastBuildOnBranchTestFields"}}]}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CompletedBuild"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","alias":{"kind":"Name","value":"testsForStatus"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"1000"}},{"kind":"Argument","name":{"kind":"Name","value":"statuses"},"value":{"kind":"Variable","name":{"kind":"Name","value":"testStatuses"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"StatusTestFields"}}]}}]}},{"kind":"Field","alias":{"kind":"Name","value":"testsForStory"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"storyId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"storyId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"LastBuildOnBranchTestFields"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"StatusTestFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Test"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","name":{"kind":"Name","value":"story"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"storyId"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"LastBuildOnBranchTestFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Test"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"result"}}]}}]} as unknown as DocumentNode<LastBuildOnBranchBuildFieldsFragment, unknown>;
-export const StoryTestFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"StoryTestFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Test"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","name":{"kind":"Name","value":"webUrl"}},{"kind":"Field","name":{"kind":"Name","value":"comparisons"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","name":{"kind":"Name","value":"browser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"version"}}]}},{"kind":"Field","name":{"kind":"Name","value":"captureDiff"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"diffImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}}]}},{"kind":"Field","name":{"kind":"Name","value":"focusImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"headCapture"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"captureImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"backgroundColor"}},{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}},{"kind":"Field","name":{"kind":"Name","value":"thumbnailUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"captureError"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"kind"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CaptureErrorInteractionFailure"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"error"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CaptureErrorJSError"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"error"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CaptureErrorFailedJS"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"baseCapture"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"captureImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"mode"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"globals"}}]}},{"kind":"Field","name":{"kind":"Name","value":"story"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"storyId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"component"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<StoryTestFieldsFragment, unknown>;
-export const SelectedBuildFieldsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SelectedBuildFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Build"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"number"}},{"kind":"Field","name":{"kind":"Name","value":"branch"}},{"kind":"Field","name":{"kind":"Name","value":"commit"}},{"kind":"Field","name":{"kind":"Name","value":"committedAt"}},{"kind":"Field","name":{"kind":"Name","value":"uncommittedHash"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"StartedBuild"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"startedAt"}},{"kind":"Field","alias":{"kind":"Name","value":"testsForStory"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"storyId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"storyId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"StoryTestFields"}}]}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CompletedBuild"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"startedAt"}},{"kind":"Field","alias":{"kind":"Name","value":"testsForStory"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"storyId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"storyId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"StoryTestFields"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"StoryTestFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Test"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","name":{"kind":"Name","value":"webUrl"}},{"kind":"Field","name":{"kind":"Name","value":"comparisons"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","name":{"kind":"Name","value":"browser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"version"}}]}},{"kind":"Field","name":{"kind":"Name","value":"captureDiff"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"diffImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}}]}},{"kind":"Field","name":{"kind":"Name","value":"focusImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"headCapture"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"captureImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"backgroundColor"}},{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}},{"kind":"Field","name":{"kind":"Name","value":"thumbnailUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"captureError"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"kind"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CaptureErrorInteractionFailure"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"error"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CaptureErrorJSError"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"error"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CaptureErrorFailedJS"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"baseCapture"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"captureImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"mode"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"globals"}}]}},{"kind":"Field","name":{"kind":"Name","value":"story"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"storyId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"component"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<SelectedBuildFieldsFragment, unknown>;
-export const VisualTestsProjectCountQueryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"VisualTestsProjectCountQuery"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"viewer"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"projectCount"}},{"kind":"Field","name":{"kind":"Name","value":"accounts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"newProjectUrl"}}]}}]}}]}}]} as unknown as DocumentNode<VisualTestsProjectCountQueryQuery, VisualTestsProjectCountQueryQueryVariables>;
-export const SelectProjectsQueryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"SelectProjectsQuery"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"viewer"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"accounts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"avatarUrl"}},{"kind":"Field","name":{"kind":"Name","value":"newProjectUrl"}},{"kind":"Field","name":{"kind":"Name","value":"projects"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"webUrl"}},{"kind":"Field","name":{"kind":"Name","value":"lastBuild"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"branch"}},{"kind":"Field","name":{"kind":"Name","value":"number"}}]}}]}}]}}]}}]}}]} as unknown as DocumentNode<SelectProjectsQueryQuery, SelectProjectsQueryQueryVariables>;
-export const ProjectQueryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ProjectQuery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"projectId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"project"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"projectId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"webUrl"}},{"kind":"Field","name":{"kind":"Name","value":"lastBuild"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"branch"}},{"kind":"Field","name":{"kind":"Name","value":"number"}}]}}]}}]}}]} as unknown as DocumentNode<ProjectQueryQuery, ProjectQueryQueryVariables>;
-export const UpdateUserPreferencesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateUserPreferences"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UserPreferencesInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateUserPreferences"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updatedPreferences"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"vtaOnboarding"}}]}}]}}]}}]} as unknown as DocumentNode<UpdateUserPreferencesMutation, UpdateUserPreferencesMutationVariables>;
-export const AddonVisualTestsBuildDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"AddonVisualTestsBuild"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"projectId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"branch"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"gitUserEmailHash"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"repositoryOwnerName"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"storyId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"testStatuses"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TestStatus"}}}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"selectedBuildId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"hasSelectedBuildId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"project"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"projectId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","alias":{"kind":"Name","value":"lastBuildOnBranch"},"name":{"kind":"Name","value":"lastBuild"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"branches"},"value":{"kind":"ListValue","values":[{"kind":"Variable","name":{"kind":"Name","value":"branch"}}]}},{"kind":"Argument","name":{"kind":"Name","value":"repositoryOwnerName"},"value":{"kind":"Variable","name":{"kind":"Name","value":"repositoryOwnerName"}}},{"kind":"Argument","name":{"kind":"Name","value":"localBuilds"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"localBuildEmailHash"},"value":{"kind":"Variable","name":{"kind":"Name","value":"gitUserEmailHash"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"LastBuildOnBranchBuildFields"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"SelectedBuildFields"},"directives":[{"kind":"Directive","name":{"kind":"Name","value":"skip"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"if"},"value":{"kind":"Variable","name":{"kind":"Name","value":"hasSelectedBuildId"}}}]}]}]}},{"kind":"Field","name":{"kind":"Name","value":"lastBuild"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}},{"kind":"Field","name":{"kind":"Name","value":"branch"}}]}}]}},{"kind":"Field","alias":{"kind":"Name","value":"selectedBuild"},"name":{"kind":"Name","value":"build"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"selectedBuildId"}}}],"directives":[{"kind":"Directive","name":{"kind":"Name","value":"include"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"if"},"value":{"kind":"Variable","name":{"kind":"Name","value":"hasSelectedBuildId"}}}]}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"SelectedBuildFields"}}]}},{"kind":"Field","name":{"kind":"Name","value":"viewer"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"preferences"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"vtaOnboarding"}}]}},{"kind":"Field","name":{"kind":"Name","value":"projectMembership"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"projectId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"projectId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"userCanReview"},"name":{"kind":"Name","value":"meetsAccessLevel"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"minimumAccessLevel"},"value":{"kind":"EnumValue","value":"REVIEWER"}}]}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"StatusTestFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Test"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","name":{"kind":"Name","value":"story"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"storyId"}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"LastBuildOnBranchTestFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Test"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"result"}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"StoryTestFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Test"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","name":{"kind":"Name","value":"webUrl"}},{"kind":"Field","name":{"kind":"Name","value":"comparisons"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","name":{"kind":"Name","value":"browser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"version"}}]}},{"kind":"Field","name":{"kind":"Name","value":"captureDiff"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"diffImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}}]}},{"kind":"Field","name":{"kind":"Name","value":"focusImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"headCapture"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"captureImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"backgroundColor"}},{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}},{"kind":"Field","name":{"kind":"Name","value":"thumbnailUrl"}}]}},{"kind":"Field","name":{"kind":"Name","value":"captureError"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"kind"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CaptureErrorInteractionFailure"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"error"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CaptureErrorJSError"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"error"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CaptureErrorFailedJS"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"baseCapture"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"captureImage"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"signed"},"value":{"kind":"BooleanValue","value":true}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"imageWidth"}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"mode"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"globals"}}]}},{"kind":"Field","name":{"kind":"Name","value":"story"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"storyId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"component"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"LastBuildOnBranchBuildFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Build"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"committedAt"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"StartedBuild"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"testsForStatus"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"1000"}},{"kind":"Argument","name":{"kind":"Name","value":"statuses"},"value":{"kind":"Variable","name":{"kind":"Name","value":"testStatuses"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"StatusTestFields"}}]}}]}},{"kind":"Field","alias":{"kind":"Name","value":"testsForStory"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"storyId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"storyId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"LastBuildOnBranchTestFields"}}]}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CompletedBuild"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"result"}},{"kind":"Field","alias":{"kind":"Name","value":"testsForStatus"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"IntValue","value":"1000"}},{"kind":"Argument","name":{"kind":"Name","value":"statuses"},"value":{"kind":"Variable","name":{"kind":"Name","value":"testStatuses"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"StatusTestFields"}}]}}]}},{"kind":"Field","alias":{"kind":"Name","value":"testsForStory"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"storyId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"storyId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"LastBuildOnBranchTestFields"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"SelectedBuildFields"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Build"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"number"}},{"kind":"Field","name":{"kind":"Name","value":"branch"}},{"kind":"Field","name":{"kind":"Name","value":"commit"}},{"kind":"Field","name":{"kind":"Name","value":"committedAt"}},{"kind":"Field","name":{"kind":"Name","value":"uncommittedHash"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"StartedBuild"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"startedAt"}},{"kind":"Field","alias":{"kind":"Name","value":"testsForStory"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"storyId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"storyId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"StoryTestFields"}}]}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"CompletedBuild"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"startedAt"}},{"kind":"Field","alias":{"kind":"Name","value":"testsForStory"},"name":{"kind":"Name","value":"tests"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"storyId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"storyId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"StoryTestFields"}}]}}]}}]}}]}}]} as unknown as DocumentNode<AddonVisualTestsBuildQuery, AddonVisualTestsBuildQueryVariables>;
-export const ReviewTestDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ReviewTest"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ReviewTestInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"reviewTest"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updatedTests"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}}]}},{"kind":"Field","name":{"kind":"Name","value":"userErrors"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"UserError"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"Field","name":{"kind":"Name","value":"message"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"BuildSupersededError"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"build"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"TestUnreviewableError"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"test"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]}}]}}]}}]} as unknown as DocumentNode<ReviewTestMutation, ReviewTestMutationVariables>;
+export const StatusTestFieldsFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StatusTestFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Test" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "result" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "story" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "storyId" } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<StatusTestFieldsFragment, unknown>;
+export const LastBuildOnBranchTestFieldsFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "LastBuildOnBranchTestFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Test" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "result" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<LastBuildOnBranchTestFieldsFragment, unknown>;
+export const LastBuildOnBranchBuildFieldsFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "LastBuildOnBranchBuildFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Build" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "committedAt" } },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "StartedBuild" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStatus" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "IntValue", value: "1000" },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "statuses" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "testStatuses" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "StatusTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStory" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "storyId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "storyId" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "LastBuildOnBranchTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "CompletedBuild" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "result" } },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStatus" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "IntValue", value: "1000" },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "statuses" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "testStatuses" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "StatusTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStory" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "storyId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "storyId" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "LastBuildOnBranchTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StatusTestFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Test" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "result" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "story" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "storyId" } }],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "LastBuildOnBranchTestFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Test" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "result" } },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<LastBuildOnBranchBuildFieldsFragment, unknown>;
+export const StoryTestFieldsFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StoryTestFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Test" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "result" } },
+          { kind: "Field", name: { kind: "Name", value: "webUrl" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "comparisons" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                { kind: "Field", name: { kind: "Name", value: "result" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "browser" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "key" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                      { kind: "Field", name: { kind: "Name", value: "version" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "captureDiff" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "diffImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "focusImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "headCapture" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "captureImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "backgroundColor" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                            { kind: "Field", name: { kind: "Name", value: "thumbnailUrl" } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "captureError" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "kind" } },
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: {
+                                kind: "NamedType",
+                                name: { kind: "Name", value: "CaptureErrorInteractionFailure" },
+                              },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "error" } },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: {
+                                kind: "NamedType",
+                                name: { kind: "Name", value: "CaptureErrorJSError" },
+                              },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "error" } },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: {
+                                kind: "NamedType",
+                                name: { kind: "Name", value: "CaptureErrorFailedJS" },
+                              },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "error" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "baseCapture" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "captureImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "mode" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                { kind: "Field", name: { kind: "Name", value: "globals" } },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "story" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "storyId" } },
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "component" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "name" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<StoryTestFieldsFragment, unknown>;
+export const SelectedBuildFieldsFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "SelectedBuildFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Build" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "number" } },
+          { kind: "Field", name: { kind: "Name", value: "branch" } },
+          { kind: "Field", name: { kind: "Name", value: "commit" } },
+          { kind: "Field", name: { kind: "Name", value: "committedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "uncommittedHash" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "StartedBuild" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "startedAt" } },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStory" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "storyId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "storyId" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "StoryTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "CompletedBuild" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "startedAt" } },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStory" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "storyId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "storyId" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "StoryTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StoryTestFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Test" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "result" } },
+          { kind: "Field", name: { kind: "Name", value: "webUrl" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "comparisons" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                { kind: "Field", name: { kind: "Name", value: "result" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "browser" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "key" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                      { kind: "Field", name: { kind: "Name", value: "version" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "captureDiff" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "diffImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "focusImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "headCapture" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "captureImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "backgroundColor" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                            { kind: "Field", name: { kind: "Name", value: "thumbnailUrl" } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "captureError" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "kind" } },
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: {
+                                kind: "NamedType",
+                                name: { kind: "Name", value: "CaptureErrorInteractionFailure" },
+                              },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "error" } },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: {
+                                kind: "NamedType",
+                                name: { kind: "Name", value: "CaptureErrorJSError" },
+                              },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "error" } },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: {
+                                kind: "NamedType",
+                                name: { kind: "Name", value: "CaptureErrorFailedJS" },
+                              },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "error" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "baseCapture" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "captureImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "mode" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                { kind: "Field", name: { kind: "Name", value: "globals" } },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "story" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "storyId" } },
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "component" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "name" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<SelectedBuildFieldsFragment, unknown>;
+export const VisualTestsProjectCountQueryDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "VisualTestsProjectCountQuery" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "viewer" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "projectCount" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "accounts" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "newProjectUrl" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  VisualTestsProjectCountQueryQuery,
+  VisualTestsProjectCountQueryQueryVariables
+>;
+export const SelectProjectsQueryDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "SelectProjectsQuery" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "viewer" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "accounts" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                      { kind: "Field", name: { kind: "Name", value: "avatarUrl" } },
+                      { kind: "Field", name: { kind: "Name", value: "newProjectUrl" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "projects" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                            { kind: "Field", name: { kind: "Name", value: "webUrl" } },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "lastBuild" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "branch" } },
+                                  { kind: "Field", name: { kind: "Name", value: "number" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<SelectProjectsQueryQuery, SelectProjectsQueryQueryVariables>;
+export const ProjectQueryDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "ProjectQuery" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "projectId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "project" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "projectId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                { kind: "Field", name: { kind: "Name", value: "webUrl" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "lastBuild" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "branch" } },
+                      { kind: "Field", name: { kind: "Name", value: "number" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ProjectQueryQuery, ProjectQueryQueryVariables>;
+export const UpdateUserPreferencesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "UpdateUserPreferences" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "UserPreferencesInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateUserPreferences" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "updatedPreferences" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "vtaOnboarding" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<UpdateUserPreferencesMutation, UpdateUserPreferencesMutationVariables>;
+export const AddonVisualTestsBuildDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "AddonVisualTestsBuild" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "projectId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "branch" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "gitUserEmailHash" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "repositoryOwnerName" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "storyId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "testStatuses" } },
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: {
+                kind: "NonNullType",
+                type: { kind: "NamedType", name: { kind: "Name", value: "TestStatus" } },
+              },
+            },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "selectedBuildId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "hasSelectedBuildId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "project" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "projectId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "lastBuildOnBranch" },
+                  name: { kind: "Name", value: "lastBuild" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "branches" },
+                      value: {
+                        kind: "ListValue",
+                        values: [{ kind: "Variable", name: { kind: "Name", value: "branch" } }],
+                      },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "repositoryOwnerName" },
+                      value: {
+                        kind: "Variable",
+                        name: { kind: "Name", value: "repositoryOwnerName" },
+                      },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "localBuilds" },
+                      value: {
+                        kind: "ObjectValue",
+                        fields: [
+                          {
+                            kind: "ObjectField",
+                            name: { kind: "Name", value: "localBuildEmailHash" },
+                            value: {
+                              kind: "Variable",
+                              name: { kind: "Name", value: "gitUserEmailHash" },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "FragmentSpread",
+                        name: { kind: "Name", value: "LastBuildOnBranchBuildFields" },
+                      },
+                      {
+                        kind: "FragmentSpread",
+                        name: { kind: "Name", value: "SelectedBuildFields" },
+                        directives: [
+                          {
+                            kind: "Directive",
+                            name: { kind: "Name", value: "skip" },
+                            arguments: [
+                              {
+                                kind: "Argument",
+                                name: { kind: "Name", value: "if" },
+                                value: {
+                                  kind: "Variable",
+                                  name: { kind: "Name", value: "hasSelectedBuildId" },
+                                },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "lastBuild" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "slug" } },
+                      { kind: "Field", name: { kind: "Name", value: "branch" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            alias: { kind: "Name", value: "selectedBuild" },
+            name: { kind: "Name", value: "build" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "selectedBuildId" } },
+              },
+            ],
+            directives: [
+              {
+                kind: "Directive",
+                name: { kind: "Name", value: "include" },
+                arguments: [
+                  {
+                    kind: "Argument",
+                    name: { kind: "Name", value: "if" },
+                    value: {
+                      kind: "Variable",
+                      name: { kind: "Name", value: "hasSelectedBuildId" },
+                    },
+                  },
+                ],
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "FragmentSpread", name: { kind: "Name", value: "SelectedBuildFields" } },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "viewer" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "preferences" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "vtaOnboarding" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "projectMembership" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "projectId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "projectId" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        alias: { kind: "Name", value: "userCanReview" },
+                        name: { kind: "Name", value: "meetsAccessLevel" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "minimumAccessLevel" },
+                            value: { kind: "EnumValue", value: "REVIEWER" },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StatusTestFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Test" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "result" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "story" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "storyId" } }],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "LastBuildOnBranchTestFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Test" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "result" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "StoryTestFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Test" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "result" } },
+          { kind: "Field", name: { kind: "Name", value: "webUrl" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "comparisons" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                { kind: "Field", name: { kind: "Name", value: "result" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "browser" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "key" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                      { kind: "Field", name: { kind: "Name", value: "version" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "captureDiff" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "diffImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "focusImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "headCapture" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "captureImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "backgroundColor" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                            { kind: "Field", name: { kind: "Name", value: "thumbnailUrl" } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "captureError" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "kind" } },
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: {
+                                kind: "NamedType",
+                                name: { kind: "Name", value: "CaptureErrorInteractionFailure" },
+                              },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "error" } },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: {
+                                kind: "NamedType",
+                                name: { kind: "Name", value: "CaptureErrorJSError" },
+                              },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "error" } },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: {
+                                kind: "NamedType",
+                                name: { kind: "Name", value: "CaptureErrorFailedJS" },
+                              },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "error" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "baseCapture" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "captureImage" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "signed" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "imageUrl" } },
+                            { kind: "Field", name: { kind: "Name", value: "imageWidth" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "mode" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                { kind: "Field", name: { kind: "Name", value: "globals" } },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "story" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "storyId" } },
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "component" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "name" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "LastBuildOnBranchBuildFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Build" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          { kind: "Field", name: { kind: "Name", value: "committedAt" } },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "StartedBuild" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStatus" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "IntValue", value: "1000" },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "statuses" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "testStatuses" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "StatusTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStory" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "storyId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "storyId" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "LastBuildOnBranchTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "CompletedBuild" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "result" } },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStatus" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "IntValue", value: "1000" },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "statuses" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "testStatuses" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "StatusTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStory" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "storyId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "storyId" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "LastBuildOnBranchTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "SelectedBuildFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Build" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "number" } },
+          { kind: "Field", name: { kind: "Name", value: "branch" } },
+          { kind: "Field", name: { kind: "Name", value: "commit" } },
+          { kind: "Field", name: { kind: "Name", value: "committedAt" } },
+          { kind: "Field", name: { kind: "Name", value: "uncommittedHash" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "StartedBuild" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "startedAt" } },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStory" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "storyId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "storyId" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "StoryTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "CompletedBuild" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "startedAt" } },
+                {
+                  kind: "Field",
+                  alias: { kind: "Name", value: "testsForStory" },
+                  name: { kind: "Name", value: "tests" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "storyId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "storyId" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "FragmentSpread",
+                              name: { kind: "Name", value: "StoryTestFields" },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AddonVisualTestsBuildQuery, AddonVisualTestsBuildQueryVariables>;
+export const ReviewTestDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "ReviewTest" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "input" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ReviewTestInput" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "reviewTest" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "Variable", name: { kind: "Name", value: "input" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "updatedTests" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "status" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "userErrors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: { kind: "Name", value: "UserError" },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "__typename" } },
+                            { kind: "Field", name: { kind: "Name", value: "message" } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: { kind: "Name", value: "BuildSupersededError" },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "build" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "InlineFragment",
+                        typeCondition: {
+                          kind: "NamedType",
+                          name: { kind: "Name", value: "TestUnreviewableError" },
+                        },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "test" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ReviewTestMutation, ReviewTestMutationVariables>;

--- a/src/screens/VisualTests/BuildResultsFooter.tsx
+++ b/src/screens/VisualTests/BuildResultsFooter.tsx
@@ -14,7 +14,7 @@ export const BuildResultsFooter = () => {
 
   return (
     <Footer>
-      {modeResults.length > 0 && (
+      {modeResults.length > 0 && storyState.selectedTest && (
         <ModeSelector
           isAccepted={storyState.summary.status === TestStatus.Accepted}
           modeOrder={storyState.modeOrder}
@@ -23,7 +23,7 @@ export const BuildResultsFooter = () => {
           onSelectMode={storyState.onSelectMode}
         />
       )}
-      {browserResults.length > 0 && (
+      {browserResults.length > 0 && storyState.selectedComparison && (
         <BrowserSelector
           isAccepted={storyState.summary.status === TestStatus.Accepted}
           selectedBrowser={storyState.selectedComparison.browser}

--- a/src/screens/VisualTests/SnapshotComparison.stories.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.stories.tsx
@@ -122,6 +122,13 @@ export const FirstPassed: Story = {
       })
     ),
   },
+  play: playAll(async ({ canvasElement, canvasIndex }) => {
+    const canvas = within(canvasElement);
+    const menu = await canvas.findByRole("button", { name: "Safari" });
+    await userEvent.click(menu);
+    const items = await screen.findAllByText("Chrome");
+    await userEvent.click(items[canvasIndex]);
+  }),
 } satisfies Story;
 
 export const StoryAdded: Story = {

--- a/src/screens/VisualTests/SnapshotComparison.stories.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.stories.tsx
@@ -101,11 +101,9 @@ export const SpotlightOnly = {
 } satisfies Story;
 
 /**
- * Sort of confusing situation where the only comparison with changes (1200px/Safari) is on the
- * "opposite" side of the current comparison (800px/Chrome). In this case we still show the first
- * test, which does not have a visual diff.
+ * When first loading a story, we prefer to show changed comparisons over unchanged comparisons.
  */
-export const FirstPassed: Story = {
+export const PrefersChanged: Story = {
   parameters: {
     selectedBuild: withTests(
       build,
@@ -122,13 +120,6 @@ export const FirstPassed: Story = {
       })
     ),
   },
-  play: playAll(async ({ canvasElement, canvasIndex }) => {
-    const canvas = within(canvasElement);
-    const menu = await canvas.findByRole("button", { name: "Safari" });
-    await userEvent.click(menu);
-    const items = await screen.findAllByText("Chrome");
-    await userEvent.click(items[canvasIndex]);
-  }),
 } satisfies Story;
 
 export const StoryAdded: Story = {

--- a/src/screens/VisualTests/SnapshotComparison.tsx
+++ b/src/screens/VisualTests/SnapshotComparison.tsx
@@ -152,15 +152,15 @@ export const SnapshotComparison = ({
   // This checks if the specific comparison is new, but the story itself is not. This indicates it was probably a new mode being added.
   const isNewMode =
     !isNewStory &&
-    selectedTest.result === TestResult.Added &&
-    selectedTest.status !== TestStatus.Accepted;
+    selectedTest?.result === TestResult.Added &&
+    selectedTest?.status !== TestStatus.Accepted;
 
   // If any of the tests has a new comparison, and the test isn't new it is a new browser.
   const isNewBrowser =
     !isNewStory &&
-    selectedComparison.result === ComparisonResult.Added &&
-    selectedTest.result !== TestResult.Added &&
-    selectedTest.status !== TestStatus.Accepted;
+    selectedComparison?.result === ComparisonResult.Added &&
+    selectedTest?.result !== TestResult.Added &&
+    selectedTest?.status !== TestStatus.Accepted;
 
   useEffect(() => {
     // It's possible this component doesn't unmount when the selected build, comparison, or story changes, so we need to reset state values.
@@ -284,9 +284,9 @@ export const SnapshotComparison = ({
         {!isInProgress && selectedComparison && (
           <SnapshotImage
             key={selectedComparison.id}
-            componentName={selectedTest.story?.component?.name}
-            storyName={selectedTest.story?.name}
-            testUrl={selectedTest.webUrl}
+            componentName={selectedTest?.story?.component?.name}
+            storyName={selectedTest?.story?.name}
+            testUrl={selectedTest?.webUrl}
             comparisonResult={selectedComparison.result ?? undefined}
             latestImage={selectedComparison.headCapture?.captureImage ?? undefined}
             baselineImage={selectedComparison.baseCapture?.captureImage ?? undefined}

--- a/src/screens/VisualTests/SnapshotControls.tsx
+++ b/src/screens/VisualTests/SnapshotControls.tsx
@@ -109,8 +109,8 @@ export const SnapshotControls = ({ isOutdated }: { isOutdated: boolean }) => {
       </Controls>
     );
 
-  const isAcceptable = changeCount > 0 && selectedTest.status !== TestStatus.Accepted;
-  const isUnacceptable = changeCount > 0 && selectedTest.status === TestStatus.Accepted;
+  const isAcceptable = changeCount > 0 && selectedTest?.status !== TestStatus.Accepted;
+  const isUnacceptable = changeCount > 0 && selectedTest?.status === TestStatus.Accepted;
   const hasControls = selectedComparison?.result === ComparisonResult.Changed;
 
   return (
@@ -178,7 +178,7 @@ export const SnapshotControls = ({ isOutdated }: { isOutdated: boolean }) => {
 
       {(isAcceptable || isUnacceptable) && (
         <Actions showDivider={hasControls}>
-          {userCanReview && buildIsReviewable && isAcceptable && (
+          {userCanReview && buildIsReviewable && isAcceptable && selectedTest && (
             <ButtonGroup>
               <WithTooltip
                 tooltip={<TooltipNote note="Accept this story" />}

--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -470,13 +470,6 @@ export const ModeAddedInSelectedBuild = {
       },
     },
   },
-  play: playAll(async ({ canvasElement, canvasIndex }) => {
-    const canvas = within(canvasElement);
-    const menu = await canvas.findByRole("button", { name: "480px" });
-    await userEvent.click(menu);
-    const items = await screen.findAllByText("1200px");
-    await userEvent.click(items[canvasIndex]);
-  }),
 } satisfies Story;
 
 export const ModeAddedAndAccepted = {
@@ -508,13 +501,6 @@ export const BrowserAddedInSelectedBuild = {
       },
     },
   },
-  play: playAll(async ({ canvasElement, canvasIndex }) => {
-    const canvas = within(canvasElement);
-    const menu = await canvas.findByRole("button", { name: "Chrome" });
-    await userEvent.click(menu);
-    const items = await screen.findAllByText("Safari");
-    await userEvent.click(items[canvasIndex]);
-  }),
 } satisfies Story;
 
 export const BrowserAddedAndAccepted: Story = {

--- a/src/utils/useTests.stories.tsx
+++ b/src/utils/useTests.stories.tsx
@@ -1,0 +1,146 @@
+import { expect, waitFor } from "@storybook/test";
+import React, { useEffect } from "react";
+
+import { SELECTED_BROWSER_ID, SELECTED_MODE_NAME } from "../constants";
+import { ComparisonResult, StoryTestFieldsFragment, TestStatus } from "../gql/graphql";
+import { playAll } from "./playAll";
+import { useSharedState } from "./useSharedState";
+import { useTests } from "./useTests";
+
+const UseTests = ({ tests }: { tests: StoryTestFieldsFragment[] }) => {
+  const data = useTests(tests);
+  const [globalMode] = useSharedState<string>(SELECTED_MODE_NAME);
+  const [globalBrowser] = useSharedState<string>(SELECTED_BROWSER_ID);
+  const json = JSON.stringify({ ...data, globalMode, globalBrowser }, null, 2);
+  return <pre key={json}>{json}</pre>;
+};
+
+const Component = ({
+  tests,
+  selectedMode,
+  selectedBrowser,
+}: {
+  tests: StoryTestFieldsFragment[];
+  selectedMode?: string;
+  selectedBrowser?: string;
+}) => {
+  const [initialized, setInitialized] = React.useState(false);
+  const setMode = useSharedState<string>(SELECTED_MODE_NAME)[1];
+  const setBrowser = useSharedState<string>(SELECTED_BROWSER_ID)[1];
+
+  useEffect(() => {
+    if (initialized) return;
+    setMode(selectedMode);
+    setBrowser(selectedBrowser);
+    setInitialized(true);
+  }, [initialized, selectedBrowser, selectedMode, setBrowser, setMode]);
+
+  return initialized && <UseTests tests={tests} />;
+};
+
+const expectData = (expected: any) =>
+  playAll(async ({ canvasElement }) => {
+    const data = await waitFor(() => JSON.parse(canvasElement.textContent as any));
+    await expect(data).toEqual(expected);
+  });
+
+const chrome = { browser: { id: "chrome" }, result: ComparisonResult.Equal };
+const safari = { browser: { id: "safari" }, result: ComparisonResult.Equal };
+const chromeChanged = { browser: { id: "chrome" }, result: ComparisonResult.Changed };
+const safariChanged = { browser: { id: "safari" }, result: ComparisonResult.Changed };
+
+const alpha = { mode: { name: "A" }, comparisons: [chrome] };
+const bravo = { mode: { name: "B" }, comparisons: [chrome, safari] };
+const charlie = { mode: { name: "C" }, comparisons: [chromeChanged] };
+const delta = { mode: { name: "D" }, comparisons: [chrome, safariChanged] };
+
+export default {
+  component: Component,
+  args: {
+    tests: [alpha, bravo, charlie, delta],
+  },
+  parameters: {
+    chromatic: {
+      modes: {
+        Light: { theme: "light", viewport: "default" },
+      },
+    },
+  },
+};
+
+export const NoTests = {
+  args: {
+    tests: [],
+  },
+  play: expectData({}),
+};
+
+export const SelectsFirstTest = {
+  args: {
+    tests: [alpha, bravo], // Only unchanged tests
+  },
+  play: expectData({
+    globalMode: "A",
+    globalBrowser: "chrome",
+    selectedTest: alpha,
+    selectedComparison: chrome,
+  }),
+};
+
+export const SelectsFirstTestMatchingMode = {
+  args: {
+    tests: [alpha, bravo], // Only unchanged tests
+    selectedMode: "B",
+  },
+  play: expectData({
+    globalMode: "B",
+    globalBrowser: "chrome",
+    selectedTest: bravo,
+    selectedComparison: chrome,
+  }),
+};
+
+export const SelectsFirstChangedTest = {
+  play: expectData({
+    globalMode: "C",
+    globalBrowser: "chrome",
+    selectedTest: charlie,
+    selectedComparison: chromeChanged,
+  }),
+};
+
+export const SelectsFirstChangedComparisonMatchingMode = {
+  args: {
+    selectedMode: "D",
+  },
+  play: expectData({
+    globalMode: "D",
+    globalBrowser: "safari",
+    selectedTest: delta,
+    selectedComparison: safariChanged,
+  }),
+};
+
+export const SelectsFirstChangedTestIgnoringBrowser = {
+  args: {
+    selectedBrowser: "safari",
+  },
+  play: expectData({
+    globalMode: "C",
+    globalBrowser: "chrome",
+    selectedTest: charlie,
+    selectedComparison: chromeChanged,
+  }),
+};
+
+export const SelectsFirstChangedTestMatchingBrowser = {
+  args: {
+    tests: [alpha, bravo, delta, charlie],
+  },
+  play: expectData({
+    globalMode: "D",
+    globalBrowser: "safari",
+    selectedTest: delta,
+    selectedComparison: safariChanged,
+  }),
+};

--- a/src/utils/useTests.test.ts
+++ b/src/utils/useTests.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { ComparisonResult, StoryTestFieldsFragment } from "../gql/graphql";
+import { getMostUsefulComparison, getMostUsefulTest } from "./useTests";
+
+describe("getMostUsefulTest", () => {
+  const chrome = { browser: { id: "chrome" }, result: ComparisonResult.Equal };
+  const safari = { browser: { id: "safari" }, result: ComparisonResult.Equal };
+  const chromeChanged = { browser: { id: "chrome" }, result: ComparisonResult.Changed };
+  const safariChanged = { browser: { id: "safari" }, result: ComparisonResult.Changed };
+
+  const alpha = { mode: { name: "A" }, comparisons: [chrome] };
+  const bravo = { mode: { name: "B" }, comparisons: [chrome, safari] };
+  const charlie = { mode: { name: "C" }, comparisons: [chromeChanged] };
+  const delta = { mode: { name: "D" }, comparisons: [chrome, safariChanged] };
+
+  describe("when some tests have changes", () => {
+    const tests = [alpha, bravo, charlie, delta] as StoryTestFieldsFragment[];
+
+    it("returns the test with changes that matches the given mode name", () => {
+      const modeName = "D";
+      const test = getMostUsefulTest(tests, modeName);
+      expect(test).toEqual(delta);
+    });
+
+    it("returns the first test with changes when none of them match the given mode name", () => {
+      const modeName = "Z";
+      const test = getMostUsefulTest(tests, modeName);
+      expect(test).toEqual(charlie);
+    });
+
+    it("returns the first test with changes when no mode name is given", () => {
+      const test = getMostUsefulTest(tests);
+      expect(test).toEqual(charlie);
+    });
+  });
+
+  describe("when no tests have changes", () => {
+    const tests = [alpha, bravo] as StoryTestFieldsFragment[];
+
+    it("returns the first test that matches the given mode name", () => {
+      const modeName = "B";
+      const test = getMostUsefulTest(tests, modeName);
+      expect(test).toEqual(bravo);
+    });
+
+    it("returns the first test when none match the given mode name", () => {
+      const modeName = "Z";
+      const test = getMostUsefulTest(tests, modeName);
+      expect(test).toEqual(alpha);
+    });
+
+    it("returns the first test when no mode name is given", () => {
+      const test = getMostUsefulTest(tests);
+      expect(test).toEqual(alpha);
+    });
+  });
+
+  // no tests
+});
+
+describe("getMostUsefulComparison", () => {
+  const chrome = { browser: { id: "chrome" }, result: ComparisonResult.Equal };
+  const safari = { browser: { id: "safari" }, result: ComparisonResult.Equal };
+  const chromeChanged = { browser: { id: "chrome" }, result: ComparisonResult.Changed };
+  const safariChanged = { browser: { id: "safari" }, result: ComparisonResult.Changed };
+
+  describe("when some comparisons have changes", () => {
+    const comparisons = [
+      chrome,
+      safari,
+      chromeChanged,
+      safariChanged,
+    ] as StoryTestFieldsFragment["comparisons"];
+
+    it("returns the comparison with changes that matches the given browser id", () => {
+      const browserId = "safari";
+      const comparison = getMostUsefulComparison(comparisons, browserId);
+      expect(comparison).toEqual(safariChanged);
+    });
+
+    it("returns the first comparison with changes when none of them match the given browser id", () => {
+      const browserId = "firefox";
+      const comparison = getMostUsefulComparison(comparisons, browserId);
+      expect(comparison).toEqual(chromeChanged);
+    });
+
+    it("returns the first comparison with changes when no browser id is given", () => {
+      const comparison = getMostUsefulComparison(comparisons);
+      expect(comparison).toEqual(chromeChanged);
+    });
+  });
+
+  describe("when no comparisons have changes", () => {
+    const comparisons = [chrome, safari] as StoryTestFieldsFragment["comparisons"];
+
+    it("returns the first comparison that matches the given browser id", () => {
+      const browserId = "safari";
+      const comparison = getMostUsefulComparison(comparisons, browserId);
+      expect(comparison).toEqual(safari);
+    });
+
+    it("returns the first comparison when none match the given browser id", () => {
+      const browserId = "firefox";
+      const comparison = getMostUsefulComparison(comparisons, browserId);
+      expect(comparison).toEqual(chrome);
+    });
+
+    it("returns the first comparison when no browser id is given", () => {
+      const comparison = getMostUsefulComparison(comparisons);
+      expect(comparison).toEqual(chrome);
+    });
+  });
+});

--- a/src/utils/useTests.ts
+++ b/src/utils/useTests.ts
@@ -1,8 +1,14 @@
 import { useGlobals, useGlobalTypes } from "@storybook/manager-api";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { SELECTED_BROWSER_ID, SELECTED_MODE_NAME } from "../constants";
-import { BrowserInfo, StoryTestFieldsFragment, TestMode, TestStatus } from "../gql/graphql";
+import {
+  BrowserInfo,
+  ComparisonResult,
+  StoryTestFieldsFragment,
+  TestMode,
+  TestStatus,
+} from "../gql/graphql";
 import { useSharedState } from "./useSharedState";
 
 type BrowserData = Pick<BrowserInfo, "id" | "key" | "name">;
@@ -17,48 +23,56 @@ const useGlobalValue = (key: string) => {
   }
 };
 
+const hasChanges = ({ result }: StoryTestFieldsFragment["comparisons"][number]) =>
+  result !== ComparisonResult.Equal && result !== ComparisonResult.Fixed;
+
 /**
  * Pick a single test+comparison (by viewport+browser) from a set of tests
  * for the same story.
+ *
+ * Select the initial test mode based on the following criteria (in order of priority):
+ * 1. The first test with changes detected and the mode name matches the one previously selected
+ * 2. The first test with changes detected
+ * 3. The first test where the mode name matches the one previously selected
+ * 4. The first test
  */
 export function useTests(tests: StoryTestFieldsFragment[]) {
-  const [theme, themeType] = useGlobalValue("theme");
-  const [globalSelectedBrowserId, setGlobalSelectedBrowserId] =
-    useSharedState<string>(SELECTED_BROWSER_ID);
+  const themeType = useGlobalValue("theme")[1];
+
   const [globalSelectedModeName, setGlobalSelectedModeName] =
     useSharedState<string>(SELECTED_MODE_NAME);
-  const [selectedModeName, setSelectedModeName] = useState<ModeData["name"]>(() => {
-    // Select the initial test mode based on the following criteria (in order of priority):
-    // 1. The first test with changes detected and the mode name matches the one previously selected
-    // 2. The first test with changes detected
-    // 3. The first test where the mode name matches the one previously selected
-    // 4. The first test
-    const changedTests = tests.filter(({ status }) => status !== TestStatus.Passed);
+  const [globalSelectedBrowserId, setGlobalSelectedBrowserId] =
+    useSharedState<string>(SELECTED_BROWSER_ID);
+
+  const selectedModeName = useRef(globalSelectedModeName);
+  const selectedBrowserId = useRef(globalSelectedBrowserId);
+
+  if (tests?.length && (!selectedModeName.current || !selectedBrowserId.current)) {
+    const changedTests = tests.filter((test) => test.comparisons.some(hasChanges));
     const candidateTests = changedTests.length ? changedTests : tests;
-    const test =
-      candidateTests.find(({ mode }) => mode.name === globalSelectedModeName) || candidateTests[0];
-    if (test?.mode.name !== globalSelectedModeName) {
-      setGlobalSelectedModeName(test?.mode.name);
-    }
-    return test?.mode.name;
-  });
+    const selectedTest =
+      candidateTests.find((t) => t.mode.name === globalSelectedModeName) || candidateTests[0];
 
-  const onSelectBrowser = useCallback(
-    ({ id }: BrowserData) => setGlobalSelectedBrowserId(id),
-    [setGlobalSelectedBrowserId]
-  );
-  const onSelectMode = useCallback(
-    ({ name }: ModeData) => {
-      setSelectedModeName(name);
-      setGlobalSelectedModeName(name);
-    },
-    [setGlobalSelectedModeName]
-  );
+    const changedComparisons = selectedTest.comparisons.filter(hasChanges);
+    const candidateComparisons = changedComparisons.length
+      ? changedComparisons
+      : selectedTest.comparisons;
+    const selectedComparison =
+      candidateComparisons.find((c) => c.browser.id === globalSelectedBrowserId) ||
+      candidateComparisons[0];
 
-  const selectedTest = tests.find(({ mode }) => mode.name === selectedModeName) || tests[0];
+    selectedModeName.current = selectedTest.mode.name;
+    selectedBrowserId.current = selectedComparison.browser.id;
+  }
+
+  const selectedTest = tests.find(({ mode }) => mode.name === selectedModeName.current) || tests[0];
   const selectedComparison =
-    selectedTest?.comparisons.find(({ browser }) => browser.id === globalSelectedBrowserId) ||
+    selectedTest?.comparisons.find(({ browser }) => browser.id === selectedBrowserId.current) ||
     selectedTest?.comparisons[0];
+
+  if (selectedTest?.mode.name !== globalSelectedModeName) {
+    setGlobalSelectedModeName(selectedTest?.mode.name);
+  }
   if (selectedComparison?.browser.id !== globalSelectedBrowserId) {
     setGlobalSelectedBrowserId(selectedComparison?.browser.id);
   }
@@ -67,7 +81,13 @@ export function useTests(tests: StoryTestFieldsFragment[]) {
     modeOrder: themeType?.toolbar?.items?.map((item: { title: string }) => item.title),
     selectedTest,
     selectedComparison,
-    onSelectBrowser,
-    onSelectMode,
+    onSelectBrowser: useCallback(
+      (browser: BrowserData) => setGlobalSelectedBrowserId(browser.id),
+      [setGlobalSelectedBrowserId]
+    ),
+    onSelectMode: useCallback(
+      (mode: ModeData) => setGlobalSelectedModeName(mode.name),
+      [setGlobalSelectedModeName]
+    ),
   };
 }

--- a/src/utils/useTests.ts
+++ b/src/utils/useTests.ts
@@ -60,37 +60,32 @@ export const getMostUsefulComparison = (
  * for the same story.
  */
 export function useTests(tests: StoryTestFieldsFragment[]) {
-  // console.log("rendering useTests");
   const [initialRender, setInitialRender] = useState(true);
   const themeType = useGlobalValue("theme")[1];
 
-  const [globalSelectedModeName, setGlobalSelectedModeName] =
-    useSharedState<string>(SELECTED_MODE_NAME);
-  const [globalSelectedBrowserId, setGlobalSelectedBrowserId] =
-    useSharedState<string>(SELECTED_BROWSER_ID);
+  const [selectedModeName, setSelectedModeName] = useSharedState<string>(SELECTED_MODE_NAME);
+  const [selectedBrowserId, setSelectedBrowserId] = useSharedState<string>(SELECTED_BROWSER_ID);
 
-  // TODO: how should we actually handle when there are no tests?
-  // if (!tests.length) {
-  //   return {};
-  // }
+  let selectedTest;
+  let selectedComparison;
+  if (tests.length) {
+    selectedTest = initialRender
+      ? getMostUsefulTest(tests, selectedModeName)
+      : tests.find(({ mode }) => mode.name === selectedModeName) || tests[0];
+    selectedComparison = initialRender
+      ? getMostUsefulComparison(selectedTest.comparisons, selectedBrowserId)
+      : selectedTest?.comparisons.find(({ browser }) => browser.id === selectedBrowserId) ||
+        selectedTest?.comparisons[0];
 
-  const selectedTest = initialRender
-    ? getMostUsefulTest(tests, globalSelectedModeName)
-    : tests.find(({ mode }) => mode.name === globalSelectedModeName);
-  // console.log("selectedTest", selectedTest);
-  const selectedComparison = initialRender
-    ? getMostUsefulComparison(selectedTest?.comparisons, globalSelectedBrowserId)
-    : selectedTest?.comparisons.find(({ browser }) => browser.id === globalSelectedBrowserId);
-
-  if (selectedTest?.mode.name !== globalSelectedModeName) {
-    setGlobalSelectedModeName(selectedTest?.mode.name);
-  }
-  if (selectedComparison?.browser.id !== globalSelectedBrowserId) {
-    setGlobalSelectedBrowserId(selectedComparison?.browser.id);
-  }
-
-  if (initialRender) {
-    setInitialRender(false);
+    if (initialRender) {
+      if (selectedModeName !== selectedTest?.mode.name) {
+        setSelectedModeName(selectedTest?.mode.name);
+      }
+      if (selectedBrowserId !== selectedComparison?.browser.id) {
+        setSelectedBrowserId(selectedComparison?.browser.id);
+      }
+      setInitialRender(false);
+    }
   }
 
   return {
@@ -98,12 +93,12 @@ export function useTests(tests: StoryTestFieldsFragment[]) {
     selectedTest,
     selectedComparison,
     onSelectBrowser: useCallback(
-      (browser: BrowserData) => setGlobalSelectedBrowserId(browser.id),
-      [setGlobalSelectedBrowserId]
+      (browser: BrowserData) => setSelectedBrowserId(browser.id),
+      [setSelectedBrowserId]
     ),
     onSelectMode: useCallback(
-      (mode: ModeData) => setGlobalSelectedModeName(mode.name),
-      [setGlobalSelectedModeName]
+      (mode: ModeData) => setSelectedModeName(mode.name),
+      [setSelectedModeName]
     ),
   };
 }

--- a/src/utils/useTests.ts
+++ b/src/utils/useTests.ts
@@ -1,14 +1,8 @@
 import { useGlobals, useGlobalTypes } from "@storybook/manager-api";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { SELECTED_BROWSER_ID, SELECTED_MODE_NAME } from "../constants";
-import {
-  BrowserInfo,
-  ComparisonResult,
-  StoryTestFieldsFragment,
-  TestMode,
-  TestStatus,
-} from "../gql/graphql";
+import { BrowserInfo, ComparisonResult, StoryTestFieldsFragment, TestMode } from "../gql/graphql";
 import { useSharedState } from "./useSharedState";
 
 type BrowserData = Pick<BrowserInfo, "id" | "key" | "name">;
@@ -27,16 +21,47 @@ const hasChanges = ({ result }: StoryTestFieldsFragment["comparisons"][number]) 
   result !== ComparisonResult.Equal && result !== ComparisonResult.Fixed;
 
 /**
- * Pick a single test+comparison (by viewport+browser) from a set of tests
- * for the same story.
- *
- * Select the initial test mode based on the following criteria (in order of priority):
- * 1. The first test with changes detected and the mode name matches the one previously selected
+ * Select the initial test based on the following criteria (in order of priority):
+ * 1. The first test with changes detected and the mode name matches the global one
  * 2. The first test with changes detected
- * 3. The first test where the mode name matches the one previously selected
+ * 3. The first test where the mode name matches the global one
  * 4. The first test
  */
+export const getMostUsefulTest = (
+  tests: StoryTestFieldsFragment[],
+  modeName?: ModeData["name"]
+): StoryTestFieldsFragment => {
+  const changedTests = tests.filter((test) => test.comparisons.some(hasChanges));
+  const candidateTests = changedTests.length ? changedTests : tests;
+  const test = candidateTests.find((t) => t.mode.name === modeName) || candidateTests[0];
+  return test;
+};
+
+/**
+ * Select the initial comparison based on the following criteria (in order of priority):
+ * 1. The comparison with changes detected and the browser id matches the global one
+ * 2. The first comparison with changes detected
+ * 3. The first comparison where the browser id matches the global one
+ * 4. The first comparison
+ */
+export const getMostUsefulComparison = (
+  comparisons: StoryTestFieldsFragment["comparisons"],
+  browserId?: BrowserData["id"]
+): StoryTestFieldsFragment["comparisons"][number] => {
+  const changedComparisons = comparisons.filter(hasChanges);
+  const candidateComparisons = changedComparisons.length ? changedComparisons : comparisons;
+  const comparison =
+    candidateComparisons.find((c) => c.browser.id === browserId) || candidateComparisons[0];
+  return comparison;
+};
+
+/**
+ * Pick a single test+comparison (by viewport+browser) from a set of tests
+ * for the same story.
+ */
 export function useTests(tests: StoryTestFieldsFragment[]) {
+  // console.log("rendering useTests");
+  const [initialRender, setInitialRender] = useState(true);
   const themeType = useGlobalValue("theme")[1];
 
   const [globalSelectedModeName, setGlobalSelectedModeName] =
@@ -44,37 +69,28 @@ export function useTests(tests: StoryTestFieldsFragment[]) {
   const [globalSelectedBrowserId, setGlobalSelectedBrowserId] =
     useSharedState<string>(SELECTED_BROWSER_ID);
 
-  const selectedModeName = useRef(globalSelectedModeName);
-  const selectedBrowserId = useRef(globalSelectedBrowserId);
+  // TODO: how should we actually handle when there are no tests?
+  // if (!tests.length) {
+  //   return {};
+  // }
 
-  if (tests?.length && (!selectedModeName.current || !selectedBrowserId.current)) {
-    const changedTests = tests.filter((test) => test.comparisons.some(hasChanges));
-    const candidateTests = changedTests.length ? changedTests : tests;
-    const selectedTest =
-      candidateTests.find((t) => t.mode.name === globalSelectedModeName) || candidateTests[0];
-
-    const changedComparisons = selectedTest.comparisons.filter(hasChanges);
-    const candidateComparisons = changedComparisons.length
-      ? changedComparisons
-      : selectedTest.comparisons;
-    const selectedComparison =
-      candidateComparisons.find((c) => c.browser.id === globalSelectedBrowserId) ||
-      candidateComparisons[0];
-
-    selectedModeName.current = selectedTest.mode.name;
-    selectedBrowserId.current = selectedComparison.browser.id;
-  }
-
-  const selectedTest = tests.find(({ mode }) => mode.name === selectedModeName.current) || tests[0];
-  const selectedComparison =
-    selectedTest?.comparisons.find(({ browser }) => browser.id === selectedBrowserId.current) ||
-    selectedTest?.comparisons[0];
+  const selectedTest = initialRender
+    ? getMostUsefulTest(tests, globalSelectedModeName)
+    : tests.find(({ mode }) => mode.name === globalSelectedModeName);
+  // console.log("selectedTest", selectedTest);
+  const selectedComparison = initialRender
+    ? getMostUsefulComparison(selectedTest?.comparisons, globalSelectedBrowserId)
+    : selectedTest?.comparisons.find(({ browser }) => browser.id === globalSelectedBrowserId);
 
   if (selectedTest?.mode.name !== globalSelectedModeName) {
     setGlobalSelectedModeName(selectedTest?.mode.name);
   }
   if (selectedComparison?.browser.id !== globalSelectedBrowserId) {
     setGlobalSelectedBrowserId(selectedComparison?.browser.id);
+  }
+
+  if (initialRender) {
+    setInitialRender(false);
   }
 
   return {


### PR DESCRIPTION
QA

1. Use a project with stories with modes:
   - One story should have a mode that is passed and then a mode that has changed, in that order
   - Another story should have the same modes, but both modes have changes
   - A third story should have additional modes that are not found in the first two stories, with changes
2. Navigate to the first story and verify that the second mode (the one with changes) is selected
3. Verify that you can change to the first mode and view the test
4. Navigate to the second story and verify that the same mode is shown from step 3
5. Navigate back to the first story and verify the the _unchanged_ mode is selected (this takes precedence over a selected mode that does not contain changes)
6. Navigate to the third story and select a mode that is unique to that story
7. Navigate back to the first story and verify that the mode with changes is selected
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.22--canary.218.31120f4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.2.22--canary.218.31120f4.0
  # or 
  yarn add @chromatic-com/storybook@1.2.22--canary.218.31120f4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
