### PR TITLE
Fix white background on snapshot image thumbnail with transparent `backgroundColor`

### DIFF
--- a/src/components/SnapshotImageThumb.stories.tsx
+++ b/src/components/SnapshotImageThumb.stories.tsx
@@ -31,7 +31,18 @@ export const Positive = {
 
 export const Small = {
   args: {
-    backgroundColor: "rgba(255, 255, 255, 1)",
     thumbnailUrl: "/capture-16b798d6.png",
+  },
+} satisfies Story;
+
+export const BackgroundColor = {
+  args: {
+    backgroundColor: "#313d4c",
+  },
+} satisfies Story;
+
+export const TransparentBackground = {
+  args: {
+    backgroundColor: "rbga(0, 0, 0, 0)",
   },
 } satisfies Story;

--- a/src/components/SnapshotImageThumb.tsx
+++ b/src/components/SnapshotImageThumb.tsx
@@ -5,7 +5,6 @@ import React from "react";
 const Wrapper = styled.div<{ status?: "positive" }>(({ status, theme }) => ({
   position: "relative",
   display: "inline-flex",
-  backgroundColor: "white",
   border: `1px solid ${status === "positive" ? theme.color.green : theme.appBorderColor}`,
   borderRadius: 5,
   margin: "15px 15px 0",
@@ -13,15 +12,6 @@ const Wrapper = styled.div<{ status?: "positive" }>(({ status, theme }) => ({
   minWidth: 200,
   maxWidth: 500,
 
-  div: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    width: "100%",
-    border: `2px solid ${theme.background.content}`,
-    borderRadius: 4,
-    overflow: "hidden",
-  },
   img: {
     display: "block",
     maxWidth: "100%",
@@ -39,6 +29,22 @@ const Wrapper = styled.div<{ status?: "positive" }>(({ status, theme }) => ({
   },
 }));
 
+const Background = styled.div({
+  width: "100%",
+  margin: 2,
+  background: "white",
+  borderRadius: 3,
+  overflow: "hidden",
+
+  div: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    height: "100%",
+  },
+});
+
 interface SnapshotImageThumbProps {
   backgroundColor?: string | null;
   status?: "positive";
@@ -52,9 +58,11 @@ export const SnapshotImageThumb = ({
 }: SnapshotImageThumbProps & React.ImgHTMLAttributes<HTMLImageElement>) => {
   return (
     <Wrapper status={status}>
-      <div style={backgroundColor ? { backgroundColor } : {}}>
-        <img alt="Snapshot thumbnail" src={thumbnailUrl} />
-      </div>
+      <Background>
+        <div style={backgroundColor ? { backgroundColor } : {}}>
+          <img alt="Snapshot thumbnail" src={thumbnailUrl} />
+        </div>
+      </Background>
       {status === "positive" && <CheckIcon />}
     </Wrapper>
   );

--- a/src/components/SnapshotImageThumb.tsx
+++ b/src/components/SnapshotImageThumb.tsx
@@ -5,21 +5,26 @@ import React from "react";
 const Wrapper = styled.div<{ status?: "positive" }>(({ status, theme }) => ({
   position: "relative",
   display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  backgroundColor: theme.background.content,
+  backgroundColor: "white",
   border: `1px solid ${status === "positive" ? theme.color.green : theme.appBorderColor}`,
   borderRadius: 5,
   margin: "15px 15px 0",
-  padding: 5,
   minHeight: 200,
   minWidth: 200,
   maxWidth: 500,
 
+  div: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    border: `2px solid ${theme.background.content}`,
+    borderRadius: 4,
+    overflow: "hidden",
+  },
   img: {
     display: "block",
     maxWidth: "100%",
-    borderRadius: 3,
   },
   svg: {
     position: "absolute",
@@ -46,8 +51,10 @@ export const SnapshotImageThumb = ({
   thumbnailUrl,
 }: SnapshotImageThumbProps & React.ImgHTMLAttributes<HTMLImageElement>) => {
   return (
-    <Wrapper status={status} style={backgroundColor ? { backgroundColor } : {}}>
-      <img alt="Snapshot thumbnail" src={thumbnailUrl} />
+    <Wrapper status={status}>
+      <div style={backgroundColor ? { backgroundColor } : {}}>
+        <img alt="Snapshot thumbnail" src={thumbnailUrl} />
+      </div>
       {status === "positive" && <CheckIcon />}
     </Wrapper>
   );


### PR DESCRIPTION
If the `backgroundColor` for a snapshot is transparent (e.g. `rgba(0, 0, 0, 0)` which is the default), the thumbnail would render against that transparent background rather than the intended white background (which would be the effective page background color). This fixes that issue and adds some stories to verify it.

<img width="882" alt="Screenshot 2024-04-04 at 20 42 02" src="https://github.com/chromaui/addon-visual-tests/assets/321738/13839280-6fb5-49af-9ce3-2a330efd5d49">

<img width="884" alt="Screenshot 2024-04-04 at 20 43 32" src="https://github.com/chromaui/addon-visual-tests/assets/321738/00132e7e-77c7-4655-b163-56a54d964ce2">

Additionally, I tweaked the UI to have a little border around the snapshot, similar to what we have on the Chromatic webapp (note the white border):

<img width="251" alt="Screenshot 2024-04-04 at 20 03 01" src="https://github.com/chromaui/addon-visual-tests/assets/321738/27d2422b-a70b-4483-b443-664b53c1ab97">
