### PR TITLE
Allow interacting with Storybook UI through the Joyride overlay

### DIFF
--- a/src/screens/GuidedTour/GuidedTour.tsx
+++ b/src/screens/GuidedTour/GuidedTour.tsx
@@ -278,6 +278,7 @@ export const GuidedTour = ({
           overlay: {
             mixBlendMode: "unset",
             backgroundColor: "none",
+            pointerEvents: "none",
           },
           spotlight: {
             backgroundColor: "none",


### PR DESCRIPTION
The Joyride (guided tour) overlay normally prevents the user from interacting with the underlying page. However, it's possible for the "spotlight" area (which can be interacted with) to be positioned outside the viewport. When this happens it's impossible to continue or skip the tour since the entire screen is locked. By disabling user events on the overlay, it becomes possible to interact with the content below, including scrolling the sidebar. This is the simplest fix and while it's a little weird to be able to use Storybook with an overlay on top, I think that's a reasonable tradeoff.

https://github.com/chromaui/addon-visual-tests/assets/321738/d2153924-2ba7-40d9-803d-a053eb6f0308

It's a little weird that the overlay removes itself while scrolling, unfortunately I didn't find a way to prevent that.