### PR TITLE
Add `paramKey: "chromatic"` to allow disabling the VTA panel through story parameters

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,7 @@ export const SELECTED_BROWSER_ID = `${ADDON_ID}/selectedBrowserId`;
 export const TELEMETRY = `${ADDON_ID}/telemetry`;
 export const ENABLE_FILTER = `${ADDON_ID}/enableFilter`;
 export const REMOVE_ADDON = `${ADDON_ID}/removeAddon`;
+export const PARAM_KEY = ADDON_ID;
 
 export const CONFIG_OVERRIDES = {
   // Local changes should never be auto-accepted

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,7 @@ export const SELECTED_BROWSER_ID = `${ADDON_ID}/selectedBrowserId`;
 export const TELEMETRY = `${ADDON_ID}/telemetry`;
 export const ENABLE_FILTER = `${ADDON_ID}/enableFilter`;
 export const REMOVE_ADDON = `${ADDON_ID}/removeAddon`;
-export const PARAM_KEY = ADDON_ID;
+export const PARAM_KEY = "chromatic";
 
 export const CONFIG_OVERRIDES = {
   // Local changes should never be auto-accepted

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -6,7 +6,7 @@ import React from "react";
 
 import { SidebarBottom } from "./components/SidebarBottom";
 import { SidebarTop } from "./components/SidebarTop";
-import { ADDON_ID, PANEL_ID, SIDEBAR_BOTTOM_ID, SIDEBAR_TOP_ID } from "./constants";
+import { ADDON_ID, PANEL_ID, PARAM_KEY, SIDEBAR_BOTTOM_ID, SIDEBAR_TOP_ID } from "./constants";
 import { Panel } from "./Panel";
 
 let heartbeatTimeout: NodeJS.Timeout;
@@ -18,6 +18,7 @@ addons.register(ADDON_ID, (api) => {
   addons.add(PANEL_ID, {
     type: Addon_TypesEnum.PANEL,
     title: "Visual Tests",
+    paramKey: PARAM_KEY,
     match: ({ viewMode }) => viewMode === "story",
     render: ({ active }) => <Panel active={!!active} api={api} />,
   });


### PR DESCRIPTION
Configures the addon's `paramKey`, so that disabling this parameter will disable the Visual Tests panel in Storybook for a specific story:

```jsx
const MyStory = {
  parameters: {
    chromatic: {
      disable: true
    }
  }
}
```

Similarly, this can be set on `meta` instead to disable the VTA for all stories in the file.

The key is set to `chromatic` because this will cause Chromatic to skip the story when snapshotting. If you want to [disable snapshotting](https://www.chromatic.com/docs/ignoring-elements/#with-storybook) without disabling the addon panel, you can use the `disableSnapshot: true` parameter instead.