### PR TITLE
Upgrade `chromatic` to v12.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@neoconfetti/react": "^1.0.0",
-    "chromatic": "^11.27.0",
+    "chromatic": "^12.0.0",
     "filesize": "^10.0.12",
     "jsonfile": "^6.1.0",
     "strip-ansi": "^7.1.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,6 +47,8 @@ export const CONFIG_OVERRIDES = {
   interactive: false,
   // Builds initiated from the addon are always considered local
   isLocalBuild: true,
+  // Prefix for Chromatic CLI log messages
+  logPrefix: '\x1b[38;5;202mChromatic\x1B[0m:',
   // Never skip local builds
   skip: false,
   // Don't check for CLI updates

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -131,7 +131,7 @@ const observeGitInfo = (
   let timer: NodeJS.Timeout | undefined;
   const act = async () => {
     try {
-      const gitInfo = await getGitInfo();
+      const gitInfo = await getGitInfo({ log: chromaticLogger });
       if (Object.entries(gitInfo).some(([key, value]) => prev?.[key as keyof GitInfo] !== value)) {
         callback(gitInfo, prev);
       }

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -2,7 +2,13 @@ import { watch } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join, normalize, relative } from 'node:path';
 
-import { type Configuration, getConfiguration, getGitInfo, type GitInfo } from 'chromatic/node';
+import {
+  type Configuration,
+  createLogger,
+  getConfiguration,
+  getGitInfo,
+  type GitInfo,
+} from 'chromatic/node';
 import type { Channel } from 'storybook/internal/channels';
 import { experimental_getTestProviderStore } from 'storybook/internal/core-server';
 import { telemetry } from 'storybook/internal/telemetry';
@@ -12,6 +18,7 @@ import {
   ADDON_ID,
   CHROMATIC_BASE_URL,
   CONFIG_INFO,
+  CONFIG_OVERRIDES,
   GIT_INFO,
   GIT_INFO_ERROR,
   LOCAL_BUILD_PROGRESS,
@@ -34,6 +41,8 @@ import {
 import { ChannelFetch } from './utils/ChannelFetch';
 import { SharedState } from './utils/SharedState';
 import { updateChromaticConfig } from './utils/updateChromaticConfig';
+
+const chromaticLogger = createLogger(undefined, CONFIG_OVERRIDES);
 
 /**
  * to load the built addon in this test Storybook
@@ -83,7 +92,7 @@ const getConfigInfo = async (
   const problems: ConfigurationUpdate = {};
   const suggestions: ConfigurationUpdate = {};
 
-  const { repositoryRootDir } = await getGitInfo();
+  const { repositoryRootDir } = await getGitInfo({ log: chromaticLogger });
   const baseDir = repositoryRootDir && normalize(relative(repositoryRootDir, process.cwd()));
   if (baseDir !== normalize(configuration.storybookBaseDir ?? '')) {
     problems.storybookBaseDir = baseDir;

--- a/src/runChromaticBuild.ts
+++ b/src/runChromaticBuild.ts
@@ -200,7 +200,6 @@ export const runChromaticBuild = async (
     options: {
       ...options,
       ...CONFIG_OVERRIDES,
-      logPrefix: '\x1b[38;5;202mChromatic\x1B[0m:',
       experimental_onTaskStart: onStartOrProgress(localBuildProgress, timeout),
       experimental_onTaskProgress: onStartOrProgress(localBuildProgress, timeout),
       experimental_onTaskComplete: onCompleteOrError(localBuildProgress, timeout),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,7 +1173,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^3.0.8"
     auto: "npm:^11.0.5"
     boxen: "npm:^5.0.1"
-    chromatic: "npm:^11.27.0"
+    chromatic: "npm:^12.0.0"
     date-fns: "npm:^2.30.0"
     dedent: "npm:^0.7.0"
     eslint: "npm:^9.21.0"
@@ -4795,9 +4795,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromatic@npm:^11.27.0":
-  version: 11.27.0
-  resolution: "chromatic@npm:11.27.0"
+"chromatic@npm:^12.0.0":
+  version: 12.0.0
+  resolution: "chromatic@npm:12.0.0"
   peerDependencies:
     "@chromatic-com/cypress": ^0.*.* || ^1.0.0
     "@chromatic-com/playwright": ^0.*.* || ^1.0.0
@@ -4810,7 +4810,7 @@ __metadata:
     chroma: dist/bin.js
     chromatic: dist/bin.js
     chromatic-cli: dist/bin.js
-  checksum: 10c0/500c1a522a48b3ef9188d63693b2602128b4cd7b2b96e5cb5412cdc0e3b7ac2a33c30d8f55f7662de4111e1c7c70bcb970e86782700e02580881400bdd10419b
+  checksum: 10c0/fb6022581f9d04b29b731a0696178f027cf7b37b90d34bcb6c493f158c7b66f5047b2702d06b4c5246d5ac8ae5712ff5996959b32061726f862c0ec9396adfdb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades the Chromatic CLI to v12 which introduces a context parameter to `getGitInfo` which requires VTA to pass a custom logger.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.2.7--canary.376.5545a81.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@3.2.7--canary.376.5545a81.0
  # or 
  yarn add @chromatic-com/storybook@3.2.7--canary.376.5545a81.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
