### PR TITLE
Show message when snapshotting is disabled for story

### DIFF
--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -1,5 +1,6 @@
 import { Loader } from "@storybook/components";
 import { PlayIcon } from "@storybook/icons";
+import { useParameter } from "@storybook/manager-api";
 import { styled } from "@storybook/theming";
 import React from "react";
 import { CombinedError } from "urql";
@@ -44,6 +45,7 @@ export const NoBuild = ({
 }: NoBuildProps) => {
   const { setAccessToken } = useAuthState();
   const { isRunning, startBuild } = useRunBuildState();
+  const { disable, disableSnapshot, docsOnly } = useParameter("chromatic", {} as any);
 
   const getDetails = () => {
     const button = (
@@ -127,6 +129,31 @@ export const NoBuild = ({
 
             <ButtonStackLink isButton onClick={() => setAccessToken(null)} withArrow>
               Switch account
+            </ButtonStackLink>
+          </Stack>
+        </Container>
+      );
+    }
+
+    if (disable || disableSnapshot || docsOnly) {
+      // eslint-disable-next-line no-nested-ternary
+      const param = disable ? "disable" : disableSnapshot ? "disableSnapshot" : "docsOnly";
+      return (
+        <Container>
+          <Stack>
+            <div>
+              <Heading>Visual Tests disabled for this story</Heading>
+              <Text center muted>
+                Update <code>parameters.chromatic.{param}</code> to enable snapshots for this story.
+              </Text>
+            </div>
+
+            <ButtonStackLink
+              withArrow
+              href="https://www.chromatic.com/docs/ignoring-elements/#ignore-stories"
+              target="_blank"
+            >
+              Read more
             </ButtonStackLink>
           </Stack>
         </Container>

--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -114,6 +114,7 @@ type StoryArgs = Parameters<typeof VisualTestsWithoutSelectedBuildId>[0] & {
   togglePanelPosition: () => void;
   setSelectedPanel: () => void;
   getCurrentStoryData: () => any;
+  getCurrentParameter: () => any;
   once: () => void;
   $graphql?: { AddonVisualTestsBuild?: QueryInput };
 };
@@ -131,6 +132,7 @@ const meta = {
     togglePanelPosition: { type: "function", target: "manager-api" },
     setSelectedPanel: { type: "function", target: "manager-api" },
     getCurrentStoryData: { type: "function", target: "manager-api" },
+    getCurrentParameter: { type: "function", target: "manager-api" },
     once: { type: "function", target: "manager-api" },
     $graphql: {
       AddonVisualTestsBuild: { map: mapQuery },
@@ -160,6 +162,7 @@ const meta = {
     togglePanelPosition: fn(),
     setSelectedPanel: fn(),
     getCurrentStoryData: () => ({ type: "story" }),
+    getCurrentParameter: () => ({}),
     once: fn(),
     $graphql: { AddonVisualTestsBuild: {} },
   },
@@ -814,6 +817,19 @@ export const Accepted = {
   parameters: {
     ...withFigmaDesign(
       "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=508-305053&t=0rxMQnkxsVpVj1qy-4"
+    ),
+  },
+} satisfies Story;
+
+export const Disabled = {
+  args: {
+    storyId: "button--tertiary",
+    selectedBuildInfo: { buildId: pendingBuild.id, storyId: meta.args.storyId },
+    getCurrentParameter: () => ({ disableSnapshot: true }),
+  },
+  parameters: {
+    ...withFigmaDesign(
+      "https://www.figma.com/file/GFEbCgCVDtbZhngULbw2gP/Visual-testing-in-Storybook?type=design&node-id=2255-42087&t=a8NRPgQk3kXMyxqZ-0"
     ),
   },
 } satisfies Story;


### PR DESCRIPTION
Snapshots may be disabled using the `disable`, `disableSnapshot` or `docsOnly` parameter. If this happens, we now show a message explaining how to enable visual tests:

<img width="504" alt="Screenshot 2024-05-08 at 12 43 45" src="https://github.com/chromaui/addon-visual-tests/assets/321738/198b2448-6bda-4d27-893d-6666a0c2c817">
