### PR TITLE
Chore: Adjust Chromatic documentation links

### DIFF
--- a/src/screens/VisualTests/BuildResults.tsx
+++ b/src/screens/VisualTests/BuildResults.tsx
@@ -155,7 +155,7 @@ export const BuildResults = ({
             </div>
             <Button asChild size="medium" variant="outline">
               <a
-                href="https://www.chromatic.com/docs/ignoring-elements#ignore-stories"
+                href="https://www.chromatic.com/docs/ignoring-elements#with-storybook"
                 target="_new"
               >
                 <DocumentIcon />

--- a/src/screens/VisualTests/Configuration.tsx
+++ b/src/screens/VisualTests/Configuration.tsx
@@ -307,11 +307,7 @@ export const Configuration = ({ onClose }: ConfigurationProps) => {
           <PageDescription>
             This is a read-only representation of the Chromatic configuration options found in{" "}
             <Code>{configFile}</Code>. Changes to the config file will be reflected here.{" "}
-            <Link
-              href="https://www.chromatic.com/docs/cli/#configuration-options"
-              target="_blank"
-              withArrow
-            >
+            <Link href="https://www.chromatic.com/docs/configure/" target="_blank" withArrow>
               Learn more
             </Link>
           </PageDescription>
@@ -320,7 +316,7 @@ export const Configuration = ({ onClose }: ConfigurationProps) => {
             To configure this addon, create <Code>chromatic.config.json</Code> in your project's
             root directory.{" "}
             <Link
-              href="https://www.chromatic.com/docs/cli/#configuration-options"
+              href="https://www.chromatic.com/docs/cli#chromatic-config-file"
               target="_blank"
               withArrow
             >

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -150,7 +150,7 @@ export const NoBuild = ({
 
             <ButtonStackLink
               withArrow
-              href="https://www.chromatic.com/docs/ignoring-elements/#ignore-stories"
+              href="https://www.chromatic.com/docs/ignoring-elements#with-storybook"
               target="_blank"
             >
               Read more


### PR DESCRIPTION
Closes #335 

With this pull request, the links used throughout the addon that point at various places in the Chromatic documentation were updated to reflect some of the recent changes that were provided (e.g., Chromatic configuration reference documentation).

What was done:
- Adjusted the links in various components

@ghengeveld, when you have a moment, can you take a look at this and let me know if you have any feedback?
