### PR TITLE
Allow any version of Storybook in `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "zx": "^1.14.1"
   },
   "peerDependencies": {
-    "storybook": "^8.3.0"
+    "storybook": "*"
   },
   "engines": {
     "node": ">=16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,7 +1056,7 @@ __metadata:
     zod: "npm:^3.22.2"
     zx: "npm:^1.14.1"
   peerDependencies:
-    storybook: ^8.3.0
+    storybook: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This is mostly to enable compatibility with prerelease versions (e.g. `8.4.0-beta.1`) which wouldn't otherwise be allowed by npm.