### PR TITLE
Relay client-side fetch requests to the server using the Storybook channel API

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -28,9 +28,10 @@ import { ControlsProvider } from "./screens/VisualTests/ControlsContext";
 import { RunBuildProvider } from "./screens/VisualTests/RunBuildContext";
 import { VisualTests } from "./screens/VisualTests/VisualTests";
 import { APIInfoPayload, GitInfoPayload, LocalBuildProgress, UpdateStatusFunction } from "./types";
-import { client, Provider, useAccessToken } from "./utils/graphQLClient";
+import { createClient, GraphQLClientProvider, useAccessToken } from "./utils/graphQLClient";
 import { TelemetryProvider } from "./utils/TelemetryContext";
 import { useBuildEvents } from "./utils/useBuildEvents";
+import { useChannelFetch } from "./utils/useChannelFetch";
 import { useProjectId } from "./utils/useProjectId";
 import { clearSessionState, useSessionState } from "./utils/useSessionState";
 import { useSharedState } from "./utils/useSharedState";
@@ -81,8 +82,9 @@ export const Panel = ({ active, api }: PanelProps) => {
   const trackEvent = useCallback((data: any) => emit(TELEMETRY, data), [emit]);
   const { isRunning, startBuild, stopBuild } = useBuildEvents({ localBuildProgress, accessToken });
 
+  const fetch = useChannelFetch();
   const withProviders = (children: React.ReactNode) => (
-    <Provider key={PANEL_ID} value={client}>
+    <GraphQLClientProvider key={PANEL_ID} value={createClient({ fetch })}>
       <TelemetryProvider value={trackEvent}>
         <AuthProvider value={{ accessToken, setAccessToken }}>
           <UninstallProvider
@@ -99,7 +101,7 @@ export const Panel = ({ active, api }: PanelProps) => {
           </UninstallProvider>
         </AuthProvider>
       </TelemetryProvider>
-    </Provider>
+    </GraphQLClientProvider>
   );
 
   if (!active) {

--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -11,7 +11,6 @@ import {
   IS_OFFLINE,
   IS_OUTDATED,
   LOCAL_BUILD_PROGRESS,
-  PANEL_ID,
   REMOVE_ADDON,
   TELEMETRY,
 } from "./constants";
@@ -96,7 +95,7 @@ export const Panel = ({ active, api }: PanelProps) => {
 
   const fetch = useChannelFetch();
   const withProviders = (children: React.ReactNode) => (
-    <GraphQLClientProvider key={PANEL_ID} value={createClient({ fetch })}>
+    <GraphQLClientProvider value={createClient({ fetch })}>
       <TelemetryProvider value={trackEvent}>
         <AuthProvider value={{ accessToken, setAccessToken }}>
           <UninstallProvider
@@ -136,7 +135,6 @@ export const Panel = ({ active, api }: PanelProps) => {
   if (!accessToken) {
     return withProviders(
       <Authentication
-        key={PANEL_ID}
         setAccessToken={setAccessToken}
         setCreatedProjectId={setCreatedProjectId}
         hasProjectId={!!projectId}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,10 @@ export const TELEMETRY = `${ADDON_ID}/telemetry`;
 export const ENABLE_FILTER = `${ADDON_ID}/enableFilter`;
 export const REMOVE_ADDON = `${ADDON_ID}/removeAddon`;
 
+export const FETCH_ABORTED = `${ADDON_ID}/ChannelFetch/aborted`;
+export const FETCH_REQUEST = `${ADDON_ID}ChannelFetch/request`;
+export const FETCH_RESPONSE = `${ADDON_ID}ChannelFetch/response`;
+
 export const CONFIG_OVERRIDES = {
   // Local changes should never be auto-accepted
   autoAcceptChanges: false,

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -35,6 +35,7 @@ import {
   LocalBuildProgress,
   ProjectInfoPayload,
 } from "./types";
+import { ChannelFetch } from "./utils/ChannelFetch";
 import { SharedState } from "./utils/SharedState";
 import { updateChromaticConfig } from "./utils/updateChromaticConfig";
 
@@ -192,6 +193,9 @@ const watchConfigFile = async (
 
 async function serverChannel(channel: Channel, options: Options & { configFile?: string }) {
   const { configFile, presets } = options;
+
+  // Handle relayed fetch requests from the client
+  ChannelFetch.subscribe(ADDON_ID, channel);
 
   // Lazy load these APIs since we don't need them right away
   const apiPromise = presets.apply<any>("experimental_serverAPI");

--- a/src/utils/ChannelFetch.test.ts
+++ b/src/utils/ChannelFetch.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FETCH_ABORTED, FETCH_REQUEST, FETCH_RESPONSE } from "../constants";
+import { ChannelFetch } from "./ChannelFetch";
+import { MockChannel } from "./MockChannel";
+
+const resolveAfter = (ms: number, value: any) =>
+  new Promise((resolve) => setTimeout(resolve, ms, value));
+
+const rejectAfter = (ms: number, reason: any) =>
+  new Promise((_, reject) => setTimeout(reject, ms, reason));
+
+describe("ChannelFetch", () => {
+  let channel: MockChannel;
+
+  beforeEach(() => {
+    channel = new MockChannel();
+  });
+
+  it("should handle fetch requests", async () => {
+    const fetch = vi.fn(() => resolveAfter(100, { headers: [], text: async () => "data" }));
+    ChannelFetch.subscribe("req", channel, fetch as any);
+
+    channel.emit(FETCH_REQUEST, {
+      requestId: "req",
+      input: "https://example.com",
+      init: { headers: { foo: "bar" } },
+    });
+
+    await vi.waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("https://example.com", {
+        headers: { foo: "bar" },
+        signal: expect.any(AbortSignal),
+      });
+    });
+  });
+
+  it("should send fetch responses", async () => {
+    const fetch = vi.fn(() => resolveAfter(100, { headers: [], text: async () => "data" }));
+    const instance = ChannelFetch.subscribe("res", channel, fetch as any);
+
+    const promise = new Promise<void>((resolve) => {
+      channel.on(FETCH_RESPONSE, ({ response, error }) => {
+        expect(response.body).toBe("data");
+        expect(error).toBeUndefined();
+        resolve();
+      });
+    });
+
+    channel.emit(FETCH_REQUEST, { requestId: "res", input: "https://example.com" });
+    await vi.waitFor(() => {
+      expect(instance.abortControllers.size).toBe(1);
+    });
+
+    await promise;
+
+    expect(instance.abortControllers.size).toBe(0);
+  });
+
+  it("should send fetch error responses", async () => {
+    const fetch = vi.fn(() => rejectAfter(100, new Error("oops")));
+    const instance = ChannelFetch.subscribe("err", channel, fetch as any);
+
+    const promise = new Promise<void>((resolve) => {
+      channel.on(FETCH_RESPONSE, ({ response, error }) => {
+        expect(response).toBeUndefined();
+        expect(error).toMatch(/oops/);
+        resolve();
+      });
+    });
+
+    channel.emit(FETCH_REQUEST, { requestId: "err", input: "https://example.com" });
+    await vi.waitFor(() => {
+      expect(instance.abortControllers.size).toBe(1);
+    });
+
+    await promise;
+    expect(instance.abortControllers.size).toBe(0);
+  });
+
+  it("should abort fetch requests", async () => {
+    const fetch = vi.fn((input, init) => new Promise<Response>(() => {}));
+    const instance = ChannelFetch.subscribe("abort", channel, fetch);
+
+    channel.emit(FETCH_REQUEST, { requestId: "abort", input: "https://example.com" });
+    await vi.waitFor(() => {
+      expect(instance.abortControllers.size).toBe(1);
+    });
+
+    channel.emit(FETCH_ABORTED, { requestId: "abort" });
+    await vi.waitFor(() => {
+      expect(fetch.mock.lastCall?.[1].signal.aborted).toBe(true);
+      expect(instance.abortControllers.size).toBe(0);
+    });
+  });
+});

--- a/src/utils/ChannelFetch.ts
+++ b/src/utils/ChannelFetch.ts
@@ -1,0 +1,48 @@
+import type { Channel } from "@storybook/channels";
+
+export const FETCH_ABORTED = "ChannelFetch/aborted";
+export const FETCH_REQUEST = "ChannelFetch/request";
+export const FETCH_RESPONSE = "ChannelFetch/response";
+
+type ChannelLike = Pick<Channel, "emit" | "on" | "off">;
+
+const instances = new Map<string, ChannelFetch>();
+
+export class ChannelFetch {
+  channel: ChannelLike;
+
+  abortControllers: Map<string, AbortController>;
+
+  constructor(channel: ChannelLike) {
+    this.channel = channel;
+    this.abortControllers = new Map<string, AbortController>();
+
+    this.channel.on(FETCH_ABORTED, ({ requestId }) => {
+      this.abortControllers.get(requestId)?.abort();
+      this.abortControllers.delete(requestId);
+    });
+
+    this.channel.on(FETCH_REQUEST, async ({ requestId, input, init }) => {
+      const controller = new AbortController();
+      this.abortControllers.set(requestId, controller);
+
+      try {
+        const res = await fetch(input as RequestInfo, { ...init, signal: controller.signal });
+        const body = await res.text();
+        const headers = Array.from(res.headers as any);
+        const response = { body, headers, status: res.status, statusText: res.statusText };
+        this.channel.emit(FETCH_RESPONSE, { requestId, response });
+      } catch (error) {
+        this.channel.emit(FETCH_RESPONSE, { requestId, error });
+      } finally {
+        this.abortControllers.delete(requestId);
+      }
+    });
+  }
+
+  static subscribe<T>(key: string, channel: ChannelLike) {
+    const instance = instances.get(key) || new ChannelFetch(channel);
+    if (!instances.has(key)) instances.set(key, instance);
+    return instance;
+  }
+}

--- a/src/utils/ChannelFetch.ts
+++ b/src/utils/ChannelFetch.ts
@@ -1,8 +1,6 @@
 import type { Channel } from "@storybook/channels";
 
-export const FETCH_ABORTED = "ChannelFetch/aborted";
-export const FETCH_REQUEST = "ChannelFetch/request";
-export const FETCH_RESPONSE = "ChannelFetch/response";
+import { FETCH_ABORTED, FETCH_REQUEST, FETCH_RESPONSE } from "../constants";
 
 type ChannelLike = Pick<Channel, "emit" | "on" | "off">;
 

--- a/src/utils/MockChannel.ts
+++ b/src/utils/MockChannel.ts
@@ -1,0 +1,16 @@
+export class MockChannel {
+  private listeners: Record<string, ((...args: any[]) => void)[]> = {};
+
+  on(event: string, listener: (...args: any[]) => void) {
+    this.listeners[event] = [...(this.listeners[event] ?? []), listener];
+  }
+
+  off(event: string, listener: (...args: any[]) => void) {
+    this.listeners[event] = (this.listeners[event] ?? []).filter((l) => l !== listener);
+  }
+
+  emit(event: string, ...args: any[]) {
+    // setTimeout is used to simulate the asynchronous nature of the real channel
+    (this.listeners[event] || []).forEach((listener) => setTimeout(() => listener(...args)));
+  }
+}

--- a/src/utils/SharedState.test.ts
+++ b/src/utils/SharedState.test.ts
@@ -1,23 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { MockChannel } from "./MockChannel";
 import { SharedState } from "./SharedState";
-
-class MockChannel {
-  private listeners: Record<string, ((...args: any[]) => void)[]> = {};
-
-  on(event: string, listener: (...args: any[]) => void) {
-    this.listeners[event] = [...(this.listeners[event] ?? []), listener];
-  }
-
-  off(event: string, listener: (...args: any[]) => void) {
-    this.listeners[event] = (this.listeners[event] ?? []).filter((l) => l !== listener);
-  }
-
-  emit(event: string, ...args: any[]) {
-    // setTimeout is used to simulate the asynchronous nature of the real channel
-    (this.listeners[event] || []).forEach((listener) => setTimeout(() => listener(...args)));
-  }
-}
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
 

--- a/src/utils/graphQLClient.tsx
+++ b/src/utils/graphQLClient.tsx
@@ -109,14 +109,7 @@ export const createClient = (options?: Partial<ClientOptions>) =>
 export const GraphQLClientProvider = ({
   children,
   value = createClient(),
-  ...rest
 }: {
   children: React.ReactNode;
   value?: Client;
-}) => {
-  return (
-    <Provider value={value} {...rest}>
-      {children}
-    </Provider>
-  );
-};
+}) => <Provider value={value}>{children}</Provider>;

--- a/src/utils/useChannelFetch.ts
+++ b/src/utils/useChannelFetch.ts
@@ -1,0 +1,54 @@
+import { useChannel } from "@storybook/manager-api";
+
+const FETCH_ABORTED = "ChannelFetch/aborted";
+const FETCH_REQUEST = "ChannelFetch/request";
+const FETCH_RESPONSE = "ChannelFetch/response";
+
+type SerializedResponse = {
+  status: number;
+  statusText: string;
+  headers: [string, string][];
+  body: string;
+};
+
+const pendingRequests = new Map<
+  string,
+  { resolve: (value: Response) => void; reject: (reason?: any) => void }
+>();
+
+export const useChannelFetch: () => typeof fetch = () => {
+  const emit = useChannel({
+    [FETCH_RESPONSE]: (
+      data:
+        | { requestId: string; response: SerializedResponse }
+        | { requestId: string; error: string }
+    ) => {
+      const request = pendingRequests.get(data.requestId);
+      if (!request) return;
+
+      pendingRequests.delete(data.requestId);
+      if ("error" in data) {
+        request.reject(new Error(data.error));
+      } else {
+        const { body, headers, status, statusText } = data.response;
+        const res = new Response(body, { headers, status, statusText });
+        request.resolve(res);
+      }
+    },
+  });
+
+  return async (input: string | URL | Request, { signal, ...init }: RequestInit = {}) => {
+    const requestId = Math.random().toString(36).slice(2);
+    emit(FETCH_REQUEST, { requestId, input, init });
+
+    signal?.addEventListener("abort", () => emit(FETCH_ABORTED, { requestId }));
+
+    return new Promise((resolve, reject) => {
+      pendingRequests.set(requestId, { resolve, reject });
+      setTimeout(() => {
+        reject(new Error("Request timed out"));
+        pendingRequests.delete(requestId);
+      }, 30000);
+    });
+  };
+};

--- a/src/utils/useChannelFetch.ts
+++ b/src/utils/useChannelFetch.ts
@@ -1,8 +1,6 @@
 import { useChannel } from "@storybook/manager-api";
 
-const FETCH_ABORTED = "ChannelFetch/aborted";
-const FETCH_REQUEST = "ChannelFetch/request";
-const FETCH_RESPONSE = "ChannelFetch/response";
+import { FETCH_ABORTED, FETCH_REQUEST, FETCH_RESPONSE } from "../constants";
 
 type SerializedResponse = {
   status: number;


### PR DESCRIPTION
Fixes #312 

This adds a `ChannelFetch` utility and `useChannelFetch` hook. ChannelFetch listens for messages on the `serverChannel`, performs `fetch` requests, and sends back a message with the response. The goal is relay client-side requests to the server, in order to avoid polluting the network request log in DevTools.

A `useChannelFetch` hook is included, which returns a `fetch` compatible function. This `fetch` replacement is passed to the URQL Client so all GraphQL requests will happen over the channel. Requests time out after 30 seconds (if they haven't already). The `signal` property is supported by means of a dedicated abort message.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.9.0--canary.331.67b13f2.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.9.0--canary.331.67b13f2.0
  # or 
  yarn add @chromatic-com/storybook@1.9.0--canary.331.67b13f2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
