### PR TITLE
Prebundle react-confetti dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "chromatic": "^11.15.0",
     "filesize": "^10.0.12",
     "jsonfile": "^6.1.0",
-    "react-confetti": "^6.1.0",
     "strip-ansi": "^7.1.0"
   },
   "devDependencies": {
@@ -114,6 +113,7 @@
     "prompts": "^2.4.2",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
+    "react-confetti": "^6.1.0",
     "react-dom": "^18.3.1",
     "react-joyride": "^2.7.2",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Followup work for https://github.com/storybookjs/storybook/pull/29996

This way we can support React 19 without relying on react-confetti to make an update
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.3.0--canary.348.e32cb15.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@3.3.0--canary.348.e32cb15.0
  # or 
  yarn add @chromatic-com/storybook@3.3.0--canary.348.e32cb15.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
