### PR TITLE
Don't auto-expand build eyebrow when canceling build

### DIFF
--- a/src/screens/VisualTests/BuildEyebrow.stories.ts
+++ b/src/screens/VisualTests/BuildEyebrow.stories.ts
@@ -84,7 +84,7 @@ export const Error: Story = {
 export const Aborted: Story = {
   args: buildProgressStories.Aborted.args,
   parameters: buildProgressStories.Aborted.parameters,
-  play: dismissEyebrow,
+  play: expandEyebrow,
 };
 
 export const NewBuildRunning: Story = {

--- a/src/screens/VisualTests/BuildEyebrow.tsx
+++ b/src/screens/VisualTests/BuildEyebrow.tsx
@@ -203,19 +203,23 @@ export const BuildEyebrow = ({
   };
 
   if (localBuildProgress) {
-    const isWarning = ["aborted", "error"].includes(localBuildProgress.currentStep);
+    const aborted = localBuildProgress.currentStep === "aborted";
+    const errored = localBuildProgress.currentStep === "error";
     return (
       <>
         <Header
-          as={isWarning ? "div" : "button"}
-          onClick={isWarning ? undefined : toggleExpanded}
-          isWarning={isWarning}
+          as={errored ? "div" : "button"}
+          onClick={errored ? undefined : toggleExpanded}
+          isWarning={errored}
         >
-          <Bar percentage={localBuildProgress.buildProgressPercentage} isWarning={isWarning} />
+          <Bar
+            percentage={localBuildProgress.buildProgressPercentage}
+            isWarning={errored || aborted}
+          />
           <Label>
             <BuildProgressLabel localBuildProgress={localBuildProgress} withEmoji />
           </Label>
-          {isWarning ? (
+          {errored ? (
             <IconButton onClick={dismissBuildError}>
               <CloseIcon aria-label="Dismiss" />
             </IconButton>
@@ -223,7 +227,7 @@ export const BuildEyebrow = ({
             <IconButton as="div">{expanded ? <CollapseIcon /> : <ExpandAltIcon />}</IconButton>
           )}
         </Header>
-        <BuildProgress localBuildProgress={localBuildProgress} expanded={expanded || isWarning} />
+        <BuildProgress localBuildProgress={localBuildProgress} expanded={expanded || errored} />
       </>
     );
   }

--- a/src/screens/VisualTests/BuildEyebrow.tsx
+++ b/src/screens/VisualTests/BuildEyebrow.tsx
@@ -205,17 +205,15 @@ export const BuildEyebrow = ({
   if (localBuildProgress) {
     const aborted = localBuildProgress.currentStep === "aborted";
     const errored = localBuildProgress.currentStep === "error";
+    const isWarning = aborted || errored;
     return (
       <>
         <Header
           as={errored ? "div" : "button"}
           onClick={errored ? undefined : toggleExpanded}
-          isWarning={errored}
+          isWarning={isWarning}
         >
-          <Bar
-            percentage={localBuildProgress.buildProgressPercentage}
-            isWarning={errored || aborted}
-          />
+          <Bar percentage={localBuildProgress.buildProgressPercentage} isWarning={isWarning} />
           <Label>
             <BuildProgressLabel localBuildProgress={localBuildProgress} withEmoji />
           </Label>


### PR DESCRIPTION
Only auto-expand on build error, not when build is aborted.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.1--canary.315.18cebad.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.5.1--canary.315.18cebad.0
  # or 
  yarn add @chromatic-com/storybook@1.5.1--canary.315.18cebad.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
