### PR TITLE
Support disabling ChannelFetch using `--debug` flag

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -85,7 +85,8 @@ export const Panel = ({ active }: PanelProps) => {
   const trackEvent = useCallback((data: any) => emit(TELEMETRY, data), [emit]);
   const { isRunning, startBuild, stopBuild } = useBuildEvents({ localBuildProgress, accessToken });
 
-  const fetch = useChannelFetch();
+  const channelFetch = useChannelFetch();
+  const fetch = globalThis.LOGLEVEL === 'debug' ? globalThis.fetch : channelFetch;
   const withProviders = (children: React.ReactNode) => (
     <GraphQLClientProvider value={createClient({ fetch })}>
       <TelemetryProvider value={trackEvent}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,8 @@ import { SelectedBuildFieldsFragment } from './gql/graphql';
 declare global {
   // eslint-disable-next-line no-var
   var CONFIG_TYPE: string;
+  // eslint-disable-next-line no-var
+  var LOGLEVEL: string;
 }
 
 export type AnnouncedBuild = Extract<SelectedBuildFieldsFragment, { __typename: 'AnnouncedBuild' }>;


### PR DESCRIPTION
When debugging, it's pretty inconvenient for network requests to go through the server channel. This update disables ChannelFetch when passing `--debug` to the Storybook CLI.