### PR TITLE
Deeply reset the build progress when starting a new build

### DIFF
--- a/src/buildSteps.ts
+++ b/src/buildSteps.ts
@@ -132,3 +132,5 @@ export const INITIAL_BUILD_PAYLOAD = {
     StepProgressPayload
   >,
 };
+
+export const INITIAL_BUILD_PAYLOAD_JSON = JSON.stringify(INITIAL_BUILD_PAYLOAD);

--- a/src/runChromaticBuild.ts
+++ b/src/runChromaticBuild.ts
@@ -6,7 +6,7 @@ import {
   BUILD_STEP_CONFIG,
   BUILD_STEP_ORDER,
   hasProgressEvent,
-  INITIAL_BUILD_PAYLOAD,
+  INITIAL_BUILD_PAYLOAD_JSON,
   isKnownStep,
 } from "./buildSteps";
 import { CONFIG_OVERRIDES } from "./constants";
@@ -184,7 +184,8 @@ export const runChromaticBuild = async (
   if (!options.projectId) throw new Error("Missing projectId");
   if (!options.userToken) throw new Error("Missing userToken");
 
-  localBuildProgress.value = INITIAL_BUILD_PAYLOAD;
+  // Set initial progress state. JSON.parse avoids mutating the constant.
+  localBuildProgress.value = JSON.parse(INITIAL_BUILD_PAYLOAD_JSON);
 
   // Timeout is defined here so it's shared between all handlers
   let timeout: ReturnType<typeof setTimeout> | undefined;


### PR DESCRIPTION
Fixes #252 

The `localBuildProgress` value is mutated during the build, which was affecting `INITIAL_BUILD_PAYLOAD` causing subsequent builds to think steps had already been completed. By ensuring a clean initial value each time, this issue is avoided.

I could've avoided the mutation itself, but that would've been a brittle fix prone to regression.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.1--canary.284.bf6291a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.3.1--canary.284.bf6291a.0
  # or 
  yarn add @chromatic-com/storybook@1.3.1--canary.284.bf6291a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
