### PR TITLE
Add steps to link for local testing

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -16,10 +16,26 @@ CHROMATIC_BASE_URL=https://www.dev-chromatic.com yarn storybook
 
 ## Running against an outside Storybook
 
-If you want to test the addon with an actual project, you can install it from npm as usual -- we publish canaries for each PR. You can also link the addon in the usual ways.
+If you want to test the addon with an actual project, you can install it from NPM as usual -- we publish canaries for each PR.
+
+You can also link the addon in the usual ways. One way via Yarn is:
+
+```
+yarn link /path/to/addon-visual-tests/repo
+```
+
+Once you do that, the project will use your local version of the addon.
 
 When running, you can connect the addon to staging/dev similarly, although you'll need to configure the project identifier/token manually.
 
 ```bash
 CHROMATIC_BASE_URL=https://www.staging-chromatic.com yarn storybook
+```
+
+## Running a local version of the Chromatic CLI
+
+You can link a local copy of the [Chromatic CLI](https://github.com/chromaui/chromatic-cli) for testing the build workflow through the addon:
+
+```
+yarn link /path/to/chromatic-cli/repo
 ```


### PR DESCRIPTION
It took me a while to figure out how to setup a local version of the VTA with a local version of the CLI for testing. This adds the steps I used to save others some time!