### PR TITLE
Upgrade Chromatic CLI and pass `skipUpdateCheck: false`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "chromatic": "^11.0.0",
+    "chromatic": "^11.3.0",
     "filesize": "^10.0.12",
     "jsonfile": "^6.1.0",
     "react-confetti": "^6.1.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,12 +37,14 @@ export const CONFIG_OVERRIDES = {
   forceRebuild: true,
   // This should never be set for local builds
   fromCI: false,
+  // No prompts from the Build proces
+  interactive: false,
   // Builds initiated from the addon are always considered local
   isLocalBuild: true,
   // Never skip local builds
   skip: false,
-  // No prompts from the Build proces
-  interactive: false,
+  // Don't check for CLI updates
+  skipUpdateCheck: true,
 };
 
 export const DOCS_URL = "https://www.chromatic.com/docs/visual-tests-addon";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5163,10 +5163,10 @@ chownr@^2.0.0:
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromatic@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.0.0.tgz#3fcd5129a01c9b6bbd5ed46a11795ad5ac0731d3"
-  integrity sha512-utzRVqdMrpzYwZNf7dHWU0z0/rx6SH/FUVNozQxYHDtQfYUdEj+Ro4OSch5+Wsk2FoUmznJyLkaC2J839z1N7A==
+chromatic@^11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.3.0.tgz#d46b7aac1a0eaed29a765645eaf93c484220174c"
+  integrity sha512-q1ZtJDJrjLGnz60ivpC16gmd7KFzcaA4eTb7gcytCqbaKqlHhCFr1xQmcUDsm14CK7JsqdkFU6S+JQdOd2ZNJg==
 
 citty@^0.1.5:
   version "0.1.5"


### PR DESCRIPTION
Updates CLI to [v11.3.0](https://github.com/chromaui/chromatic-cli/blob/main/CHANGELOG.md#v1130-fri-mar-29-2024) which:
- Handles JSON parse errors in config file more gracefully
- Suppresses issues caused by missing Git remote
- Adds `skipUpdateCheck` option (set to `true` for VTA builds)