### PR TITLE
Remove the connection timeout notification

### DIFF
--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -1,6 +1,4 @@
-import { FailedIcon } from "@storybook/icons";
 import { addons, type API } from "@storybook/manager-api";
-import { color } from "@storybook/theming";
 import { type Addon_TestProviderType, Addon_TypesEnum } from "@storybook/types";
 import React from "react";
 
@@ -16,11 +14,6 @@ import {
 } from "./constants";
 import { Panel } from "./Panel";
 import { TestingModuleDescription } from "./TestingModuleDescription";
-
-let heartbeatTimeout: NodeJS.Timeout;
-const expectHeartbeat = (api: API) => {
-  heartbeatTimeout = setTimeout(() => expectHeartbeat(api), 30000);
-};
 
 addons.register(ADDON_ID, (api) => {
   addons.add(PANEL_ID, {
@@ -54,28 +47,4 @@ addons.register(ADDON_ID, (api) => {
       render: () => <SidebarBottom api={api} />,
     });
   }
-
-  const channel = api.getChannel();
-  if (!channel) return;
-
-  let notificationId: string | undefined;
-  channel.on(`${ADDON_ID}/heartbeat`, () => {
-    clearTimeout(heartbeatTimeout);
-    if (notificationId) {
-      api.clearNotification(notificationId);
-      notificationId = undefined;
-    }
-    heartbeatTimeout = setTimeout(() => {
-      notificationId = `${ADDON_ID}/connection-lost/${Date.now()}`;
-      api.addNotification({
-        id: notificationId,
-        content: {
-          headline: "Connection lost",
-          subHeadline: "Lost connection to the Storybook server. Try refreshing the page.",
-        },
-        icon: <FailedIcon color={color.negative} />,
-        link: undefined,
-      });
-    }, 3000);
-  });
 });

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -294,8 +294,6 @@ async function serverChannel(channel: Channel, options: Options & { configFile?:
     configInfoState.value = await getConfigInfo(configuration, options);
   });
 
-  setInterval(() => channel.emit(`${ADDON_ID}/heartbeat`), 1000);
-
   channel.on(REMOVE_ADDON, () => {
     apiPromise.then((api) => api.removeAddon(PACKAGE_NAME)).catch((e) => console.error(e));
     gitInfoObserver.cancel();


### PR DESCRIPTION
VTA had a built-in heartbeat check to determine whether the WS connection was alive. If it isn't, it shows a notification to the user. We are removing this check to build it into Storybook.

Relates to https://github.com/storybookjs/storybook/issues/28258