### PR TITLE
Poll for API connection and show notification when it fails

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -115,7 +115,7 @@ export const Panel = ({ active, api }: PanelProps) => {
   }
 
   if (apiInfo?.connected === false) {
-    return withProviders(<NoNetwork />);
+    return withProviders(<NoNetwork aborted={apiInfo.aborted} />);
   }
 
   // Render the Authentication flow if the user is not signed in.

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from "./AuthContext";
 import { Spinner } from "./components/design-system";
 import {
   ADDON_ID,
+  API_INFO,
   GIT_INFO,
   GIT_INFO_ERROR,
   IS_OUTDATED,
@@ -20,12 +21,13 @@ import { LinkedProject } from "./screens/LinkProject/LinkedProject";
 import { LinkingProjectFailed } from "./screens/LinkProject/LinkingProjectFailed";
 import { LinkProject } from "./screens/LinkProject/LinkProject";
 import { NoDevServer } from "./screens/NoDevServer/NoDevServer";
+import { NoNetwork } from "./screens/NoNetwork/NoNetwork";
 import { UninstallProvider } from "./screens/Uninstalled/UninstallContext";
 import { Uninstalled } from "./screens/Uninstalled/Uninstalled";
 import { ControlsProvider } from "./screens/VisualTests/ControlsContext";
 import { RunBuildProvider } from "./screens/VisualTests/RunBuildContext";
 import { VisualTests } from "./screens/VisualTests/VisualTests";
-import { GitInfoPayload, LocalBuildProgress, UpdateStatusFunction } from "./types";
+import { APIInfoPayload, GitInfoPayload, LocalBuildProgress, UpdateStatusFunction } from "./types";
 import { client, Provider, useAccessToken } from "./utils/graphQLClient";
 import { TelemetryProvider } from "./utils/TelemetryContext";
 import { useBuildEvents } from "./utils/useBuildEvents";
@@ -49,6 +51,7 @@ export const Panel = ({ active, api }: PanelProps) => {
   );
   const { storyId } = useStorybookState();
 
+  const [apiInfo] = useSharedState<APIInfoPayload>(API_INFO);
   const [gitInfo] = useSharedState<GitInfoPayload>(GIT_INFO);
   const [gitInfoError] = useSharedState<Error>(GIT_INFO_ERROR);
   const [isOutdated] = useSharedState<boolean>(IS_OUTDATED);
@@ -109,6 +112,10 @@ export const Panel = ({ active, api }: PanelProps) => {
 
   if (addonUninstalled) {
     return withProviders(<Uninstalled />);
+  }
+
+  if (apiInfo?.connected === false) {
+    return withProviders(<NoNetwork />);
   }
 
   // Render the Authentication flow if the user is not signed in.

--- a/src/SidebarTop.tsx
+++ b/src/SidebarTop.tsx
@@ -6,13 +6,14 @@ import React, { useCallback, useEffect, useRef } from "react";
 import { SidebarTopButton } from "./components/SidebarTopButton";
 import {
   ADDON_ID,
+  API_INFO,
   CONFIG_INFO,
   GIT_INFO_ERROR,
   IS_OUTDATED,
   LOCAL_BUILD_PROGRESS,
   PANEL_ID,
 } from "./constants";
-import { ConfigInfoPayload, LocalBuildProgress } from "./types";
+import { APIInfoPayload, ConfigInfoPayload, LocalBuildProgress } from "./types";
 import { useAccessToken } from "./utils/graphQLClient";
 import { useBuildEvents } from "./utils/useBuildEvents";
 import { useProjectId } from "./utils/useProjectId";
@@ -32,6 +33,7 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
   const [isOutdated] = useSharedState<boolean>(IS_OUTDATED);
   const [localBuildProgress] = useSharedState<LocalBuildProgress>(LOCAL_BUILD_PROGRESS);
 
+  const [apiInfo] = useSharedState<APIInfoPayload>(API_INFO);
   const [configInfo] = useSharedState<ConfigInfoPayload>(CONFIG_INFO);
   const hasConfigProblem = Object.keys(configInfo?.problems || {}).length > 0;
 
@@ -173,6 +175,7 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
   const { isRunning, startBuild, stopBuild } = useBuildEvents({ localBuildProgress, accessToken });
 
   let warning;
+  if (apiInfo?.connected === false) warning = "Visual tests locked while waiting for network.";
   if (!projectId) warning = "Visual tests locked until a project is selected.";
   if (!isLoggedIn) warning = "Visual tests locked until you are logged in.";
   if (gitInfoError) warning = "Visual tests locked due to Git synchronization problem.";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const SIDEBAR_TOP_ID = `${ADDON_ID}/sidebarTop`;
 export const SIDEBAR_BOTTOM_ID = `${ADDON_ID}/sidebarBottom`;
 export const ACCESS_TOKEN_KEY = `${ADDON_ID}/access-token/${CHROMATIC_BASE_URL}`;
 export const DEV_BUILD_ID_KEY = `${ADDON_ID}/dev-build-id`;
+export const API_INFO = `${ADDON_ID}/apiInfo`;
 export const CONFIG_INFO = `${ADDON_ID}/configInfo`;
 export const CONFIG_INFO_DISMISSED = `${ADDON_ID}/configInfoDismissed`;
 export const GIT_INFO = `${ADDON_ID}/gitInfo`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,7 @@ export const SELECTED_BROWSER_ID = `${ADDON_ID}/selectedBrowserId`;
 export const TELEMETRY = `${ADDON_ID}/telemetry`;
 
 export const REMOVE_ADDON = `${ADDON_ID}/removeAddon`;
+export const RETRY_CONNECTION = `${ADDON_ID}/retryConnection`;
 
 export const CONFIG_OVERRIDES = {
   // Local changes should never be auto-accepted

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -35,9 +35,9 @@ addons.register(ADDON_ID, (api) => {
   if (!channel) return;
 
   let notificationShown = false;
-  channel.on(`${ADDON_ID}/heartbeat`, ({ apiConnected }: { apiConnected: boolean }) => {
+  channel.on(`${ADDON_ID}/heartbeat`, () => {
     clearTimeout(heartbeatTimeout);
-    if (notificationShown && apiConnected) {
+    if (notificationShown) {
       notificationShown = false;
       api.clearNotification(`${ADDON_ID}/connection-lost`);
     }
@@ -57,22 +57,5 @@ addons.register(ADDON_ID, (api) => {
         link: undefined,
       });
     }, 3000);
-
-    if (!apiConnected && !notificationShown) {
-      notificationShown = true;
-      api.addNotification({
-        id: `${ADDON_ID}/connection-lost`,
-        content: {
-          headline: "No network",
-          subHeadline: "Lost connection to the Chromatic API. Are you offline?",
-        },
-        icon: {
-          name: "failed",
-          color: color.negative,
-        },
-        // @ts-expect-error SB needs a proper API for no link
-        link: undefined,
-      });
-    }
   });
 });

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -35,9 +35,9 @@ addons.register(ADDON_ID, (api) => {
   if (!channel) return;
 
   let notificationShown = false;
-  channel.on(`${ADDON_ID}/heartbeat`, () => {
+  channel.on(`${ADDON_ID}/heartbeat`, ({ apiConnected }: { apiConnected: boolean }) => {
     clearTimeout(heartbeatTimeout);
-    if (notificationShown) {
+    if (notificationShown && apiConnected) {
       notificationShown = false;
       api.clearNotification(`${ADDON_ID}/connection-lost`);
     }
@@ -57,5 +57,22 @@ addons.register(ADDON_ID, (api) => {
         link: undefined,
       });
     }, 3000);
+
+    if (!apiConnected && !notificationShown) {
+      notificationShown = true;
+      api.addNotification({
+        id: `${ADDON_ID}/connection-lost`,
+        content: {
+          headline: "No network",
+          subHeadline: "Lost connection to the Chromatic API. Are you offline?",
+        },
+        icon: {
+          name: "failed",
+          color: color.negative,
+        },
+        // @ts-expect-error SB needs a proper API for no link
+        link: undefined,
+      });
+    }
   });
 });

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -271,10 +271,7 @@ async function serverChannel(channel: Channel, options: Options & { configFile?:
     configInfoState.value = await getConfigInfo(configuration, options);
   });
 
-  setInterval(
-    () => channel.emit(`${ADDON_ID}/heartbeat`, { apiConnected: apiInfoState.value?.connected }),
-    1000
-  );
+  setInterval(() => channel.emit(`${ADDON_ID}/heartbeat`), 1000);
 
   return channel;
 }

--- a/src/screens/NoNetwork/NoNetwork.stories.tsx
+++ b/src/screens/NoNetwork/NoNetwork.stories.tsx
@@ -1,0 +1,11 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { NoNetwork } from "./NoNetwork";
+
+const meta = {
+  component: NoNetwork,
+} satisfies Meta<typeof NoNetwork>;
+
+export const Default = {} satisfies StoryObj<typeof meta>;
+
+export default meta;

--- a/src/screens/NoNetwork/NoNetwork.stories.tsx
+++ b/src/screens/NoNetwork/NoNetwork.stories.tsx
@@ -6,6 +6,6 @@ const meta = {
   component: NoNetwork,
 } satisfies Meta<typeof NoNetwork>;
 
-export const Default = {} satisfies StoryObj<typeof meta>;
-
 export default meta;
+
+export const Default = {} satisfies StoryObj<typeof meta>;

--- a/src/screens/NoNetwork/NoNetwork.stories.tsx
+++ b/src/screens/NoNetwork/NoNetwork.stories.tsx
@@ -4,8 +4,17 @@ import { NoNetwork } from "./NoNetwork";
 
 const meta = {
   component: NoNetwork,
+  args: {
+    aborted: false,
+  },
 } satisfies Meta<typeof NoNetwork>;
 
 export default meta;
 
 export const Default = {} satisfies StoryObj<typeof meta>;
+
+export const Aborted = {
+  args: {
+    aborted: true,
+  },
+} satisfies StoryObj<typeof meta>;

--- a/src/screens/NoNetwork/NoNetwork.tsx
+++ b/src/screens/NoNetwork/NoNetwork.tsx
@@ -1,14 +1,19 @@
-import { AlertIcon } from "@storybook/icons";
+import { AlertIcon, SyncIcon } from "@storybook/icons";
+import { useChannel } from "@storybook/manager-api";
 import React from "react";
 
 import { Button } from "../../components/Button";
 import { Container } from "../../components/Container";
+import { Link } from "../../components/design-system";
 import { Heading } from "../../components/Heading";
 import { Screen } from "../../components/Screen";
 import { Stack } from "../../components/Stack";
 import { Text } from "../../components/Text";
+import { RETRY_CONNECTION } from "../../constants";
 
 export const NoNetwork = () => {
+  const emit = useChannel({});
+  const retry = () => emit(RETRY_CONNECTION);
   return (
     <Screen footer={null}>
       <Container>
@@ -20,11 +25,13 @@ export const NoNetwork = () => {
               Double check your internet connection and firewall settings.
             </Text>
           </div>
-          <Button asChild size="medium" variant="solid">
-            <a href="https://status.chromatic.com" target="_blank" rel="noreferrer">
-              Check API status
-            </a>
+          <Button size="medium" variant="solid" onClick={retry}>
+            <SyncIcon />
+            Retry
           </Button>
+          <Link href="https://status.chromatic.com" target="_blank" rel="noreferrer" withArrow>
+            Chromatic API status
+          </Link>
         </Stack>
       </Container>
     </Screen>

--- a/src/screens/NoNetwork/NoNetwork.tsx
+++ b/src/screens/NoNetwork/NoNetwork.tsx
@@ -1,4 +1,4 @@
-import { AlertIcon, SyncIcon } from "@storybook/icons";
+import { SyncIcon } from "@storybook/icons";
 import { useChannel } from "@storybook/manager-api";
 import { styled } from "@storybook/theming";
 import React, { useEffect, useState } from "react";
@@ -34,7 +34,6 @@ export const NoNetwork = ({ aborted }: { aborted: boolean }) => {
     <Screen footer={null}>
       <Container>
         <Stack>
-          <AlertIcon width={32} height={32} />
           <div>
             <Heading>Can't connect to Chromatic</Heading>
             <Text center muted>

--- a/src/screens/NoNetwork/NoNetwork.tsx
+++ b/src/screens/NoNetwork/NoNetwork.tsx
@@ -1,0 +1,32 @@
+import { AlertIcon } from "@storybook/icons";
+import React from "react";
+
+import { Button } from "../../components/Button";
+import { Container } from "../../components/Container";
+import { Heading } from "../../components/Heading";
+import { Screen } from "../../components/Screen";
+import { Stack } from "../../components/Stack";
+import { Text } from "../../components/Text";
+
+export const NoNetwork = () => {
+  return (
+    <Screen footer={null}>
+      <Container>
+        <Stack>
+          <AlertIcon width={32} height={32} />
+          <div>
+            <Heading>Can't connect to Chromatic</Heading>
+            <Text center muted>
+              Double check your internet connection and firewall settings.
+            </Text>
+          </div>
+          <Button asChild size="medium" variant="solid">
+            <a href="https://status.chromatic.com" target="_blank" rel="noreferrer">
+              Check API status
+            </a>
+          </Button>
+        </Stack>
+      </Container>
+    </Screen>
+  );
+};

--- a/src/screens/NoNetwork/NoNetwork.tsx
+++ b/src/screens/NoNetwork/NoNetwork.tsx
@@ -1,19 +1,35 @@
 import { AlertIcon, SyncIcon } from "@storybook/icons";
 import { useChannel } from "@storybook/manager-api";
-import React from "react";
+import { styled } from "@storybook/theming";
+import React, { useEffect, useState } from "react";
 
 import { Button } from "../../components/Button";
 import { Container } from "../../components/Container";
 import { Link } from "../../components/design-system";
+import { rotate360 } from "../../components/design-system/shared/animation";
 import { Heading } from "../../components/Heading";
 import { Screen } from "../../components/Screen";
 import { Stack } from "../../components/Stack";
 import { Text } from "../../components/Text";
 import { RETRY_CONNECTION } from "../../constants";
 
-export const NoNetwork = () => {
+const SpinIcon = styled(SyncIcon)({
+  animation: `${rotate360} 1s linear infinite`,
+});
+
+export const NoNetwork = ({ aborted }: { aborted: boolean }) => {
+  const [retried, setRetried] = useState(false);
   const emit = useChannel({});
-  const retry = () => emit(RETRY_CONNECTION);
+
+  const retry = () => {
+    setRetried(true);
+    emit(RETRY_CONNECTION);
+  };
+
+  useEffect(() => {
+    setRetried(false);
+  }, [aborted]);
+
   return (
     <Screen footer={null}>
       <Container>
@@ -25,10 +41,17 @@ export const NoNetwork = () => {
               Double check your internet connection and firewall settings.
             </Text>
           </div>
-          <Button size="medium" variant="solid" onClick={retry}>
-            <SyncIcon />
-            Retry
-          </Button>
+          {aborted ? (
+            <Button size="medium" variant="solid" onClick={retry} disabled={retried}>
+              <SyncIcon />
+              Retry
+            </Button>
+          ) : (
+            <Button size="medium" variant="ghost" onClick={retry} disabled={retried}>
+              <SpinIcon />
+              Connecting...
+            </Button>
+          )}
           <Link href="https://status.chromatic.com" target="_blank" rel="noreferrer" withArrow>
             Chromatic API status
           </Link>

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type ConfigurationUpdate = {
 };
 
 export type APIInfoPayload = {
+  aborted: boolean;
   connected: boolean;
 };
 export type ConfigInfoPayload = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,9 @@ export type ConfigurationUpdate = {
   [Property in keyof Configuration]: Configuration[Property] | null;
 };
 
+export type APIInfoPayload = {
+  connected: boolean;
+};
 export type ConfigInfoPayload = {
   configuration: Awaited<ReturnType<typeof getConfiguration>>;
   problems?: ConfigurationUpdate;


### PR DESCRIPTION
Runs a (server-side) GraphQL query every 5 seconds to check whether it's connected. If not, it prevents starting a new build:

<img width="244" alt="Screenshot 2024-05-10 at 16 37 15" src="https://github.com/chromaui/addon-visual-tests/assets/321738/49064d0d-0b99-477a-8445-96de030a5f64">

And shows a warning screen in the addon panel:

<img width="437" alt="Screenshot 2024-05-13 at 14 16 01" src="https://github.com/chromaui/addon-visual-tests/assets/321738/34c12895-cc1f-45bd-984f-dbd252ddad9d">

These automatically go away when the connection is restored (delayed up to 5 seconds as it polls).

When the automatic retry is aborted after 10 attempts (~50 seconds), the user is prompted to retry manually:

<img width="432" alt="Screenshot 2024-05-13 at 14 16 33" src="https://github.com/chromaui/addon-visual-tests/assets/321738/37c5e311-baad-4cf1-8745-630e8ee0ee87">

This way we don't just keep trying indefinitely when there is no internet connection.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.4.0--canary.303.3053a3b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.4.0--canary.303.3053a3b.0
  # or 
  yarn add @chromatic-com/storybook@1.4.0--canary.303.3053a3b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
