### PR TITLE
fix: move Chromatic CLI to devDeps (to avoid duplicated install)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   },
   "dependencies": {
     "@neoconfetti/react": "^1.0.0",
-    "chromatic": "^13.3.4",
     "filesize": "^10.0.12",
     "jsonfile": "^6.1.0",
     "strip-ansi": "^7.1.0"
@@ -82,6 +81,7 @@
     "@vitest/coverage-v8": "^3.0.8",
     "auto": "^11.0.5",
     "boxen": "^5.0.1",
+    "chromatic": "^13.3.4",
     "date-fns": "^2.30.0",
     "dedent": "^0.7.0",
     "eslint": "^9.21.0",


### PR DESCRIPTION
The `chromatic` dependency is only used as a CLI, not used in the package code itself (unless I'm wrong/missed something).

Moreover, it's outdated, currently set as v13.3.4, but latest is v16.3.0.
So, because I use a newer version in my project, the CLI is installed twice unnecessarily (detected thanks to [Node Modules Inspector](https://node-modules.dev/)):

<img width="229" height="126" alt="image" src="https://github.com/user-attachments/assets/388af81a-0130-4517-9484-858953268fff" />

One could argue, that it's "useless" (or not relevant) to install `@chromatic-com/storybook` without the Chromatic CLI in most cases, so we could put it as a peer dep instead, but that doesn't really help in anything.

I believe the best way to solve this "duplicated installation" issue, it's to put it in dev deps.