### PR TITLE
Show Errors filter in sidebar when there's component errors

### DIFF
--- a/src/SidebarBottom.tsx
+++ b/src/SidebarBottom.tsx
@@ -12,6 +12,13 @@ const filterError: API_FilterFunction = ({ status }) => status?.[ADDON_ID]?.stat
 const filterBoth: API_FilterFunction = ({ status }) =>
   status?.[ADDON_ID]?.status === "warn" || status?.[ADDON_ID]?.status === "error";
 
+const getFilter = (showWarnings = false, showErrors = false) => {
+  if (showWarnings && showErrors) return filterBoth;
+  if (showWarnings) return filterWarn;
+  if (showErrors) return filterError;
+  return filterNone;
+};
+
 const Wrapper = styled.div({
   display: "flex",
   gap: 5,
@@ -35,9 +42,7 @@ export const SidebarBottom = ({ api }: SidebarBottomProps) => {
   const toggleErrors = useCallback(() => setShowErrors((shown) => !shown), []);
 
   useEffect(() => {
-    let filter = filterNone;
-    if (hasWarnings && showWarnings) filter = filterWarn;
-    if (hasErrors && showErrors) filter = filter === filterWarn ? filterBoth : filterError;
+    const filter = getFilter(hasWarnings && showWarnings, hasErrors && showErrors);
     api.experimental_setFilter(ADDON_ID, filter);
     api.emit(ENABLE_FILTER, filter);
   }, [api, hasWarnings, hasErrors, showWarnings, showErrors]);

--- a/src/components/SidebarToggleButton.stories.ts
+++ b/src/components/SidebarToggleButton.stories.ts
@@ -1,24 +1,41 @@
 import { action } from "@storybook/addon-actions";
-import { type StoryObj } from "@storybook/react";
-import { findByRole, userEvent } from "@storybook/testing-library";
 
-import { playAll } from "../utils/playAll";
 import { SidebarToggleButton } from "./SidebarToggleButton";
 
 export default {
   component: SidebarToggleButton,
   args: {
-    count: 12,
-    onEnable: action("onEnable"),
-    onDisable: action("onDisable"),
+    active: false,
+    onClick: action("onClick"),
   },
 };
 
-export const Default = {};
+export const Changes = {
+  args: {
+    count: 12,
+    label: "Change",
+    status: "warning",
+  },
+};
 
-export const Enabled: StoryObj = {
-  play: playAll(async ({ canvasElement }) => {
-    const button = await findByRole(canvasElement, "button");
-    await userEvent.click(button);
-  }),
+export const ChangesActive = {
+  args: {
+    ...Changes.args,
+    active: true,
+  },
+};
+
+export const Errors = {
+  args: {
+    count: 2,
+    label: "Error",
+    status: "critical",
+  },
+};
+
+export const ErrorsActive = {
+  args: {
+    ...Errors.args,
+    active: true,
+  },
 };

--- a/src/components/SidebarToggleButton.tsx
+++ b/src/components/SidebarToggleButton.tsx
@@ -1,7 +1,7 @@
 import { Badge as BaseBadge } from "@storybook/components";
 import { css, styled } from "@storybook/theming";
 import pluralize from "pluralize";
-import React, { useEffect, useState } from "react";
+import React, { ComponentProps } from "react";
 
 import { IconButton } from "./IconButton";
 
@@ -13,10 +13,15 @@ const Badge = styled(BaseBadge)(({ theme }) => ({
 const Button = styled(IconButton)(
   ({ theme }) => ({
     fontSize: theme.typography.size.s2,
-    "&:hover [data-badge], [data-badge=true]": {
+    "&:hover [data-badge][data-status=warning], [data-badge=true][data-status=warning]": {
       background: "#E3F3FF",
       borderColor: "rgba(2, 113, 182, 0.1)",
       color: "#0271B6",
+    },
+    "&:hover [data-badge][data-status=critical], [data-badge=true][data-status=critical]": {
+      background: theme.background.negative,
+      boxShadow: `inset 0 0 0 1px rgba(182, 2, 2, 0.1)`,
+      color: theme.color.negativeText,
     },
   }),
   ({ active, theme }) =>
@@ -33,33 +38,25 @@ const Label = styled.span(({ theme }) => ({
 }));
 
 interface SidebarToggleButtonProps {
+  active: boolean;
   count: number;
-  onEnable: () => void;
-  onDisable: () => void;
+  label: string;
+  status: ComponentProps<typeof Badge>["status"];
 }
 
-export const SidebarToggleButton = React.memo(function SidebarToggleButton({
+export const SidebarToggleButton = ({
+  active,
   count,
-  onEnable,
-  onDisable,
-}: SidebarToggleButtonProps) {
-  const [filter, setFilter] = useState(false);
-
-  const toggleFilter = () => {
-    setFilter(!filter);
-    if (filter) onDisable();
-    else onEnable();
-  };
-
-  // Ensure the filter is disabled if the button is not visible
-  useEffect(() => () => onDisable(), [onDisable]);
-
+  label,
+  status,
+  ...props
+}: SidebarToggleButtonProps & Omit<ComponentProps<typeof Button>, "status">) => {
   return (
-    <Button id="changes-found-filter" active={filter} onClick={toggleFilter}>
-      <Badge status="warning" data-badge={filter}>
+    <Button active={active} {...props}>
+      <Badge status={status} data-badge={active} data-status={status}>
         {count}
       </Badge>
-      <Label>{pluralize("Change", count)}</Label>
+      <Label>{pluralize(label, count)}</Label>
     </Button>
   );
-});
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export const LOCAL_BUILD_PROGRESS = `${ADDON_ID}/localBuildProgress`;
 export const SELECTED_MODE_NAME = `${ADDON_ID}/selectedModeName`;
 export const SELECTED_BROWSER_ID = `${ADDON_ID}/selectedBrowserId`;
 export const TELEMETRY = `${ADDON_ID}/telemetry`;
-
+export const ENABLE_FILTER = `${ADDON_ID}/enableFilter`;
 export const REMOVE_ADDON = `${ADDON_ID}/removeAddon`;
 export const RETRY_CONNECTION = `${ADDON_ID}/retryConnection`;
 

--- a/src/screens/GuidedTour/GuidedTour.tsx
+++ b/src/screens/GuidedTour/GuidedTour.tsx
@@ -3,8 +3,7 @@ import { useTheme } from "@storybook/theming";
 import React, { useEffect, useRef } from "react";
 import Joyride from "react-joyride";
 
-import { PANEL_ID } from "../../constants";
-import { ENABLE_FILTER } from "../../SidebarBottom";
+import { ENABLE_FILTER, PANEL_ID } from "../../constants";
 import { useSessionState } from "../../utils/useSessionState";
 import { useSelectedStoryState } from "../VisualTests/BuildContext";
 import { Confetti } from "./Confetti";


### PR DESCRIPTION
<img width="335" alt="Screenshot 2024-05-15 at 14 11 34" src="https://github.com/chromaui/addon-visual-tests/assets/321738/b606ffe8-6ad7-40f5-8cc6-a76bc7fe9819">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.0--canary.308.072e40b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.5.0--canary.308.072e40b.0
  # or 
  yarn add @chromatic-com/storybook@1.5.0--canary.308.072e40b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
