### PR TITLE
Update story status reporting for Storybook 8.3 and use new `SET_FILTER` event

### DIFF
--- a/src/components/SidebarBottom.tsx
+++ b/src/components/SidebarBottom.tsx
@@ -53,7 +53,7 @@ export const SidebarBottomBase = ({ api, status }: SidebarBottomProps) => {
     <Wrapper id="sidebar-bottom-wrapper">
       {hasWarnings && (
         <SidebarToggleButton
-          id="changes-found-filter"
+          id="warnings-found-filter"
           active={showWarnings}
           count={warnings.length}
           label="Change"

--- a/src/screens/GuidedTour/GuidedTour.tsx
+++ b/src/screens/GuidedTour/GuidedTour.tsx
@@ -9,6 +9,8 @@ import { useSelectedStoryState } from "../VisualTests/BuildContext";
 import { Confetti } from "./Confetti";
 import { Tooltip, TooltipProps } from "./Tooltip";
 
+const SET_FILTER = "setFilter"; // TODO: Import from @storybook/core-events once available
+
 type GuidedTourStep = TooltipProps["step"];
 
 interface TourProps {
@@ -75,14 +77,22 @@ export const GuidedTour = ({
   }, []);
 
   useEffect(() => {
-    // Listen for internal event to indicate a filter was set before moving to next step.
-    managerApi.once(ENABLE_FILTER, () => {
+    const onFilter = () => {
       setStepIndex(1);
       // Force a resize to make sure the react-joyride centers on the sidebar properly. Timeout is needed to make sure the filter takes place.
       setTimeout(() => {
         window.dispatchEvent(new Event("resize"));
       }, 100);
-    });
+    };
+
+    // Listen for event to indicate a filter was set before moving to next step.
+    // Storybook before v8.3 didn't have SET_FILTER, those versions use ENABLE_FILTER instead.
+    managerApi.on(ENABLE_FILTER, onFilter);
+    managerApi.on(SET_FILTER, onFilter);
+    return () => {
+      managerApi.off(ENABLE_FILTER, onFilter);
+      managerApi.off(SET_FILTER, onFilter);
+    };
   }, [managerApi, setStepIndex]);
 
   useEffect(() => {

--- a/src/screens/GuidedTour/GuidedTour.tsx
+++ b/src/screens/GuidedTour/GuidedTour.tsx
@@ -117,7 +117,7 @@ export const GuidedTour = ({
         </>
       ),
       floaterProps: {
-        target: "#changes-found-filter",
+        target: "#warnings-found-filter",
         options: {
           preventOverflow: {
             boundariesElement: "window",

--- a/src/screens/VisualTests/VisualTests.stories.tsx
+++ b/src/screens/VisualTests/VisualTests.stories.tsx
@@ -704,6 +704,7 @@ export const Pending = {
       expect(args.updateBuildStatus).toHaveBeenCalledWith({
         "button--primary": {
           status: "warn",
+          onClick: expect.anything(),
           title: "Visual Tests",
           description: "Chromatic Visual Tests",
         },

--- a/src/screens/VisualTests/VisualTests.tsx
+++ b/src/screens/VisualTests/VisualTests.tsx
@@ -264,7 +264,8 @@ export const VisualTestsWithoutSelectedBuildId = ({
     "testsForStatus" in lastBuildOnBranch &&
     lastBuildOnBranch.testsForStatus?.nodes &&
     getFragment(FragmentStatusTestFields, lastBuildOnBranch.testsForStatus.nodes);
-  const statusUpdate = lastBuildOnBranchIsSelectable && testsToStatusUpdate(testsForStatus || []);
+  const statusUpdate =
+    lastBuildOnBranchIsSelectable && testsToStatusUpdate(managerApi, testsForStatus || []);
   useEffect(() => {
     updateBuildStatus((state) => ({
       ...createEmptyStoryStatusUpdate(state),

--- a/src/utils/testsToStatusUpdate.test.ts
+++ b/src/utils/testsToStatusUpdate.test.ts
@@ -1,11 +1,17 @@
-import { expect, it } from "vitest";
+import type { API } from "@storybook/manager-api";
+import { expect, it, vi } from "vitest";
 
 import { TestStatus } from "../gql/graphql";
 import { testsToStatusUpdate } from "./testsToStatusUpdate";
 
+const api: API = {
+  setSelectedPanel: vi.fn(),
+  togglePanel: vi.fn(),
+} as any;
+
 it("handles single test with no changes", () => {
   expect(
-    testsToStatusUpdate([
+    testsToStatusUpdate(api, [
       {
         id: "1",
         status: TestStatus.Passed,
@@ -23,7 +29,7 @@ it("handles single test with no changes", () => {
 
 it("handles single test with changes", () => {
   expect(
-    testsToStatusUpdate([
+    testsToStatusUpdate(api, [
       {
         id: "1",
         status: TestStatus.Pending,
@@ -36,6 +42,7 @@ it("handles single test with changes", () => {
     {
       "story--id": {
         "description": "Chromatic Visual Tests",
+        "onClick": [Function],
         "status": "warn",
         "title": "Visual Tests",
       },
@@ -45,7 +52,7 @@ it("handles single test with changes", () => {
 
 it("handles multiple tests", () => {
   expect(
-    testsToStatusUpdate([
+    testsToStatusUpdate(api, [
       {
         id: "1",
         status: TestStatus.Pending,
@@ -65,11 +72,13 @@ it("handles multiple tests", () => {
     {
       "story--id": {
         "description": "Chromatic Visual Tests",
+        "onClick": [Function],
         "status": "warn",
         "title": "Visual Tests",
       },
       "story2--id": {
         "description": "Chromatic Visual Tests",
+        "onClick": [Function],
         "status": "error",
         "title": "Visual Tests",
       },
@@ -79,7 +88,7 @@ it("handles multiple tests", () => {
 
 it("handles multiple viewports", () => {
   expect(
-    testsToStatusUpdate([
+    testsToStatusUpdate(api, [
       {
         id: "1",
         status: TestStatus.Broken,
@@ -99,6 +108,7 @@ it("handles multiple viewports", () => {
     {
       "story--id": {
         "description": "Chromatic Visual Tests",
+        "onClick": [Function],
         "status": "error",
         "title": "Visual Tests",
       },
@@ -108,7 +118,7 @@ it("handles multiple viewports", () => {
 
 it("handles multiple viewports, reverse order", () => {
   expect(
-    testsToStatusUpdate([
+    testsToStatusUpdate(api, [
       {
         id: "1",
         status: TestStatus.Pending,
@@ -128,6 +138,7 @@ it("handles multiple viewports, reverse order", () => {
     {
       "story--id": {
         "description": "Chromatic Visual Tests",
+        "onClick": [Function],
         "status": "error",
         "title": "Visual Tests",
       },

--- a/src/utils/testsToStatusUpdate.ts
+++ b/src/utils/testsToStatusUpdate.ts
@@ -1,5 +1,7 @@
+import type { API } from "@storybook/manager-api";
 import type { API_StatusUpdate, API_StatusValue, StoryId } from "@storybook/types";
 
+import { PANEL_ID } from "../constants";
 import { StatusTestFieldsFragment, TestStatus } from "../gql/graphql";
 
 export const statusMap: Partial<Record<TestStatus, API_StatusValue>> = {
@@ -22,6 +24,7 @@ function chooseWorseStatus(status: API_StatusValue | null, oldStatus: API_Status
 }
 
 export function testsToStatusUpdate<T extends StatusTestFieldsFragment>(
+  api: API,
   tests: readonly T[]
 ): API_StatusUpdate {
   const storyIdToStatus: Record<StoryId, API_StatusValue | null> = {};
@@ -34,6 +37,10 @@ export function testsToStatusUpdate<T extends StatusTestFieldsFragment>(
       storyIdToStatus[test.story.storyId]
     );
   });
+  const openAddonPanel = () => {
+    api.setSelectedPanel(PANEL_ID);
+    api.togglePanel(true);
+  };
   const update = Object.fromEntries(
     Object.entries(storyIdToStatus).map(([storyId, status]) => [
       storyId,
@@ -41,6 +48,7 @@ export function testsToStatusUpdate<T extends StatusTestFieldsFragment>(
         status,
         title: "Visual Tests",
         description: "Chromatic Visual Tests",
+        onClick: openAddonPanel,
       },
     ])
   );


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/28683

This makes the addon compatible with the upcoming changes in Storybook 8.3. See https://github.com/storybookjs/storybook/pull/28693 and https://github.com/storybookjs/storybook/pull/28739

- The `experimental_updateStatus` API now accepts an `onClick` property. This is used to open the Visual Tests panel when clicking an error/warning status in the sidebar.
- The `experimental_SIDEBAR_BOTTOM` API is deprecated and ignored in SB 8.3. The VTA will continue to use this API for backwards compatibility, but will eventually be removed. When using the VTA with Storybook 8.3, it will rely on Storybook's own sidebar filtering UI.
- Storybook 8.3 emits a `setFilter` event when a filter is set, similar to the VTA's `chromaui/addon-visual-tests/enableFilter` event. Both events are listened for in order to be compatible with Storybook <8.3 and Storybook >=8.3.

Compatibility is as follows:
- Old VTA in SB >=8.3 will use the Storybook filter UI with no issue because the Storybook filter UI is based on the `experimental_updateStatus` API which the VTA has always used. The VTA's filter UI is ignored (not applied).
- New VTA in SB <=8.2 will still apply the VTA filter UI, and that will work as it used to. It will send an `onClick` property for the story statuses, but that will be ignored by Storybook 8.2 and earlier.
- New VTA in SB >=8.3 will try to apply the VTA filter UI but it will be ignored. Instead it will use the Storybook filter UI.

Filter UI in Storybook 8.3 is mostly identical to the VTA filter UI, but it's likely to change in a later version.

<img width="396" alt="Screenshot 2024-07-23 at 16 34 07" src="https://github.com/user-attachments/assets/9e26840d-d4c5-4c6e-ad93-de2f6607895c">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.7.0--canary.332.f043bff.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@1.7.0--canary.332.f043bff.0
  # or 
  yarn add @chromatic-com/storybook@1.7.0--canary.332.f043bff.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
