### PR TITLE
Hide refs (composed Storybooks) while guided tour is active

### DIFF
--- a/src/screens/GuidedTour/GuidedTour.tsx
+++ b/src/screens/GuidedTour/GuidedTour.tsx
@@ -62,6 +62,20 @@ export const GuidedTour = ({
   const nextStep = () => setStepIndex((prev = 0) => prev + 1);
 
   useEffect(() => {
+    // Hide composed Storybooks (refs) in the sidebar while the guided tour is active.
+    const explorer = document.getElementById("storybook-explorer-tree");
+    const refElements = Array.from(explorer instanceof HTMLElement ? explorer.children : [])
+      .filter((el): el is HTMLElement => el instanceof HTMLElement)
+      .slice(1);
+
+    // eslint-disable-next-line no-param-reassign, no-return-assign
+    refElements.forEach((el) => (el.style.display = "none"));
+
+    // eslint-disable-next-line no-param-reassign, no-return-assign
+    return () => refElements.forEach((el) => (el.style.display = ""));
+  }, []);
+
+  useEffect(() => {
     // Listen for internal event to indicate a filter was set before moving to next step.
     managerApi.once(ENABLE_FILTER, () => {
       setStepIndex(1);


### PR DESCRIPTION
To avoid issues with scrolling in the sidebar during the guided tour, this hides any composed Storybooks in the sidebar while the tour is active.

Unfortunately there is no element wrapping the composed Storybooks, or any kind of id/classname we can use to target the refs, so I ended up just hiding everything except the first element (which is the story tree of the local Storybook).