### PR TITLE
Upgrade Chromatic CLI to v11.4.0 to fix baseline behavior with TurboSnap

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jackspeak": "2.1.1"
   },
   "dependencies": {
-    "chromatic": "^11.3.2",
+    "chromatic": "^11.4.0",
     "filesize": "^10.0.12",
     "jsonfile": "^6.1.0",
     "react-confetti": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5098,10 +5098,10 @@ chownr@^2.0.0:
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromatic@^11.3.2:
-  version "11.3.2"
-  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.3.2.tgz#e95a5eba9a1f3d10761335aba2b986c4436dde7a"
-  integrity sha512-0PuHl49VvBMoDHEfmNjC/bim9YYNhWF3axTZlFuatC0avwr2Xw4GDqJDG9fArEWN8oM8VtYHkE9D7qc87dmz2w==
+chromatic@^11.4.0:
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.4.0.tgz#411a51e82599472b2131a08895faf000e0f9a0fa"
+  integrity sha512-/O6OwEUckqKTBGbm9KvYsR/eKCXy4s2eelO38yyfimBIJiL8+TS/pVnBqdtzUqO2hVK4GjrFiea9CnZUG9Akzw==
 
 citty@^0.1.5:
   version "0.1.5"


### PR DESCRIPTION
v11.4.0 includes https://github.com/chromaui/chromatic-cli/pull/988 which addresses https://github.com/chromaui/addon-visual-tests/issues/231.

This fixes baseline behavior when using TurboSnap with the VTA, specifically when running local builds with uncommitted changes.