### PR TITLE
Add backport releases to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@
 
 ---
 
+# v1.5.1 (Fri Jun 28 2024)
+
+#### 🐛 Bug Fix
+
+- Replace API polling with browser-native "online" status check [#326](https://github.com/chromaui/addon-visual-tests/pull/326) ([@ghengeveld](https://github.com/ghengeveld))
+
+# v1.4.1 (Fri Jun 28 2024)
+
+#### 🐛 Bug Fix
+
+- Replace API polling with browser-native "online" status check [#326](https://github.com/chromaui/addon-visual-tests/pull/326) ([@ghengeveld](https://github.com/ghengeveld))
+
 # v1.5.0 (Tue May 28 2024)
 
 #### 🚀 Enhancement


### PR DESCRIPTION
These were released manually without the use of `auto shipit` so the changelog must also be updated manually.