### PR TITLE
Fix closing multiple notifications of the same type

### DIFF
--- a/src/components/SidebarTop.tsx
+++ b/src/components/SidebarTop.tsx
@@ -90,8 +90,9 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
     lastStep.current = localBuildProgress?.currentStep;
 
     if (localBuildProgress?.currentStep === "initialize") {
+      const notificationId = `${ADDON_ID}/build-initialize/${Date.now()}`;
       addNotification({
-        id: `${ADDON_ID}/build-initialize`,
+        id: notificationId,
         content: {
           headline: "Build started",
           subHeadline: "Check the visual test addon to see the progress of your build.",
@@ -103,12 +104,13 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
       });
 
       // Kept for backwards compatibility (before `duration` support was added)
-      setTimeout(() => clearNotification(`${ADDON_ID}/build-initialize`), 8_000);
+      setTimeout(() => clearNotification(notificationId), 8_000);
     }
 
     if (localBuildProgress?.currentStep === "aborted") {
+      const notificationId = `${ADDON_ID}/build-aborted/${Date.now()}`;
       addNotification({
-        id: `${ADDON_ID}/build-aborted`,
+        id: notificationId,
         content: {
           headline: "Build canceled",
           subHeadline: "Aborted by user.",
@@ -120,12 +122,13 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
       });
 
       // Kept for backwards compatibility (before `duration` support was added)
-      setTimeout(() => clearNotification(`${ADDON_ID}/build-aborted`), 8_000);
+      setTimeout(() => clearNotification(notificationId), 8_000);
     }
 
     if (localBuildProgress?.currentStep === "complete") {
+      const notificationId = `${ADDON_ID}/build-complete/${Date.now()}`;
       addNotification({
-        id: `${ADDON_ID}/build-complete`,
+        id: notificationId,
         content: {
           headline: "Build complete",
           // eslint-disable-next-line no-nested-ternary
@@ -145,12 +148,12 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
       });
 
       // Kept for backwards compatibility (before `duration` support was added)
-      setTimeout(() => clearNotification(`${ADDON_ID}/build-complete`), 8_000);
+      setTimeout(() => clearNotification(notificationId), 8_000);
     }
 
     if (localBuildProgress?.currentStep === "error") {
       addNotification({
-        id: `${ADDON_ID}/build-error`,
+        id: `${ADDON_ID}/build-error/${Date.now()}`,
         content: {
           headline: "Build error",
           subHeadline: "Check the Storybook process on the command line for more details.",
@@ -163,7 +166,7 @@ export const SidebarTop = ({ api }: SidebarTopProps) => {
 
     if (localBuildProgress?.currentStep === "limited") {
       addNotification({
-        id: `${ADDON_ID}/build-limited`,
+        id: `${ADDON_ID}/build-limited/${Date.now()}`,
         content: {
           headline: "Build limited",
           subHeadline:

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -35,17 +35,17 @@ addons.register(ADDON_ID, (api) => {
   const channel = api.getChannel();
   if (!channel) return;
 
-  let notificationShown = false;
+  let notificationId: string | undefined;
   channel.on(`${ADDON_ID}/heartbeat`, () => {
     clearTimeout(heartbeatTimeout);
-    if (notificationShown) {
-      notificationShown = false;
-      api.clearNotification(`${ADDON_ID}/connection-lost`);
+    if (notificationId) {
+      api.clearNotification(notificationId);
+      notificationId = undefined;
     }
     heartbeatTimeout = setTimeout(() => {
-      notificationShown = true;
+      notificationId = `${ADDON_ID}/connection-lost/${Date.now()}`;
       api.addNotification({
-        id: `${ADDON_ID}/connection-lost`,
+        id: notificationId,
         content: {
           headline: "Connection lost",
           subHeadline: "Lost connection to the Storybook server. Try refreshing the page.",

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -5,7 +5,7 @@ import type { API_StatusState } from "@storybook/types";
 import React, { useCallback, useEffect } from "react";
 import { useMutation } from "urql";
 
-import { PANEL_ID } from "../../constants";
+import { ADDON_ID, PANEL_ID } from "../../constants";
 import { getFragment, graphql } from "../../gql";
 import {
   ReviewTestBatch,
@@ -238,7 +238,7 @@ export const VisualTestsWithoutSelectedBuildId = ({
     onReviewError: (err, update) => {
       if (err instanceof Error) {
         addNotification({
-          id: "chromatic/errorAccepting",
+          id: `${ADDON_ID}/errorAccepting/${Date.now()}`,
           content: {
             headline: `Failed to ${
               update.status === ReviewTestInputStatus.Accepted ? "accept" : "unaccept"

--- a/src/utils/useErrorNotification.tsx
+++ b/src/utils/useErrorNotification.tsx
@@ -21,7 +21,7 @@ export function useErrorNotification() {
   return useCallback(
     (headline: string, err: any) => {
       addNotification({
-        id: `${ADDON_ID}/error`,
+        id: `${ADDON_ID}/error/${Date.now()}`,
         content: {
           headline,
           subHeadline: err.toString(),


### PR DESCRIPTION
Fixes #244 

Storybook has a bug that prevents notifications from being closed if there's multiple notifications with the same `id`. This PR ensures every notification has a unique ID to avoid this issue.