### PR TITLE
Upgrade react-confetti for full React 19 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "chromatic": "^11.15.0",
     "filesize": "^10.0.12",
     "jsonfile": "^6.1.0",
-    "react-confetti": "^6.1.0",
+    "react-confetti": "^6.2.0",
     "strip-ansi": "^7.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,7 +1091,7 @@ __metadata:
     prompts: "npm:^2.4.2"
     prop-types: "npm:^15.8.1"
     react: "npm:^18.3.1"
-    react-confetti: "npm:^6.1.0"
+    react-confetti: "npm:^6.2.0"
     react-dom: "npm:^18.3.1"
     react-joyride: "npm:^2.7.2"
     rimraf: "npm:^3.0.2"
@@ -11376,14 +11376,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-confetti@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "react-confetti@npm:6.1.0"
+"react-confetti@npm:^6.2.0":
+  version: 6.2.2
+  resolution: "react-confetti@npm:6.2.2"
   dependencies:
     tween-functions: "npm:^1.2.0"
   peerDependencies:
-    react: ^16.3.0 || ^17.0.1 || ^18.0.0
-  checksum: 10c0/5b4eb23eef564695f6db1d25b294ed31d5fa21ff4092c6a38e641f85cd10e3e0b50014366e3ac0f7cf772e73faaecd14614e5b11a5531336fa769dda8068ab59
+    react: ^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/c25250acc18a7e66a2a41aa429fee70a1e56346a73dced7aa64d8c8e87b96b478eb90933b530d1857832785eeb4a5978c5cb30080d187d32bbc68c3c0ef7f0a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 react-confetti 6.2.0 updated their peer dependencies to have react 19, prior to that version the peer dependency was react 18