### PR TITLE
Fix: Update broken and outdated links in the addon

### DIFF
--- a/src/components/FooterMenu.tsx
+++ b/src/components/FooterMenu.tsx
@@ -20,7 +20,7 @@ export const FooterMenu = () => {
       id: 'learn',
       title: 'About this addon',
       icon: <QuestionIcon aria-hidden />,
-      href: 'https://www.chromatic.com/docs/visual-testing-addon',
+      href: 'https://www.chromatic.com/docs/visual-tests-addon/',
       target: '_blank',
     },
     {

--- a/src/screens/LinkProject/LinkingProjectFailed.tsx
+++ b/src/screens/LinkProject/LinkingProjectFailed.tsx
@@ -30,7 +30,8 @@ const CodeWrapper = styled.div(({ theme }) => ({
   },
 }));
 
-const configureDocsLink = 'https://www.chromatic.com/docs/visual-tests-addon/#configure';
+const configureDocsLink =
+  'https://www.chromatic.com/docs/visual-tests-addon#addon-configuration-options';
 
 export function LinkingProjectFailed({ projectId, configFile }: LinkingProjectFailedProps) {
   useTelemetry('LinkProject', 'LinkingProjectFailed');

--- a/src/screens/VisualTests/BuildResults.tsx
+++ b/src/screens/VisualTests/BuildResults.tsx
@@ -155,7 +155,7 @@ export const BuildResults = ({
             </div>
             <Button asChild size="medium" variant="outline">
               <a
-                href="https://www.chromatic.com/docs/ignoring-elements#with-storybook"
+                href="https://www.chromatic.com/docs/disable-snapshots#with-storybook"
                 target="_new"
               >
                 <DocumentIcon />

--- a/src/screens/VisualTests/NoBuild.tsx
+++ b/src/screens/VisualTests/NoBuild.tsx
@@ -149,7 +149,7 @@ export const NoBuild = ({
 
             <ButtonStackLink
               withArrow
-              href="https://www.chromatic.com/docs/ignoring-elements#with-storybook"
+              href="https://www.chromatic.com/docs/disable-snapshots#with-storybook"
               target="_blank"
             >
               Read more


### PR DESCRIPTION
With this pull request, some of the links to the Chromatic documentation listed in the addon were updated to reflect their current usage and placement.


What was done:
- Updated outdated links to the Chromatic documentation


cc @ghengeveld 