### PR TITLE
Suggest enabling TurboSnap and use all suggestions in generated config file

### DIFF
--- a/src/components/Screen.stories.tsx
+++ b/src/components/Screen.stories.tsx
@@ -29,7 +29,6 @@ export const Default: Story = {};
 const configuration = {
   configFile: "chromatic.config.json",
   projectId: "Project:6480e1b0042842f149cfd74c",
-  onlyChanged: true,
   externals: ["public/**"],
   autoAcceptChanges: "main",
   exitOnceUploaded: true,
@@ -40,7 +39,7 @@ export const Configuration: Story = {
     withSharedState(CONFIG_INFO, {
       configuration,
       problems: { storybookBaseDir: "src/frontend" },
-      suggestions: { zip: true },
+      suggestions: { onlyChanged: true, zip: true },
     } satisfies ConfigInfoPayload),
   ],
   parameters: {
@@ -55,7 +54,6 @@ export const ConfigurationProblems = {
     withSharedState(CONFIG_INFO, {
       configuration,
       problems: { storybookBaseDir: "src/frontend" },
-      suggestions: { zip: true },
     }),
   ],
 } satisfies StoryObj<typeof meta>;
@@ -65,7 +63,7 @@ export const ConfigurationSuggestions = {
     withSetup(() => localStorage.removeItem(CONFIG_INFO_DISMISSED)),
     withSharedState(CONFIG_INFO, {
       configuration,
-      suggestions: { zip: true },
+      suggestions: { onlyChanged: true, zip: true },
     }),
   ],
 } satisfies StoryObj<typeof meta>;

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -176,7 +176,14 @@ async function serverChannel(channel: Channel, options: Options & { configFile?:
       // No config file may be found (file is about to be created)
       const { configFile: foundConfigFile, ...config } = await getConfiguration(writtenConfigFile);
       const targetConfigFile = foundConfigFile || writtenConfigFile || "chromatic.config.json";
-      await updateChromaticConfig(targetConfigFile, { ...config, projectId, zip: true });
+      const { problems, suggestions } = await getConfigInfo(config, options);
+      await updateChromaticConfig(targetConfigFile, {
+        ...config,
+        ...problems,
+        ...suggestions,
+        onlyChanged: true,
+        projectId,
+      });
 
       projectInfoState.value = {
         ...projectInfoState.value,

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -93,7 +93,11 @@ const getConfigInfo = async (
     problems.storybookConfigDir = configDir;
   }
 
-  if (!configuration.zip) {
+  if (configuration.onlyChanged === undefined) {
+    suggestions.onlyChanged = true;
+  }
+
+  if (configuration.zip === undefined) {
     suggestions.zip = true;
   }
 
@@ -181,7 +185,6 @@ async function serverChannel(channel: Channel, options: Options & { configFile?:
         ...config,
         ...problems,
         ...suggestions,
-        onlyChanged: true,
         projectId,
       });
 

--- a/src/screens/VisualTests/Configuration.tsx
+++ b/src/screens/VisualTests/Configuration.tsx
@@ -302,7 +302,7 @@ export const Configuration = ({ onClose }: ConfigurationProps) => {
         <CloseIcon aria-label="Close" />
       </StyledCloseButton>
       <PageWrapper>
-        <Heading>Configuration </Heading>
+        <Heading>Configuration</Heading>
         {configFile ? (
           <PageDescription>
             This is a read-only representation of the Chromatic configuration options found in{" "}

--- a/src/utils/updateChromaticConfig.ts
+++ b/src/utils/updateChromaticConfig.ts
@@ -2,5 +2,8 @@ import type { Configuration } from "chromatic/node";
 import { writeFile } from "jsonfile";
 
 export async function updateChromaticConfig(configFile: string, configuration: Configuration) {
-  await writeFile(configFile, configuration, { spaces: 2 });
+  const formatted = Object.entries(configuration)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .reduce((acc, [key, val]) => (val === null ? acc : Object.assign(acc, { [key]: val })), {});
+  await writeFile(configFile, formatted, { spaces: 2 });
 }


### PR DESCRIPTION
Uses any config suggestions/problems as input when generating a Chromatic config file, and add `onlyChanged: true` to setup TurboSnap.

Also, the generated config file is now formatted to list properties in alphabetical order.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.6--canary.306.7d1ae70.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.3.6--canary.306.7d1ae70.0
  # or 
  yarn add @chromatic-com/storybook@1.3.6--canary.306.7d1ae70.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
