### PR TITLE
Disallow stopping build after upload step

### DIFF
--- a/src/SidebarTop.tsx
+++ b/src/SidebarTop.tsx
@@ -187,7 +187,10 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
     changedStoryCount.length,
   ]);
 
-  const { isRunning, startBuild, stopBuild } = useBuildEvents({ localBuildProgress, accessToken });
+  const { isDisallowed, isRunning, startBuild, stopBuild } = useBuildEvents({
+    localBuildProgress,
+    accessToken,
+  });
 
   let warning: string | undefined;
   if (apiInfo?.connected === false) warning = "Visual tests locked while waiting for network.";
@@ -208,6 +211,7 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
   return (
     <SidebarTopButton
       isDisabled={!!warning}
+      isDisallowed={isDisallowed}
       isOutdated={isOutdated}
       isRunning={isRunning}
       localBuildProgress={localBuildProgress}

--- a/src/components/SidebarTopButton.stories.tsx
+++ b/src/components/SidebarTopButton.stories.tsx
@@ -74,7 +74,7 @@ const WithProgress = (props: ComponentProps<typeof SidebarTopButton>) => {
   );
 };
 
-export const IsRunning: Story = {
+export const Running: Story = {
   render: WithProgress,
   play: playAll(async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -84,4 +84,11 @@ export const IsRunning: Story = {
     await userEvent.hover(button);
     await screen.findAllByText("🏗 Building your Storybook...");
   }),
+};
+
+export const Unstoppable: Story = {
+  ...Running,
+  args: {
+    isDisallowed: true,
+  },
 };

--- a/src/components/SidebarTopButton.tsx
+++ b/src/components/SidebarTopButton.tsx
@@ -5,6 +5,7 @@ import React, { ComponentProps } from "react";
 
 import { LocalBuildProgress } from "../types";
 import { BuildProgressLabel } from "./BuildProgressLabel";
+import { jiggle } from "./design-system/shared/animation";
 import { IconButton } from "./IconButton";
 import { StatusDotWrapper } from "./StatusDot";
 import { TooltipNote } from "./TooltipNote";
@@ -67,19 +68,28 @@ export const ProgressCircle = styled.svg<{ progress?: boolean; spinner?: boolean
     }
 );
 
-export const SidebarIconButton = styled(IconButton)<ComponentProps<typeof IconButton>>(
-  ({ theme }) => ({
-    position: "relative",
-    overflow: "visible",
-    color: theme.textMutedColor,
-    marginTop: 0,
-    zIndex: 1,
-    marginRight: 4,
-  })
-);
+const WarningText = styled.div(({ theme }) => ({
+  color: theme.color.warningText,
+  "&&": { marginTop: 10 },
+}));
+
+export const SidebarIconButton = styled(IconButton)<
+  ComponentProps<typeof IconButton> & { isDisallowed?: boolean }
+>(({ isDisallowed, theme }) => ({
+  position: "relative",
+  overflow: "visible",
+  color: theme.textMutedColor,
+  marginTop: 0,
+  zIndex: 1,
+  marginRight: 4,
+  ...(isDisallowed && {
+    animation: `${jiggle} 700ms ease-out`,
+  }),
+}));
 
 export const SidebarTopButton = ({
   isDisabled = false,
+  isDisallowed = false,
   isOutdated = false,
   isRunning = false,
   localBuildProgress,
@@ -89,6 +99,7 @@ export const SidebarTopButton = ({
   stopBuild,
 }: {
   isDisabled?: boolean;
+  isDisallowed?: boolean;
   isOutdated?: boolean;
   isRunning?: boolean;
   localBuildProgress?: LocalBuildProgress;
@@ -126,17 +137,26 @@ export const SidebarTopButton = ({
         tooltip={
           <TooltipContent>
             <div>
-              <BuildProgressLabel localBuildProgress={localBuildProgress} withEmoji />
+              <BuildProgressLabel localBuildProgress={localBuildProgress} small withEmoji />
             </div>
             <ProgressTrack>
               {typeof buildProgressPercentage === "number" && (
                 <ProgressBar style={{ width: `${buildProgressPercentage}%` }} />
               )}
             </ProgressTrack>
+            {isDisallowed && (
+              <WarningText>
+                This job has already reached the capture cloud and cannot be stopped locally.
+              </WarningText>
+            )}
           </TooltipContent>
         }
       >
-        <SidebarIconButton aria-label="Stop tests" onClick={() => stopBuild()}>
+        <SidebarIconButton
+          aria-label="Stop tests"
+          isDisallowed={isDisallowed}
+          onClick={() => stopBuild()}
+        >
           <StopAltIcon style={{ width: 10, margin: 2 }} />
           <ProgressCircle xmlns="http://www.w3.org/2000/svg">
             <circle />


### PR DESCRIPTION
Jiggle the button and show a warning.

Fixes #241


https://github.com/chromaui/addon-visual-tests/assets/321738/0f90eea4-2591-44d3-a3f5-c68e384283bd


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.1--canary.317.42e6d13.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.5.1--canary.317.42e6d13.0
  # or 
  yarn add @chromatic-com/storybook@1.5.1--canary.317.42e6d13.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
