### PR TITLE
Normalize `configDir` before comparing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ const suggestRemovals = (
 // Detect problems in the current configuration and suggest updates.
 const getConfigInfo = async (
   configuration: Awaited<ReturnType<typeof getConfiguration>>,
-  { configDir }: Options
+  options: Options
 ) => {
   const defaults: Configuration = {
     storybookBaseDir: ".",
@@ -70,8 +70,9 @@ const getConfigInfo = async (
     problems.storybookBaseDir = baseDir;
   }
 
+  const configDir = normalize(relative(process.cwd(), options.configDir));
   if (configDir !== normalize(configuration.storybookConfigDir ?? "")) {
-    problems.storybookConfigDir = normalize(relative(process.cwd(), configDir));
+    problems.storybookConfigDir = configDir;
   }
 
   if (!configuration.zip) {


### PR DESCRIPTION
The configured `./ui/.storybook` was considered different than the suggested `ui/.storybook` value for `storybookConfigDir`, causing the addon to suggest an update. These values aren't actually different when normalized, so an update needn't be suggested. This fixes that by normalizing the suggested value before comparing to the configured value.