### PR TITLE
Support builds from (supposed) forked repository or monorepo setup

### DIFF
--- a/src/screens/VisualTests/BuildContext.tsx
+++ b/src/screens/VisualTests/BuildContext.tsx
@@ -90,14 +90,14 @@ export const useBuild = ({
     account: data?.project?.account,
     hasData: !!data && !storyDataIsStale,
     hasProject: !!data?.project,
-    hasSelectedBuild: selectedBuild?.branch === gitInfo.branch,
+    hasSelectedBuild: selectedBuild?.branch.split(":").at(-1) === gitInfo.branch,
     lastBuildOnBranch,
     lastBuildOnBranchIsNewer,
     lastBuildOnBranchIsReady,
     lastBuildOnBranchIsSelectable,
     selectedBuild,
     selectedBuildMatchesGit:
-      selectedBuild?.branch === gitInfo.branch &&
+      selectedBuild?.branch.split(":").at(-1) === gitInfo.branch &&
       selectedBuild?.commit === gitInfo.commit &&
       selectedBuild?.uncommittedHash === gitInfo.uncommittedHash,
     rerunQuery,


### PR DESCRIPTION
When the owner name of the local Git repository doesn't match that of the repository linked to the Chromatic project, local builds will have branch names prefixed with the local owner name (to indicate that the build originates from a fork).

When selecting a build in the VTA, this owner name prefix isn't taken into account, causing the VTA to hang while it looks for a build matching the local Git branch. This PR addresses this mismatch by disregarding the potential owner name prefix. This is safe to do because the BuildQuery already filters by owner name, so we needn't check it again.

Fixes #290 