### PR TITLE
Don't show extra border when no config is available

### DIFF
--- a/src/components/Screen.stories.tsx
+++ b/src/components/Screen.stories.tsx
@@ -69,3 +69,26 @@ export const ConfigurationSuggestions = {
     }),
   ],
 } satisfies StoryObj<typeof meta>;
+
+export const SparseConfiguration = {
+  decorators: [
+    withSharedState(CONFIG_INFO, {
+      configuration: { configFile: configuration.configFile },
+      // problems: { storybookBaseDir: "src/frontend" },
+      suggestions: { zip: true },
+    } satisfies ConfigInfoPayload),
+  ],
+  parameters: {
+    initialControls: {
+      configVisible: true,
+    },
+  },
+} satisfies StoryObj<typeof meta>;
+
+export const NoConfiguration = {
+  parameters: {
+    initialControls: {
+      configVisible: true,
+    },
+  },
+} satisfies StoryObj<typeof meta>;

--- a/src/components/Screen.stories.tsx
+++ b/src/components/Screen.stories.tsx
@@ -74,7 +74,6 @@ export const SparseConfiguration = {
   decorators: [
     withSharedState(CONFIG_INFO, {
       configuration: { configFile: configuration.configFile },
-      // problems: { storybookBaseDir: "src/frontend" },
       suggestions: { zip: true },
     } satisfies ConfigInfoPayload),
   ],

--- a/src/screens/VisualTests/Configuration.tsx
+++ b/src/screens/VisualTests/Configuration.tsx
@@ -260,10 +260,11 @@ const Suggestion = styled.div<{ warning?: boolean }>(({ warning, theme }) => ({
   },
 }));
 
-const DangerZone = styled.div(({ theme }) => ({
-  borderTop: `1px solid ${theme.appBorderColor}`,
-  marginTop: 10,
-  paddingTop: 20,
+const ConfigItem = styled.div(({ theme }) => ({
+  "&:nth-last-of-type(2)": {
+    borderBottom: `1px solid ${theme.appBorderColor}`,
+    paddingBottom: 30,
+  },
 }));
 
 const iconStyles = {
@@ -330,7 +331,7 @@ export const Configuration = ({ onClose }: ConfigurationProps) => {
         {config && (
           <Table>
             {config.map(({ key, value, problem, suggestion }) => (
-              <div key={key} id={`${key}-option`}>
+              <ConfigItem key={key} id={`${key}-option`}>
                 <Setting>
                   <SettingHeading>
                     <SettingLabel>{key} </SettingLabel>
@@ -371,9 +372,9 @@ export const Configuration = ({ onClose }: ConfigurationProps) => {
                     </span>
                   </Suggestion>
                 )}
-              </div>
+              </ConfigItem>
             ))}
-            <DangerZone>
+            <div>
               <Setting>
                 <SettingHeading>
                   <SettingLabel>Uninstall addon</SettingLabel>
@@ -386,7 +387,7 @@ export const Configuration = ({ onClose }: ConfigurationProps) => {
                   <Button onClick={uninstallAddon}>Uninstall</Button>
                 </SettingContent>
               </Setting>
-            </DangerZone>
+            </div>
           </Table>
         )}
       </PageWrapper>


### PR DESCRIPTION
The top "Configuration" section has a bottom border on it and the bottom "Uninstall" section has a top border on it, which is fine as long as there is something in the middle. This changes it so that the last item in the "middle" will have a bottom border, removing the top border from the "Uninstall" section. That way, when the middle is empty, there is no extra border.

I added a couple stories to make sure nothing changed when a config is actually present. None of the existing stories were capturing the bottom of the config.

Before:

<img width="399" alt="image" src="https://github.com/chromaui/addon-visual-tests/assets/3391672/6faa1e7a-d04e-4def-990b-35d67e19c289">

After:

![image](https://github.com/chromaui/addon-visual-tests/assets/3391672/bc1c505d-2e00-4a1c-b894-c15f3292ddfe)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.20--canary.221.e9f4fdf.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.2.20--canary.221.e9f4fdf.0
  # or 
  yarn add @chromatic-com/storybook@1.2.20--canary.221.e9f4fdf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
