### PR TITLE
Send Slack notification when new version is released on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "strip-ansi": "^7.1.0"
   },
   "devDependencies": {
+    "@auto-it/slack": "^11.2.1",
     "@emotion/weak-memoize": "^0.3.1",
     "@graphql-codegen/cli": "^4.0.1",
     "@graphql-codegen/client-preset": "^4.0.1",
@@ -138,6 +139,20 @@
     "registry": "https://registry.npmjs.org/"
   },
   "packageManager": "yarn@4.1.1",
+  "auto": {
+    "baseBranch": "main",
+    "plugins": [
+      "npm",
+      "released",
+      [
+        "slack",
+        {
+          "atTarget": "support-team",
+          "iconEmoji": ":package:"
+        }
+      ]
+    ]
+  },
   "bundler": {
     "exportEntries": [
       "./src/index.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,10 +79,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@atomist/slack-messages@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@atomist/slack-messages@npm:1.2.2"
+  checksum: 10c0/1d060a0a19a047e3f95596c9bb08051d7309c88a8fcbc08d172ec6c415bca0a3b08f8497a05dbaeb5320bf6f5dbc98d8134168bbd4cc12e8107204479e3ab6af
+  languageName: node
+  linkType: hard
+
 "@auto-it/bot-list@npm:11.1.0":
   version: 11.1.0
   resolution: "@auto-it/bot-list@npm:11.1.0"
   checksum: 10c0/277143c8da14f28eaec9f535f8fd7a7848be62305bbab1f6cb8f4a80cff8479f57c6c5715ae09369dacd17e772e7c3fb8dbbca9309086a101e471f2ed3458ba2
+  languageName: node
+  linkType: hard
+
+"@auto-it/bot-list@npm:11.2.1":
+  version: 11.2.1
+  resolution: "@auto-it/bot-list@npm:11.2.1"
+  checksum: 10c0/f6aa9b5e0de8b2b0e6e9f3ff14e9be13611bf62d37d9e353fc2d06874617753cb1b5ddec513cdd4389b8536d1b0a0f8acf5a6ba17eb494659925284bd9690bf8
   languageName: node
   linkType: hard
 
@@ -139,6 +153,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@auto-it/core@npm:11.2.1":
+  version: 11.2.1
+  resolution: "@auto-it/core@npm:11.2.1"
+  dependencies:
+    "@auto-it/bot-list": "npm:11.2.1"
+    "@endemolshinegroup/cosmiconfig-typescript-loader": "npm:^3.0.2"
+    "@octokit/core": "npm:^3.5.1"
+    "@octokit/plugin-enterprise-compatibility": "npm:1.3.0"
+    "@octokit/plugin-retry": "npm:^3.0.9"
+    "@octokit/plugin-throttling": "npm:^3.6.2"
+    "@octokit/rest": "npm:^18.12.0"
+    await-to-js: "npm:^3.0.0"
+    chalk: "npm:^4.0.0"
+    cosmiconfig: "npm:7.0.0"
+    deepmerge: "npm:^4.0.0"
+    dotenv: "npm:^8.0.0"
+    endent: "npm:^2.1.0"
+    enquirer: "npm:^2.3.4"
+    env-ci: "npm:^5.0.1"
+    fast-glob: "npm:^3.1.1"
+    fp-ts: "npm:^2.5.3"
+    fromentries: "npm:^1.2.0"
+    gitlog: "npm:^4.0.3"
+    https-proxy-agent: "npm:^5.0.0"
+    import-cwd: "npm:^3.0.0"
+    import-from: "npm:^3.0.0"
+    io-ts: "npm:^2.1.2"
+    lodash.chunk: "npm:^4.2.0"
+    log-symbols: "npm:^4.0.0"
+    node-fetch: "npm:2.6.7"
+    parse-author: "npm:^2.0.0"
+    parse-github-url: "npm:1.0.2"
+    pretty-ms: "npm:^7.0.0"
+    requireg: "npm:^0.2.2"
+    semver: "npm:^7.0.0"
+    signale: "npm:^1.4.0"
+    tapable: "npm:^2.2.0"
+    terminal-link: "npm:^2.1.1"
+    tinycolor2: "npm:^1.4.1"
+    ts-node: "npm:^10.9.1"
+    tslib: "npm:2.1.0"
+    type-fest: "npm:^0.21.1"
+    typescript-memoize: "npm:^1.0.0-alpha.3"
+    url-join: "npm:^4.0.0"
+  peerDependencies:
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/da3939cf521b1c065306dccba561583df44ab649eb8ee9aae95c0c5fc4f84f9d4d75165d8e761e72dbf3276a4967b5ef4f663cfc3603dda6b6e5207d014278e7
+  languageName: node
+  linkType: hard
+
 "@auto-it/npm@npm:11.1.0":
   version: 11.1.0
   resolution: "@auto-it/npm@npm:11.1.0"
@@ -182,6 +249,22 @@ __metadata:
     io-ts: "npm:^2.1.2"
     tslib: "npm:2.1.0"
   checksum: 10c0/fcb02596358b4f7721b891603b11d1450e9ed80160f26598087b4978d8d9452b95f529ba3681bf4943d3e63aad573bbd1d5d9647eda893f8dda66e7059f99c49
+  languageName: node
+  linkType: hard
+
+"@auto-it/slack@npm:^11.2.1":
+  version: 11.2.1
+  resolution: "@auto-it/slack@npm:11.2.1"
+  dependencies:
+    "@atomist/slack-messages": "npm:^1.2.2"
+    "@auto-it/core": "npm:11.2.1"
+    "@octokit/rest": "npm:^18.12.0"
+    fp-ts: "npm:^2.5.3"
+    https-proxy-agent: "npm:^5.0.0"
+    io-ts: "npm:^2.1.2"
+    node-fetch: "npm:2.6.7"
+    tslib: "npm:2.1.0"
+  checksum: 10c0/2732d31c7cb03bc0e6020e8de8ffddaf46dc1bf29d476fc82e11b556495e3e970cd84fbbf978da151744c563b688aa57a1eb1731817534241d77ea8a15a5847f
   languageName: node
   linkType: hard
 
@@ -1827,6 +1910,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@chromatic-com/storybook@workspace:."
   dependencies:
+    "@auto-it/slack": "npm:^11.2.1"
     "@emotion/weak-memoize": "npm:^0.3.1"
     "@graphql-codegen/cli": "npm:^4.0.1"
     "@graphql-codegen/client-preset": "npm:^4.0.1"


### PR DESCRIPTION
This follows the same setup we have for the CLI to send a notification in Slack whenever a new version of the package is released on npm.