### PR TITLE
Update GraphQL schema and handle `ComparisonResult.SKIPPED` value

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ export default [
   ),
   {
     files: ['**/*.ts', '**/*.tsx'],
+    ignores: ['**/node_modules/**', '**/coverage/**', '**/dist/**', '**/src/gql/**'],
     plugins: {
       'simple-import-sort': simpleImportSort,
     },

--- a/src/components/BrowserSelector.stories.ts
+++ b/src/components/BrowserSelector.stories.ts
@@ -63,6 +63,18 @@ export const WithSingleBrowserEqual: Story = {
   },
 };
 
+export const WithSingleBrowserSkipped: Story = {
+  args: {
+    selectedBrowser: browserChrome,
+    browserResults: [
+      {
+        browser: browserChrome,
+        result: ComparisonResult.Skipped,
+      },
+    ],
+  },
+};
+
 export const WithSingleBrowserError: Story = {
   args: {
     selectedBrowser: browserChrome,

--- a/src/components/BrowserSelector.tsx
+++ b/src/components/BrowserSelector.tsx
@@ -71,7 +71,11 @@ export const BrowserSelector = ({
   if (!aggregate) return null;
 
   let icon = browserIcons[selectedBrowser.key];
-  if (!isAccepted && aggregate !== ComparisonResult.Equal && browserResults.length >= 2) {
+  if (
+    !isAccepted &&
+    ![ComparisonResult.Equal, ComparisonResult.Skipped].includes(aggregate) &&
+    browserResults.length >= 2
+  ) {
     icon = <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>;
   }
 
@@ -84,7 +88,10 @@ export const BrowserSelector = ({
         active: selectedBrowser === browser,
         id: browser.id,
         onClick: () => onSelectBrowser(browser),
-        right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
+        right: !isAccepted &&
+          ![ComparisonResult.Equal, ComparisonResult.Skipped].includes(aggregate) && (
+            <StatusDot status={result} />
+          ),
         icon: browserIcons[browser.key],
         title: browser.name,
       })

--- a/src/components/ModeSelector.stories.ts
+++ b/src/components/ModeSelector.stories.ts
@@ -59,6 +59,18 @@ export const WithSingleViewportEqual: Story = {
   },
 };
 
+export const WithSingleViewportSkipped: Story = {
+  args: {
+    selectedMode: viewport1200Px,
+    modeResults: [
+      {
+        mode: viewport1200Px,
+        result: ComparisonResult.Skipped,
+      },
+    ],
+  },
+};
+
 export const WithSingleViewportError: Story = {
   args: {
     selectedMode: viewport1200Px,

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -82,7 +82,11 @@ export const ModeSelector = ({
   if (!aggregate) return null;
 
   let icon = <DiamondIcon />;
-  if (!isAccepted && aggregate !== ComparisonResult.Equal && modeResults.length >= 2) {
+  if (
+    !isAccepted &&
+    ![ComparisonResult.Equal, ComparisonResult.Skipped].includes(aggregate) &&
+    modeResults.length >= 2
+  ) {
     icon = <StatusDotWrapper status={aggregate}>{icon}</StatusDotWrapper>;
   }
 
@@ -92,7 +96,10 @@ export const ModeSelector = ({
       .map(({ mode, result }) => ({
         id: mode.name,
         title: mode.name,
-        right: !isAccepted && result !== ComparisonResult.Equal && <StatusDot status={result} />,
+        right: !isAccepted &&
+          ![ComparisonResult.Equal, ComparisonResult.Skipped].includes(aggregate) && (
+            <StatusDot status={result} />
+          ),
         onClick: () => onSelectMode(mode),
         active: selectedMode.name === mode.name,
       }))

--- a/src/components/StatusDot.tsx
+++ b/src/components/StatusDot.tsx
@@ -23,6 +23,7 @@ const Dot = styled.div<StatusDotProps & { overlay?: boolean }>(
         [TestStatus.Denied]: theme.color.positive,
         [TestStatus.Broken]: theme.color.negative,
         [TestStatus.Failed]: theme.color.negative,
+        [ComparisonResult.Skipped]: 'transparent',
         [ComparisonResult.Equal]: theme.color.positive,
         [ComparisonResult.Fixed]: theme.color.positive,
         [ComparisonResult.Added]: theme.color.gold,

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
@@ -321,6 +322,16 @@ export type CaptureErrorInteractionFailure = CaptureError & {
   kind: CaptureErrorKind;
 };
 
+export type CaptureErrorInteractionTestTimeout = CaptureError & {
+  __typename?: 'CaptureErrorInteractionTestTimeout';
+  /** The ID of the capture error. */
+  id: Scalars['ID']['output'];
+  /** The kind of capture error. */
+  kind: CaptureErrorKind;
+  /** The maximum number of milliseconds allowed for interaction tests to run. */
+  timeoutMs: Scalars['Int']['output'];
+};
+
 export type CaptureErrorJsError = CaptureError & {
   __typename?: 'CaptureErrorJSError';
   /** The original error that caused the capture to fail. Typically contains a name and message. */
@@ -340,12 +351,16 @@ export enum CaptureErrorKind {
   ImageTooLarge = 'IMAGE_TOO_LARGE',
   /** An interaction failed to complete, or encountered an assertion error. */
   InteractionFailure = 'INTERACTION_FAILURE',
+  /** The interaction test took too long to complete. */
+  InteractionTestTimeout = 'INTERACTION_TEST_TIMEOUT',
   /** A JavaScript error occurred during capture. */
   JsError = 'JS_ERROR',
   /** The page took too long to load. */
   NavigationTimeout = 'NAVIGATION_TIMEOUT',
   /** The page does not contain (valid) JavaScript. */
   NoJs = 'NO_JS',
+  /** The Storybook render took too long to complete. */
+  RenderTimeout = 'RENDER_TIMEOUT',
   /** The screenshot took too long to capture. */
   ScreenshotTimeout = 'SCREENSHOT_TIMEOUT',
   /** The story was not found. */
@@ -370,6 +385,16 @@ export type CaptureErrorNoJs = CaptureError & {
   kind: CaptureErrorKind;
 };
 
+export type CaptureErrorRenderTimeout = CaptureError & {
+  __typename?: 'CaptureErrorRenderTimeout';
+  /** The ID of the capture error. */
+  id: Scalars['ID']['output'];
+  /** The kind of capture error. */
+  kind: CaptureErrorKind;
+  /** The maximum number of milliseconds allowed for a story to render. */
+  timeoutMs: Scalars['Int']['output'];
+};
+
 export type CaptureErrorScreenshotTimeout = CaptureError & {
   __typename?: 'CaptureErrorScreenshotTimeout';
   /** The ID of the capture error. */
@@ -382,6 +407,14 @@ export type CaptureErrorScreenshotTimeout = CaptureError & {
 
 export type CaptureErrorStoryMissing = CaptureError & {
   __typename?: 'CaptureErrorStoryMissing';
+  /** The ID of the capture error. */
+  id: Scalars['ID']['output'];
+  /** The kind of capture error. */
+  kind: CaptureErrorKind;
+};
+
+export type CaptureErrorTimeoutType = CaptureError & {
+  __typename?: 'CaptureErrorTimeoutType';
   /** The ID of the capture error. */
   id: Scalars['ID']['output'];
   /** The kind of capture error. */
@@ -452,6 +485,8 @@ export enum ComparisonResult {
   Fixed = 'FIXED',
   /** There was a base capture, but no head capture. */
   Removed = 'REMOVED',
+  /** We didn't capture the story as it was skipped */
+  Skipped = 'SKIPPED',
   /** Either the head capture or the diff failed due to a system error. */
   SystemError = 'SYSTEM_ERROR'
 }
@@ -1313,7 +1348,7 @@ export type Test = Node & Temporal & {
   id: Scalars['ID']['output'];
   /** What test kinds is this test associated with. */
   kinds: Array<TestKind>;
-  /** The mode applied to this test. If this test was not using modes, the viewport is set as the mode name (e.g. "[viewport]px")  */
+  /** The mode applied to this test. If this test was not using modes, the viewport is set as the mode name (e.g. "[viewport]px") */
   mode: TestMode;
   /** Chromatic parameters configured on the story or automatically determined based on context. */
   parameters: TestParameters;
@@ -1613,7 +1648,7 @@ export type StatusTestFieldsFragment = { __typename?: 'Test', id: string, status
 
 export type LastBuildOnBranchTestFieldsFragment = { __typename?: 'Test', status: TestStatus, result?: TestResult | null } & { ' $fragmentName'?: 'LastBuildOnBranchTestFieldsFragment' };
 
-export type StoryTestFieldsFragment = { __typename?: 'Test', id: string, status: TestStatus, result?: TestResult | null, webUrl: any, comparisons: Array<{ __typename?: 'TestComparison', id: string, result?: ComparisonResult | null, browser: { __typename?: 'BrowserInfo', id: string, key: Browser, name: string, version: string }, captureDiff?: { __typename?: 'CaptureDiff', diffImage?: { __typename?: 'CaptureOverlayImage', imageUrl: any, imageWidth: number } | null, focusImage?: { __typename?: 'CaptureOverlayImage', imageUrl: any, imageWidth: number } | null } | null, headCapture?: { __typename?: 'Capture', captureImage?: { __typename?: 'CaptureImage', backgroundColor?: string | null, imageUrl: any, imageWidth: number, imageHeight: number, thumbnailUrl: any } | null, captureError?: { __typename?: 'CaptureErrorComponentOffPage', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorFailedJS', error: any, kind: CaptureErrorKind } | { __typename?: 'CaptureErrorImageTooLarge', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorInteractionFailure', error: any, kind: CaptureErrorKind } | { __typename?: 'CaptureErrorJSError', error: any, kind: CaptureErrorKind } | { __typename?: 'CaptureErrorNavigationTimeout', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorNoJS', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorScreenshotTimeout', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorStoryMissing', kind: CaptureErrorKind } | null } | null, baseCapture?: { __typename?: 'Capture', captureImage?: { __typename?: 'CaptureImage', imageUrl: any, imageWidth: number, imageHeight: number } | null } | null }>, mode: { __typename?: 'TestMode', name: string, globals: any }, story?: { __typename?: 'Story', storyId: string, name: string, component?: { __typename?: 'Component', name: string } | null } | null } & { ' $fragmentName'?: 'StoryTestFieldsFragment' };
+export type StoryTestFieldsFragment = { __typename?: 'Test', id: string, status: TestStatus, result?: TestResult | null, webUrl: any, comparisons: Array<{ __typename?: 'TestComparison', id: string, result?: ComparisonResult | null, browser: { __typename?: 'BrowserInfo', id: string, key: Browser, name: string, version: string }, captureDiff?: { __typename?: 'CaptureDiff', diffImage?: { __typename?: 'CaptureOverlayImage', imageUrl: any, imageWidth: number } | null, focusImage?: { __typename?: 'CaptureOverlayImage', imageUrl: any, imageWidth: number } | null } | null, headCapture?: { __typename?: 'Capture', captureImage?: { __typename?: 'CaptureImage', backgroundColor?: string | null, imageUrl: any, imageWidth: number, imageHeight: number, thumbnailUrl: any } | null, captureError?: { __typename?: 'CaptureErrorComponentOffPage', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorFailedJS', error: any, kind: CaptureErrorKind } | { __typename?: 'CaptureErrorImageTooLarge', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorInteractionFailure', error: any, kind: CaptureErrorKind } | { __typename?: 'CaptureErrorInteractionTestTimeout', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorJSError', error: any, kind: CaptureErrorKind } | { __typename?: 'CaptureErrorNavigationTimeout', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorNoJS', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorRenderTimeout', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorScreenshotTimeout', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorStoryMissing', kind: CaptureErrorKind } | { __typename?: 'CaptureErrorTimeoutType', kind: CaptureErrorKind } | null } | null, baseCapture?: { __typename?: 'Capture', captureImage?: { __typename?: 'CaptureImage', imageUrl: any, imageWidth: number, imageHeight: number } | null } | null }>, mode: { __typename?: 'TestMode', name: string, globals: any }, story?: { __typename?: 'Story', storyId: string, name: string, component?: { __typename?: 'Component', name: string } | null } | null } & { ' $fragmentName'?: 'StoryTestFieldsFragment' };
 
 export type ReviewTestMutationVariables = Exact<{
   input: ReviewTestInput;

--- a/src/gql/public-schema.graphql
+++ b/src/gql/public-schema.graphql
@@ -490,7 +490,7 @@ type Test implements Node & Temporal {
   parameters: TestParameters!
 
   """
-  The mode applied to this test. If this test was not using modes, the viewport is set as the mode name (e.g. "[viewport]px") 
+  The mode applied to this test. If this test was not using modes, the viewport is set as the mode name (e.g. "[viewport]px")
   """
   mode: TestMode!
 
@@ -559,6 +559,9 @@ enum ComparisonResult {
 
   """Either the head capture or the diff failed due to a system error."""
   SYSTEM_ERROR
+
+  """We didn't capture the story as it was skipped"""
+  SKIPPED
 }
 
 type ViewportInfo {
@@ -656,6 +659,12 @@ enum CaptureErrorKind {
 
   """The page took too long to load."""
   NAVIGATION_TIMEOUT
+
+  """The Storybook render took too long to complete."""
+  RENDER_TIMEOUT
+
+  """The interaction test took too long to complete."""
+  INTERACTION_TEST_TIMEOUT
 
   """The page does not contain (valid) JavaScript."""
   NO_JS
@@ -1459,6 +1468,38 @@ type CaptureErrorScreenshotTimeout implements CaptureError {
   The maximum number of milliseconds allowed for a screenshot to be taken.
   """
   screenshotTimeoutMs: Int!
+}
+
+type CaptureErrorTimeoutType implements CaptureError {
+  """The ID of the capture error."""
+  id: ID!
+
+  """The kind of capture error."""
+  kind: CaptureErrorKind!
+}
+
+type CaptureErrorRenderTimeout implements CaptureError {
+  """The ID of the capture error."""
+  id: ID!
+
+  """The kind of capture error."""
+  kind: CaptureErrorKind!
+
+  """The maximum number of milliseconds allowed for a story to render."""
+  timeoutMs: Int!
+}
+
+type CaptureErrorInteractionTestTimeout implements CaptureError {
+  """The ID of the capture error."""
+  id: ID!
+
+  """The kind of capture error."""
+  kind: CaptureErrorKind!
+
+  """
+  The maximum number of milliseconds allowed for interaction tests to run.
+  """
+  timeoutMs: Int!
 }
 
 type Query {

--- a/src/utils/aggregateResult.ts
+++ b/src/utils/aggregateResult.ts
@@ -2,6 +2,7 @@ import { ComparisonResult } from '../gql/graphql';
 
 export const resultOrder = [
   undefined,
+  ComparisonResult.Skipped,
   ComparisonResult.Equal,
   ComparisonResult.Fixed,
   ComparisonResult.Added,

--- a/src/utils/useTests.ts
+++ b/src/utils/useTests.ts
@@ -18,7 +18,8 @@ const useGlobalValue = (key: string) => {
 };
 
 const hasChanges = ({ result }: StoryTestFieldsFragment['comparisons'][number]) =>
-  result !== ComparisonResult.Equal && result !== ComparisonResult.Fixed;
+  result &&
+  ![ComparisonResult.Equal, ComparisonResult.Fixed, ComparisonResult.Skipped].includes(result);
 
 /**
  * Select the initial test based on the following criteria (in order of priority):


### PR DESCRIPTION
Fixes #365

The Chromatic API can now return `SKIPPED` for certain comparisons. This updates VTA to handle those situations.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.0.1--canary.379.41a22f0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@4.0.1--canary.379.41a22f0.0
  # or 
  yarn add @chromatic-com/storybook@4.0.1--canary.379.41a22f0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
