### PR TITLE
Upgrade Chromatic CLI dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
     "yarn": ">=1.22.18"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "bundler": {
     "exportEntries": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jackspeak": "2.1.1"
   },
   "dependencies": {
-    "chromatic": "^11.3.0",
+    "chromatic": "11.3.1--canary.974.8970353514.0",
     "filesize": "^10.0.12",
     "jsonfile": "^6.1.0",
     "react-confetti": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jackspeak": "2.1.1"
   },
   "dependencies": {
-    "chromatic": "11.3.1--canary.974.8970353514.0",
+    "chromatic": "^11.3.1",
     "filesize": "^10.0.12",
     "jsonfile": "^6.1.0",
     "react-confetti": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5098,10 +5098,10 @@ chownr@^2.0.0:
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromatic@11.3.1--canary.974.8970353514.0:
-  version "11.3.1--canary.974.8970353514.0"
-  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.3.1--canary.974.8970353514.0.tgz#92383bd384cc5e3b7ae6593b05baf1e8588653fe"
-  integrity sha512-DbpBEguyjVSxC0O7CBeyY7VPbmIpmtqnehbzW76bqsj+4RbguGHbm1mcG1A5iSt/B1fbmA0S706wylqO8cxq0w==
+chromatic@^11.3.1:
+  version "11.3.1"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.3.1.tgz#e59b1946d073c08bccb2692d89cdef9976e2477a"
+  integrity sha512-ATAfVEn84NARTIxdiGQ8QywWg3BPM/+6stVD1stSKCO7lQLEKFyGcI+PhBBDt+ZgNcgsEsg5fo3E2dQNt01W6g==
 
 citty@^0.1.5:
   version "0.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5098,10 +5098,10 @@ chownr@^2.0.0:
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromatic@^11.3.0:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.3.0.tgz#d46b7aac1a0eaed29a765645eaf93c484220174c"
-  integrity sha512-q1ZtJDJrjLGnz60ivpC16gmd7KFzcaA4eTb7gcytCqbaKqlHhCFr1xQmcUDsm14CK7JsqdkFU6S+JQdOd2ZNJg==
+chromatic@11.3.1--canary.974.8970353514.0:
+  version "11.3.1--canary.974.8970353514.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.3.1--canary.974.8970353514.0.tgz#92383bd384cc5e3b7ae6593b05baf1e8588653fe"
+  integrity sha512-DbpBEguyjVSxC0O7CBeyY7VPbmIpmtqnehbzW76bqsj+4RbguGHbm1mcG1A5iSt/B1fbmA0S706wylqO8cxq0w==
 
 citty@^0.1.5:
   version "0.1.5"


### PR DESCRIPTION
Upgrades the CLI to include [this fix](https://github.com/chromaui/chromatic-cli/pull/974). Fixes #292

Also pins the registry for publishing to npmjs.org, as I noticed it was using yarnpkg.org during publish.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.4--canary.297.538317b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.3.4--canary.297.538317b.0
  # or 
  yarn add @chromatic-com/storybook@1.3.4--canary.297.538317b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
