### PR TITLE
Respect SSO subdomain in OAuth authorize entrypoint

### DIFF
--- a/src/utils/requestAccessToken.ts
+++ b/src/utils/requestAccessToken.ts
@@ -40,11 +40,14 @@ const betaUserAccessDenied = ({ error_description }: { error_description: string
   return error_description === 'Not OAuth beta user';
 };
 
+const withSubdomain = (url: string, subdomain?: string) =>
+  subdomain ? url.replace('https://www', `https://${subdomain}`) : url;
+
 export const initiateSignin = async (subdomain?: string): Promise<TokenExchangeParameters> => {
   const verifier = base64URLEncode(seed());
   const challenge = base64URLEncode(hexStringToBytes(sha256(verifier)));
 
-  const res = await fetch(`${CHROMATIC_BASE_URL}/authorize`, {
+  const res = await fetch(`${withSubdomain(CHROMATIC_BASE_URL, subdomain)}/authorize`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
@@ -58,9 +61,7 @@ export const initiateSignin = async (subdomain?: string): Promise<TokenExchangeP
   const { device_code, user_code, verification_uri_complete, expires_in, interval } =
     await res.json();
 
-  const verificationUrl = subdomain
-    ? verification_uri_complete.replace('https://www', `https://${subdomain}`)
-    : verification_uri_complete;
+  const verificationUrl = withSubdomain(verification_uri_complete, subdomain);
 
   return {
     expires: Date.now() + expires_in * 1000,

--- a/src/utils/requestAccessToken.ts
+++ b/src/utils/requestAccessToken.ts
@@ -41,13 +41,13 @@ const betaUserAccessDenied = ({ error_description }: { error_description: string
 };
 
 const withSubdomain = (url: string, subdomain?: string) =>
-  subdomain ? url.replace('https://www', `https://${subdomain}`) : url;
+  subdomain ? url.replace(/^https:\/\/www\./, `https://${subdomain}.`) : url;
 
 export const initiateSignin = async (subdomain?: string): Promise<TokenExchangeParameters> => {
   const verifier = base64URLEncode(seed());
   const challenge = base64URLEncode(hexStringToBytes(sha256(verifier)));
 
-  const res = await fetch(`${withSubdomain(CHROMATIC_BASE_URL, subdomain)}/authorize`, {
+  const res = await fetch(withSubdomain(`${CHROMATIC_BASE_URL}/authorize`, subdomain), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.0.2--canary.381.da8c72f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/storybook@4.0.2--canary.381.da8c72f.0
  # or 
  yarn add @chromatic-com/storybook@4.0.2--canary.381.da8c72f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
