### PR TITLE
Update guided tour tooltip to match Storybook

### DIFF
--- a/src/screens/GuidedTour/Tooltip.tsx
+++ b/src/screens/GuidedTour/Tooltip.tsx
@@ -19,14 +19,14 @@ const Wrapper = styled.div({
 });
 
 const TooltipTitle = styled.div(({ theme }) => ({
-  fontSize: 14,
+  fontSize: 13,
   lineHeight: "18px",
   fontWeight: 700,
   color: theme.color.defaultText,
 }));
 
 const TooltipContent = styled.div(({ theme }) => ({
-  fontSize: 14,
+  fontSize: 13,
   lineHeight: "18px",
   textAlign: "start",
   color: theme.color.defaultText,
@@ -39,10 +39,6 @@ const TooltipFooter = styled.div({
   justifyContent: "flex-end",
   marginTop: 15,
 });
-
-const NextButton = styled(Button)(
-  ({ secondary }) => secondary && { "&&:focus": { boxShadow: "none" } }
-);
 
 export type TooltipProps = TooltipRenderProps & {
   step: TooltipRenderProps["step"] & {
@@ -62,9 +58,10 @@ export const Tooltip = ({ isLastStep, step, primaryProps, tooltipProps }: Toolti
         <TooltipContent>{step.content}</TooltipContent>
       </Wrapper>
       {(step.hideNextButton || step.hideBackButton) && (
-        <TooltipFooter id="buttonNext">
+        <TooltipFooter id="buttonSkip">
           {!step.hideSkipButton && !isLastStep && (
             <Button
+              size="medium"
               onClick={step.onSkipWalkthroughButtonClick}
               link
               style={{ paddingRight: 12, paddingLeft: 12, marginRight: 8 }}
@@ -73,17 +70,17 @@ export const Tooltip = ({ isLastStep, step, primaryProps, tooltipProps }: Toolti
             </Button>
           )}
           {!step.hideNextButton && (
-            <NextButton
+            <Button
               {...{
                 ...primaryProps,
                 // @tmeasday - I'm not sure if we ever use this, but this makes the types work
                 onClick: primaryProps.onClick as (event: SyntheticEvent) => void,
-                secondary: true,
+                primary: true,
                 ...(step.onNextButtonClick ? { onClick: step.onNextButtonClick } : {}),
               }}
             >
               {step.nextButtonText || "Next"}
-            </NextButton>
+            </Button>
           )}
         </TooltipFooter>
       )}


### PR DESCRIPTION
This updates the tooltip to match Storybook's onboarding. It also simplifies the code a touch.
It would be nice if we had a story to cover this one, but I ran into issues trying. Would love someone to take this on when there is time for it.

To test, you may have to pull this down locally and add `&vtaOnboarding=true` after restarting Storybook.

It should look like this:
<img width="576" alt="image" src="https://github.com/chromaui/addon-visual-tests/assets/1123119/7a7d6fdf-13eb-4e9f-a78f-c455f9e36e19">