### PR TITLE
Update dev config to load `preset.ts` rather than `index.ts`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -24,7 +24,7 @@ const config: StorybookConfig = {
     "@storybook/addon-interactions",
     "@storybook/addon-designs",
     {
-      name: useDistVersion ? "../dist/index.js" : "../src/dev.ts",
+      name: useDistVersion ? "../dist/preset.js" : "../src/dev.ts",
       options: {
         configFile: configFileMap[CHROMATIC_BASE_URL || '"https://www.chromatic.com"'],
       },

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -1,4 +1,4 @@
-import config from "./index";
+import config from "./preset";
 
 export default {
   ...config,


### PR DESCRIPTION
#289 renamed `index.ts` to `preset.ts` but failed to update the VTA's own Storybook config accordingly. This corrects that oversight.

Note this affects only the VTA's own development Storybook, not the VTA itself.