### PR TITLE
Refactor share-auth flow into reducer + driver pattern

### DIFF
--- a/src/manager.test.ts
+++ b/src/manager.test.ts
@@ -79,6 +79,13 @@ vi.mock('./screens/ShareSection/popoverPresence', () => ({
   isPresent: () => false,
 }));
 
+const driverMock = vi.hoisted(() => ({ handlesRedirect: true }));
+vi.mock('./utils/signInDriver', () => ({
+  get handlesOAuthRedirect() {
+    return driverMock.handlesRedirect;
+  },
+}));
+
 function stubWindow(search = '', opener: Record<string, unknown> | null = null) {
   const windowMock = {
     opener,
@@ -99,6 +106,7 @@ afterEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
   vi.unstubAllGlobals();
+  driverMock.handlesRedirect = true;
   delete (globalThis as { CONFIG_TYPE?: string }).CONFIG_TYPE;
 });
 
@@ -189,6 +197,18 @@ describe('manager', () => {
       await import('./manager');
 
       expect(opener.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not post when driver does not handle redirect (device-code flow)', async () => {
+      driverMock.handlesRedirect = false;
+      const opener = { closed: false, postMessage: vi.fn() };
+      const windowMock = stubWindow('?code=grant-code&state=abc123', opener);
+      (globalThis as { CONFIG_TYPE?: string }).CONFIG_TYPE = 'PRODUCTION';
+
+      await import('./manager');
+
+      expect(opener.postMessage).not.toHaveBeenCalled();
+      expect(windowMock.close).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/manager.tsx
+++ b/src/manager.tsx
@@ -19,9 +19,11 @@ import { isPresent as isSharePopoverPresent } from './screens/ShareSection/popov
 import { TestProviderRender } from './TestProviderRender';
 import type { ShareProgress } from './types';
 import { SharedState } from './utils/SharedState';
+import { handlesOAuthRedirect } from './utils/signInDriver';
 
-// OAuth redirect handler
-if (window.opener && !window.opener.closed) {
+// OAuth redirect handler — only runs for flows that round-trip through this
+// window (authorization-code). Device-code never opens the addon as a popup.
+if (handlesOAuthRedirect && window.opener && !window.opener.closed) {
   const params = new URLSearchParams(window.location.search);
   const code = params.get('code');
   const state = params.get('state');

--- a/src/screens/Authentication/Authentication.test.tsx
+++ b/src/screens/Authentication/Authentication.test.tsx
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DriverSnapshot } from '../../utils/signInDriver';
+
+// ---- hoisted mocks ----
+const mocks = vi.hoisted(() => {
+  const driverInstance: any = {
+    flow: 'device-code',
+    start: vi.fn(),
+    cancel: vi.fn(),
+    resume: vi.fn(),
+  };
+  return {
+    driverInstance,
+    createSignInDriver: vi.fn(() => driverInstance),
+    setSnapshot: vi.fn(),
+    setScreen: vi.fn(),
+    setSubdomain: vi.fn(),
+    onError: vi.fn(),
+  };
+});
+
+// State injected per-test
+let snapshotValue: DriverSnapshot | null = null;
+let screenValue: 'welcome' | 'signin' | 'subdomain' | 'verify' = 'verify';
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    useRef: (initial: unknown) => ({ current: initial }),
+    useCallback: (fn: unknown) => fn,
+    useEffect: (fn: () => (() => void) | void) => {
+      fn();
+    },
+    useState: (initial: unknown) => [initial, vi.fn()],
+  };
+});
+
+vi.mock('../../utils/signInDriver', () => ({
+  createSignInDriver: () => mocks.createSignInDriver(),
+}));
+
+vi.mock('../../utils/useSessionState', () => ({
+  useSessionState: vi.fn((key: string) => {
+    if (key === 'authenticationScreen') return [screenValue, mocks.setScreen];
+    if (key === 'signInSnapshot') return [snapshotValue, mocks.setSnapshot];
+    return [undefined, vi.fn()];
+  }),
+}));
+
+vi.mock('../../utils/useErrorNotification', () => ({
+  useErrorNotification: () => mocks.onError,
+}));
+
+vi.mock('../../utils/TelemetryContext', () => ({
+  useTelemetry: vi.fn(),
+}));
+
+vi.mock('../../AuthContext', () => ({
+  useAuthState: () => ({ setSubdomain: mocks.setSubdomain }),
+}));
+
+vi.mock('../Uninstalled/UninstallContext', () => ({
+  useUninstallAddon: () => ({ uninstallAddon: vi.fn() }),
+}));
+
+vi.mock('./SetSubdomain', () => ({ SetSubdomain: () => null }));
+vi.mock('./SignIn', () => ({ SignIn: () => null }));
+vi.mock('./Verify', () => ({ Verify: () => null }));
+vi.mock('./Welcome', () => ({ Welcome: () => null }));
+
+const { Authentication } = await import('./Authentication');
+
+beforeEach(() => {
+  // Re-create driver instance per test so prior call counts don't leak.
+  mocks.driverInstance.flow = 'device-code';
+  mocks.driverInstance.start = vi.fn();
+  mocks.driverInstance.cancel = vi.fn();
+  mocks.driverInstance.resume = vi.fn();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  snapshotValue = null;
+  screenValue = 'verify';
+});
+
+const invoke = (props: Partial<Parameters<typeof Authentication>[0]> = {}) =>
+  (Authentication as any)({
+    setAccessToken: vi.fn(),
+    setCreatedProjectId: vi.fn(),
+    hasProjectId: false,
+    ...props,
+  });
+
+describe('Authentication remount-with-snapshot behavior', () => {
+  it('drops snapshot and returns to signin when snapshot.flow does not match driver.flow', () => {
+    mocks.driverInstance.flow = 'device-code';
+    snapshotValue = {
+      flow: 'authorization-code',
+      params: {
+        clientId: 'c',
+        redirectUri: 'https://r.example/iframe.html',
+        codeVerifier: 'v',
+        state: 's',
+        authorizationUrl: 'https://a.example/authorize',
+        tokenEndpoint: 'https://a.example/token',
+      },
+    };
+    screenValue = 'verify';
+
+    invoke();
+
+    expect(mocks.setSnapshot).toHaveBeenCalledWith(null);
+    expect(mocks.setScreen).toHaveBeenCalledWith('signin');
+    expect(mocks.driverInstance.resume).not.toHaveBeenCalled();
+  });
+
+  it('calls driver.resume when snapshot flow matches driver flow', () => {
+    mocks.driverInstance.flow = 'device-code';
+    mocks.driverInstance.resume = vi.fn(() => new Promise(() => {}));
+    snapshotValue = {
+      flow: 'device-code',
+      deviceCode: 'dc',
+      verifier: 'v',
+      expires: Date.now() + 60_000,
+      interval: 1000,
+      userCode: 'ABC123',
+      verificationUrl: 'https://www.chromatic.com/verify',
+      tokenEndpoint: 'https://www.chromatic.com/token',
+    };
+    screenValue = 'verify';
+
+    invoke();
+
+    expect(mocks.driverInstance.resume).toHaveBeenCalledOnce();
+    const [passedSnapshot] = mocks.driverInstance.resume.mock.calls[0];
+    expect(passedSnapshot).toBe(snapshotValue);
+    expect(mocks.setSnapshot).not.toHaveBeenCalledWith(null);
+  });
+
+  it('returns to signin when verify screen has no snapshot', () => {
+    snapshotValue = null;
+    screenValue = 'verify';
+
+    invoke();
+
+    expect(mocks.setScreen).toHaveBeenCalledWith('signin');
+    expect(mocks.driverInstance.resume).not.toHaveBeenCalled();
+  });
+});

--- a/src/screens/Authentication/Authentication.tsx
+++ b/src/screens/Authentication/Authentication.tsx
@@ -1,8 +1,13 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAuthState } from '../../AuthContext';
 import { Project } from '../../gql/graphql';
-import { initiateSignin, TokenExchangeParameters } from '../../utils/requestAccessToken';
+import {
+  createSignInDriver,
+  type DriverSnapshot,
+  type SignInDriver,
+  type StartResult,
+} from '../../utils/signInDriver';
 import { useTelemetry } from '../../utils/TelemetryContext';
 import { useErrorNotification } from '../../utils/useErrorNotification';
 import { useSessionState } from '../../utils/useSessionState';
@@ -29,25 +34,79 @@ export const Authentication = ({
     'authenticationScreen',
     hasProjectId ? 'signin' : 'welcome'
   );
-  const [exchangeParameters, setExchangeParameters] =
-    useSessionState<TokenExchangeParameters>('exchangeParameters');
+  const [snapshot, setSnapshot] = useSessionState<DriverSnapshot | null>('signInSnapshot', null);
   const onError = useErrorNotification();
   const { uninstallAddon } = useUninstallAddon();
   const { setSubdomain } = useAuthState();
 
+  const driverRef = useRef<SignInDriver | null>(null);
+  if (driverRef.current === null) driverRef.current = createSignInDriver();
+
+  const [verifyState, setVerifyState] = useState<StartResult | null>(null);
+
   useTelemetry('Authentication', screen.charAt(0).toUpperCase() + screen.slice(1));
+
+  // On mount, attempt to resume from a stored snapshot when the flow matches
+  // the current driver. Mismatched snapshots (e.g. flow flipped between
+  // sessions) get dropped so the user falls back to the sign-in screen.
+  useEffect(() => {
+    const driver = driverRef.current!;
+    if (screen !== 'verify') return;
+    if (!snapshot) {
+      setScreen('signin');
+      return;
+    }
+    if (snapshot.flow !== driver.flow || !driver.resume) {
+      setSnapshot(null);
+      setScreen('signin');
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await driver.resume!(snapshot, { onSnapshot: setSnapshot });
+        if (!cancelled) setVerifyState(result);
+      } catch (err) {
+        if (!cancelled) {
+          onError('Sign in Error', err);
+          setSnapshot(null);
+          setScreen('signin');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Cancel the driver if we leave the verify screen or unmount.
+  useEffect(() => {
+    if (screen !== 'verify') {
+      driverRef.current?.cancel();
+      setVerifyState(null);
+    }
+  }, [screen]);
+
+  useEffect(
+    () => () => {
+      driverRef.current?.cancel();
+    },
+    []
+  );
 
   const initiateSignInAndMoveToVerify = useCallback(
     async (subdomain?: string) => {
       try {
         setSubdomain(subdomain ?? 'www');
-        setExchangeParameters(await initiateSignin(subdomain));
+        const result = await driverRef.current!.start({ subdomain, onSnapshot: setSnapshot });
+        setVerifyState(result);
         setScreen('verify');
       } catch (err: any) {
         onError('Sign in Error', err);
       }
     },
-    [onError, setExchangeParameters, setScreen, setSubdomain]
+    [onError, setScreen, setSnapshot, setSubdomain]
   );
 
   if (screen === 'welcome' && !hasProjectId) {
@@ -71,16 +130,17 @@ export const Authentication = ({
   }
 
   if (screen === 'verify') {
-    if (!exchangeParameters) {
-      throw new Error('Expected to have a `exchangeParameters` if at `verify` step');
-    }
+    if (!verifyState) return null;
     return (
       <Verify
         onBack={() => setScreen('signin')}
         hasProjectId={hasProjectId}
         setAccessToken={setAccessToken}
         setCreatedProjectId={setCreatedProjectId}
-        exchangeParameters={exchangeParameters}
+        driver={driverRef.current!}
+        affordance={verifyState.affordance}
+        snapshot={snapshot}
+        tokenPromise={verifyState.token}
       />
     );
   }

--- a/src/screens/Authentication/Verify.test.tsx
+++ b/src/screens/Authentication/Verify.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { DriverSnapshot, SignInAffordance, SignInDriver } from '../../utils/signInDriver';
+
+// ---- hoisted mocks ----
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  errorNotification: vi.fn(),
+}));
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    useRef: (initial: unknown) => ({ current: initial }),
+    useCallback: (fn: unknown) => fn,
+    useEffect: (fn: () => (() => void) | void) => {
+      fn();
+    },
+  };
+});
+
+vi.mock('urql', () => ({
+  useClient: () => ({ query: mocks.query }),
+}));
+
+vi.mock('../../utils/useChromaticDialog', () => ({
+  useChromaticDialog: () => [vi.fn(), vi.fn()] as const,
+}));
+
+vi.mock('../../utils/useErrorNotification', () => ({
+  useErrorNotification: () => mocks.errorNotification,
+}));
+
+vi.mock('../../utils/graphQLClient', () => ({
+  getFetchOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../components/Button', () => ({
+  Button: ({ children, onClick }: { children: React.ReactNode; onClick: () => void }) =>
+    React.createElement('button', { onClick }, children),
+}));
+vi.mock('../../components/Container', () => ({
+  Container: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+}));
+vi.mock('../../components/Heading', () => ({
+  Heading: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('h1', null, children),
+}));
+vi.mock('../../components/Screen', () => ({
+  Screen: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+}));
+vi.mock('../../components/Stack', () => ({
+  Stack: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+}));
+vi.mock('../../components/Text', () => ({
+  Text: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('span', null, children),
+}));
+vi.mock('./AuthHeader', () => ({
+  AuthHeader: () => null,
+}));
+
+vi.mock('../../gql', () => ({
+  graphql: (..._args: unknown[]) => 'VisualTestsProjectCountQuery',
+}));
+
+vi.mock('storybook/theming', () => ({
+  styled: new Proxy(() => () => 'styled-element', {
+    get: () => () => 'styled-element',
+  }) as any,
+}));
+
+const { Verify } = await import('./Verify');
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const baseDriver: SignInDriver = {
+  flow: 'device-code',
+  start: vi.fn(),
+  cancel: vi.fn(),
+};
+
+function invokeVerify(props: Partial<Parameters<typeof Verify>[0]> = {}) {
+  const setAccessToken = vi.fn();
+  const setCreatedProjectId = vi.fn();
+  const onBack = vi.fn();
+  const tokenPromise: Promise<string> = props.tokenPromise ?? new Promise(() => {});
+  // Attach a noop catch so unfulfilled rejection doesn't surface as unhandled
+  tokenPromise.catch(() => {});
+
+  const merged = {
+    onBack,
+    hasProjectId: false,
+    setAccessToken,
+    setCreatedProjectId,
+    driver: baseDriver,
+    affordance: undefined as SignInAffordance | undefined,
+    snapshot: null as DriverSnapshot | null,
+    tokenPromise,
+    ...props,
+  };
+  // Call as plain function so mocked hooks fire synchronously.
+  const tree = (Verify as any)(merged);
+  return { tree, setAccessToken, setCreatedProjectId, onBack };
+}
+
+describe('Verify', () => {
+  it('renders Digits when affordance is provided (device-code)', () => {
+    const { tree } = invokeVerify({
+      affordance: { userCode: 'ABC123', verificationUrl: 'https://example.com' },
+    });
+    const treeStr = JSON.stringify(tree);
+    for (const ch of 'ABC123') {
+      expect(treeStr).toContain(`"type":"li","key":"${'ABC123'.indexOf(ch)}-${ch}"`);
+    }
+  });
+
+  it('does NOT render Digits when affordance is undefined (auth-code)', () => {
+    const { tree } = invokeVerify({
+      affordance: undefined,
+      snapshot: {
+        flow: 'authorization-code',
+        params: {
+          clientId: 'c',
+          redirectUri: 'https://r.example/iframe.html',
+          codeVerifier: 'v',
+          state: 's',
+          authorizationUrl: 'https://a.example/authorize',
+          tokenEndpoint: 'https://a.example/token',
+        },
+      },
+    });
+    const treeStr = JSON.stringify(tree);
+    // No userCode characters split into li elements — auth-code path has no digits.
+    expect(treeStr).not.toMatch(/"li"/);
+  });
+
+  it('awaits tokenPromise and calls setAccessToken on success', async () => {
+    mocks.query.mockResolvedValueOnce({
+      data: { viewer: { projectCount: 1, accounts: [{ newProjectUrl: null }] } },
+    });
+    const { setAccessToken } = invokeVerify({
+      affordance: { userCode: 'X', verificationUrl: 'https://example.com' },
+      tokenPromise: Promise.resolve('access-token-1'),
+    });
+    await flush();
+    await flush();
+    expect(setAccessToken).toHaveBeenCalledWith('access-token-1');
+  });
+
+  it('calls onError("Login Error", ...) when tokenPromise rejects', async () => {
+    const failing = Promise.reject(new Error('boom'));
+    failing.catch(() => {});
+    invokeVerify({
+      affordance: { userCode: 'X', verificationUrl: 'https://example.com' },
+      tokenPromise: failing,
+    });
+    await flush();
+    await flush();
+    expect(mocks.errorNotification).toHaveBeenCalled();
+    const [label, err] = mocks.errorNotification.mock.calls[0];
+    expect(label).toBe('Login Error');
+    expect((err as Error).message).toBe('boom');
+  });
+});

--- a/src/screens/Authentication/Verify.tsx
+++ b/src/screens/Authentication/Verify.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { styled } from 'storybook/theming';
 import { useClient } from 'urql';
 
 import { Button } from '../../components/Button';
@@ -9,12 +10,31 @@ import { Stack } from '../../components/Stack';
 import { Text } from '../../components/Text';
 import { graphql } from '../../gql';
 import type { Project } from '../../gql/graphql';
+import type { AuthCodeDriver } from '../../utils/authCodeDriver';
 import { getFetchOptions } from '../../utils/graphQLClient';
-import { exchangeOAuthCode, parseGrantPayload } from '../../utils/oauthGrant';
-import type { TokenExchangeParameters } from '../../utils/requestAccessToken';
+import type { DriverSnapshot, SignInAffordance, SignInDriver } from '../../utils/signInDriver';
 import { type DialogHandler, useChromaticDialog } from '../../utils/useChromaticDialog';
 import { useErrorNotification } from '../../utils/useErrorNotification';
 import { AuthHeader } from './AuthHeader';
+
+const Digits = styled.ol(({ theme }) => ({
+  display: 'inline-flex',
+  listStyle: 'none',
+  marginTop: 15,
+  marginBottom: 5,
+  padding: 0,
+  gap: 5,
+
+  'li:not(:empty)': {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: `1px dashed ${theme.input.border}`,
+    borderRadius: 4,
+    width: 28,
+    height: 32,
+  },
+}));
 
 const ProjectCountQuery = graphql(/* GraphQL */ `
   query VisualTestsProjectCountQuery {
@@ -32,7 +52,10 @@ interface VerifyProps {
   hasProjectId: boolean;
   setAccessToken: (token: string) => void;
   setCreatedProjectId: (projectId: Project['id']) => void;
-  exchangeParameters: TokenExchangeParameters;
+  driver: SignInDriver;
+  affordance?: SignInAffordance;
+  snapshot: DriverSnapshot | null;
+  tokenPromise: Promise<string>;
 }
 
 export const Verify = ({
@@ -40,67 +63,36 @@ export const Verify = ({
   hasProjectId,
   setAccessToken,
   setCreatedProjectId,
-  exchangeParameters,
+  driver,
+  affordance,
+  snapshot,
+  tokenPromise,
 }: VerifyProps) => {
   const client = useClient();
   const onError = useErrorNotification();
 
-  const { authorizationUrl, state, clientId, codeVerifier, redirectUri, tokenEndpoint } =
-    exchangeParameters;
-  const redirectOrigin = new URL(redirectUri).origin;
+  const authCodeParams =
+    snapshot && snapshot.flow === 'authorization-code' ? snapshot.params : null;
+  const authorizationUrl = authCodeParams?.authorizationUrl;
+  const redirectOrigin = authCodeParams ? new URL(authCodeParams.redirectUri).origin : null;
 
-  // Store the access token until we are ready to pass it to `setAccessToken` (at which point
-  // the Panel will close the Authentication screen)
   const accessToken = useRef<string>();
-
   const openDialogRef = useRef<(url: string, additionalOrigins?: string[]) => void>();
   const closeDialogRef = useRef<() => void>();
+
   const handler = useCallback<DialogHandler>(
     async (event) => {
-      // If the user logs in as part of the grant process, don't close the dialog,
-      // instead redirect us back to where we were trying to go.
-      if (event.message === 'login') {
+      // Auth-code path: forward dialog events to the driver. The driver parses
+      // the grant payload and resolves/rejects its internal token promise; the
+      // useEffect below awaits that promise to complete the sign-in.
+      if (event.message === 'login' && authorizationUrl && redirectOrigin) {
         openDialogRef.current?.(authorizationUrl, [redirectOrigin]);
+        return;
       }
-
       if (event.message === 'grant') {
-        try {
-          const outcome = parseGrantPayload(event, state);
-          if (outcome.kind === 'ignore') return;
-          if (outcome.kind === 'error') throw new Error(outcome.message);
-          if (outcome.kind === 'login') return;
-
-          const token = await exchangeOAuthCode(
-            { clientId, codeVerifier, redirectUri, tokenEndpoint },
-            outcome.code
-          );
-          accessToken.current = token;
-
-          // Override token for this query but don't store it yet until they've created a project
-          const fetchOptions = getFetchOptions(token);
-          const { data } = await client.query(ProjectCountQuery, {}, { fetchOptions });
-
-          if (!data?.viewer) throw new Error('Failed to fetch initial project list');
-
-          // The user has projects to choose from (or the project is already selected),
-          // so send them to pick one
-          if (data.viewer.projectCount > 0 || hasProjectId) {
-            setAccessToken(accessToken.current);
-            closeDialogRef.current?.();
-          } else {
-            // The user has no projects, so we need to get them to create one, then close the dialog
-            if (!data.viewer.accounts[0]) throw new Error('User has no accounts!');
-            if (!data.viewer.accounts[0].newProjectUrl) {
-              throw new Error('Unexpected missing project URL');
-            }
-
-            openDialogRef.current?.(data.viewer.accounts[0].newProjectUrl);
-          }
-        } catch (err) {
-          onError('Login Error', err);
-        }
+        await (driver as AuthCodeDriver).handleDialogEvent?.(event);
+        return;
       }
-
       if (event.message === 'createdProject') {
         if (!accessToken.current) {
           onError('Unexpected missing access token', new Error());
@@ -111,24 +103,52 @@ export const Verify = ({
         }
       }
     },
-    [
-      authorizationUrl,
-      redirectOrigin,
-      state,
-      clientId,
-      codeVerifier,
-      redirectUri,
-      tokenEndpoint,
-      client,
-      hasProjectId,
-      setAccessToken,
-      onError,
-      setCreatedProjectId,
-    ]
+    [authorizationUrl, redirectOrigin, driver, onError, setAccessToken, setCreatedProjectId]
   );
   const [openDialog, closeDialog] = useChromaticDialog(handler);
   openDialogRef.current = openDialog;
   closeDialogRef.current = closeDialog;
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await tokenPromise;
+        if (cancelled) return;
+        accessToken.current = token;
+
+        const fetchOptions = getFetchOptions(token);
+        const { data } = await client.query(ProjectCountQuery, {}, { fetchOptions });
+        if (cancelled) return;
+
+        if (!data?.viewer) throw new Error('Failed to fetch initial project list');
+
+        if (data.viewer.projectCount > 0 || hasProjectId) {
+          setAccessToken(token);
+          closeDialogRef.current?.();
+        } else {
+          if (!data.viewer.accounts[0]) throw new Error('User has no accounts!');
+          if (!data.viewer.accounts[0].newProjectUrl) {
+            throw new Error('Unexpected missing project URL');
+          }
+          openDialogRef.current?.(data.viewer.accounts[0].newProjectUrl);
+        }
+      } catch (err) {
+        if (!cancelled) onError('Login Error', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tokenPromise, client, hasProjectId, setAccessToken, onError]);
+
+  const handleGoToChromatic = () => {
+    if (affordance) {
+      window.open(affordance.verificationUrl, '_blank');
+    } else if (authorizationUrl && redirectOrigin) {
+      openDialog(authorizationUrl, [redirectOrigin]);
+    }
+  };
 
   return (
     <Screen footer={null} ignoreConfig>
@@ -139,16 +159,20 @@ export const Verify = ({
             <Heading>Verify your account</Heading>
             <div>
               <Text center muted>
-                Continue in Chromatic to approve access to your published Storybooks.
+                {affordance
+                  ? 'Check this verification code on Chromatic to grant access to your published Storybooks.'
+                  : 'Continue in Chromatic to approve access to your published Storybooks.'}
               </Text>
             </div>
+            {affordance ? (
+              <Digits>
+                {affordance.userCode.split('').map((char: string, index: number) => (
+                  <li key={`${index}-${char}`}>{char.replace(/[^A-Z0-9]/, '')}</li>
+                ))}
+              </Digits>
+            ) : null}
           </div>
-          <Button
-            ariaLabel={false}
-            variant="solid"
-            size="medium"
-            onClick={() => openDialog(authorizationUrl, [redirectOrigin])}
-          >
+          <Button ariaLabel={false} variant="solid" size="medium" onClick={handleGoToChromatic}>
             Go to Chromatic
           </Button>
         </Stack>

--- a/src/screens/ShareSection/ShareSection.stories.tsx
+++ b/src/screens/ShareSection/ShareSection.stories.tsx
@@ -8,6 +8,7 @@ import { ShareSectionError } from './ShareSectionError';
 import { ShareSectionIdle } from './ShareSectionIdle';
 import { ShareSectionSubdomain } from './ShareSectionSubdomain';
 import { ShareSectionUploading } from './ShareSectionUploading';
+import { ShareSectionVerifying } from './ShareSectionVerifying';
 import { ShareSectionWelcome } from './ShareSectionWelcome';
 
 // --- Welcome ---
@@ -48,6 +49,22 @@ export const Subdomain: SubdomainStory = {
   args: {
     onSubmit: fn().mockName('onSubmit'),
     onBack: fn().mockName('onBack'),
+  },
+};
+
+// --- Verifying (device-code 6-digit screen) ---
+
+type VerifyingStory = StoryObj<typeof ShareSectionVerifying>;
+
+export const Verifying: VerifyingStory = {
+  render: (args) => <ShareSectionVerifying {...args} />,
+  args: {
+    userCode: 'AB12CD',
+    onGoToChromatic: fn().mockName('onGoToChromatic'),
+    onBack: fn().mockName('onBack'),
+  },
+  parameters: {
+    chromatic: { ignoreSelectors: ['ol'] },
   },
 };
 
@@ -120,6 +137,22 @@ export const ErrorUnknown: ErrorStory = {
   render: (args) => <ShareSectionError {...args} />,
   args: {
     reason: 'unknown',
+    onRetry: fn().mockName('onRetry'),
+  },
+};
+
+export const ErrorVerificationCancelled: ErrorStory = {
+  render: (args) => <ShareSectionError {...args} />,
+  args: {
+    reason: 'cancelled',
+    onRetry: fn().mockName('onRetry'),
+  },
+};
+
+export const ErrorVerificationExpired: ErrorStory = {
+  render: (args) => <ShareSectionError {...args} />,
+  args: {
+    reason: 'expired',
     onRetry: fn().mockName('onRetry'),
   },
 };

--- a/src/screens/ShareSection/ShareSection.test.tsx
+++ b/src/screens/ShareSection/ShareSection.test.tsx
@@ -66,6 +66,7 @@ vi.mock('./popoverPresence', () => ({
 vi.mock('./ShareSectionWelcome', () => ({ ShareSectionWelcome: vi.fn() }));
 vi.mock('./ShareSectionIdle', () => ({ ShareSectionIdle: vi.fn() }));
 vi.mock('./ShareSectionSubdomain', () => ({ ShareSectionSubdomain: vi.fn() }));
+vi.mock('./ShareSectionVerifying', () => ({ ShareSectionVerifying: vi.fn() }));
 vi.mock('./ShareSectionUploading', () => ({ ShareSectionUploading: vi.fn() }));
 vi.mock('./ShareSectionComplete', () => ({ ShareSectionComplete: vi.fn() }));
 vi.mock('./ShareSectionError', () => ({ ShareSectionError: vi.fn() }));
@@ -284,14 +285,14 @@ describe('ShareSection', () => {
   });
 
   describe('welcome auto-skip when authenticated', () => {
-    it('dispatches AUTO_SKIP_TO_UPLOADING when token is present and welcome', () => {
+    it('dispatches START_UPLOAD when token is present and welcome', () => {
       setReducer({ screen: { status: 'welcome' } });
       shareProgressValue = undefined;
 
       invokeShareSection();
 
       const autoSkipDispatches = mocks.dispatch.mock.calls.filter(
-        ([action]) => action?.type === 'AUTO_SKIP_TO_UPLOADING'
+        ([action]) => action?.type === 'START_UPLOAD'
       );
       expect(autoSkipDispatches.length).toBeGreaterThanOrEqual(1);
     });
@@ -307,7 +308,7 @@ describe('ShareSection', () => {
       invokeShareSection();
 
       const autoSkipDispatches = mocks.dispatch.mock.calls.filter(
-        ([action]) => action?.type === 'AUTO_SKIP_TO_UPLOADING'
+        ([action]) => action?.type === 'START_UPLOAD'
       );
       expect(autoSkipDispatches).toHaveLength(0);
     });

--- a/src/screens/ShareSection/ShareSection.tsx
+++ b/src/screens/ShareSection/ShareSection.tsx
@@ -8,143 +8,16 @@ import { useAccessToken } from '../../utils/graphQLClient';
 import { useSessionState } from '../../utils/useSessionState';
 import { useSharedState } from '../../utils/useSharedState';
 import { setPresent } from './popoverPresence';
+import { applyProgress, initialShareState, shareReducer } from './shareReducer';
 import { ShareSectionComplete } from './ShareSectionComplete';
 import { ShareSectionError } from './ShareSectionError';
 import { ShareSectionIdle } from './ShareSectionIdle';
 import { ShareSectionSubdomain } from './ShareSectionSubdomain';
 import { ShareSectionUploading } from './ShareSectionUploading';
+import { ShareSectionVerifying } from './ShareSectionVerifying';
 import { ShareSectionWelcome } from './ShareSectionWelcome';
-import type { ProgressEffect, ShareAction, ShareReducerState, ShareState } from './types';
+import type { ShareReducerState } from './types';
 import { useShareAuth } from './useShareAuth';
-
-const initialState: ShareReducerState = {
-  screen: { status: 'welcome' },
-  shareRequestId: null,
-  shareTriggeredId: null,
-};
-
-function applyProgress(
-  state: ShareReducerState,
-  progress: ShareProgress,
-  gitInfo: GitInfoPayload | undefined,
-  lastCompletedShareUrl: string | null
-): { next: ShareReducerState; effect: ProgressEffect } {
-  if (progress.shareRequestId !== state.shareRequestId) {
-    return { next: state, effect: { kind: 'none' } };
-  }
-
-  if (
-    progress.status === 'uploading' &&
-    progress.shareUrl &&
-    state.screen.status === 'uploading' &&
-    progress.shareUrl !== state.screen.shareUrl
-  ) {
-    return {
-      next: { ...state, screen: { status: 'uploading', shareUrl: progress.shareUrl } },
-      effect: { kind: 'url-received' },
-    };
-  }
-
-  if (progress.status === 'complete') {
-    const { shareUrl } = progress;
-    return {
-      next: {
-        ...state,
-        screen: { status: 'complete', shareUrl, publishedAt: Date.now() },
-        shareRequestId: null,
-        shareTriggeredId: null,
-      },
-      effect: {
-        kind: 'completed',
-        shareUrl,
-        gitInfo,
-        isNew: shareUrl !== lastCompletedShareUrl,
-      },
-    };
-  }
-
-  if (progress.status === 'error') {
-    if (progress.canceled) {
-      return {
-        next: {
-          ...state,
-          screen: { status: 'error', reason: 'upload-canceled' },
-          shareRequestId: null,
-          shareTriggeredId: null,
-        },
-        effect: { kind: 'failed' },
-      };
-    }
-    const isAuthError = /\b(401|403|unauthorized|expired)\b/i.test(progress.error);
-    if (isAuthError) {
-      return {
-        next: {
-          ...state,
-          screen: { status: 'idle' },
-          shareRequestId: null,
-          shareTriggeredId: null,
-        },
-        effect: { kind: 'auth-error' },
-      };
-    }
-    return {
-      next: {
-        ...state,
-        screen: { status: 'error', reason: 'unknown', message: progress.error || undefined },
-        shareRequestId: null,
-        shareTriggeredId: null,
-      },
-      effect: { kind: 'failed' },
-    };
-  }
-
-  return { next: state, effect: { kind: 'none' } };
-}
-
-function shareReducer(state: ShareReducerState, action: ShareAction): ShareReducerState {
-  switch (action.type) {
-    case 'SET_SCREEN':
-      return { ...state, screen: action.screen };
-    case 'PUBLISH_REQUESTED':
-      if (action.hasToken) {
-        return {
-          ...state,
-          screen: { status: 'uploading', shareUrl: '' },
-          shareRequestId: action.newRequestId,
-          shareTriggeredId: null,
-        };
-      }
-      return { ...state, screen: { status: 'idle' } };
-    case 'PUBLISH_AGAIN':
-      return {
-        ...state,
-        screen: { status: 'uploading', shareUrl: '' },
-        shareRequestId: action.newRequestId,
-        shareTriggeredId: null,
-      };
-    case 'GO_SUBDOMAIN':
-      return { ...state, screen: { status: 'subdomain' } };
-    case 'BACK_TO_IDLE':
-      return { ...state, screen: { status: 'idle' } };
-    case 'AUTO_SKIP_TO_UPLOADING':
-      return {
-        ...state,
-        screen: { status: 'uploading', shareUrl: '' },
-        shareRequestId: action.newRequestId,
-        shareTriggeredId: null,
-      };
-    case 'START_SHARE_EMITTED':
-      return {
-        ...state,
-        shareRequestId: action.id,
-        shareTriggeredId: action.id,
-      };
-    case 'APPLY_STATE':
-      return action.next;
-    default:
-      return state;
-  }
-}
 
 export const ShareSection = ({ api }: { api: API }) => {
   const [token] = useAccessToken();
@@ -153,7 +26,7 @@ export const ShareSection = ({ api }: { api: API }) => {
 
   const [persisted, setPersisted] = useSessionState<ShareReducerState>(
     'shareReducer',
-    initialState
+    initialShareState
   );
   const [reducerState, dispatch] = useReducer(shareReducer, persisted);
 
@@ -188,11 +61,7 @@ export const ShareSection = ({ api }: { api: API }) => {
   const sharedUploadInFlight =
     shareProgress?.status === 'pending' || shareProgress?.status === 'uploading';
 
-  const setShareScreen = useCallback(
-    (screen: ShareState) => dispatch({ type: 'SET_SCREEN', screen }),
-    []
-  );
-  const { startSignIn, updateToken } = useShareAuth(setShareScreen);
+  const { startSignIn, updateToken } = useShareAuth(dispatch);
 
   // Auto-skip welcome/idle/subdomain if already signed in and no active share.
   useEffect(() => {
@@ -201,16 +70,16 @@ export const ShareSection = ({ api }: { api: API }) => {
       reducerState.screen.status === 'idle' ||
       reducerState.screen.status === 'subdomain';
     if (token && skippableStatus && !sharedUploadInFlight) {
-      dispatch({ type: 'AUTO_SKIP_TO_UPLOADING', newRequestId: crypto.randomUUID() });
+      dispatch({ type: 'START_UPLOAD', newRequestId: crypto.randomUUID() });
     }
   }, [token, reducerState.screen.status, sharedUploadInFlight]);
 
   const handlePublish = useCallback(() => {
-    dispatch({
-      type: 'PUBLISH_REQUESTED',
-      hasToken: Boolean(token),
-      newRequestId: crypto.randomUUID(),
-    });
+    if (!token) {
+      dispatch({ type: 'BACK_TO_IDLE' });
+      return;
+    }
+    dispatch({ type: 'START_UPLOAD', newRequestId: crypto.randomUUID() });
   }, [token]);
 
   const handleCancel = useCallback(() => {
@@ -244,9 +113,12 @@ export const ShareSection = ({ api }: { api: API }) => {
     token,
   ]);
 
-  // Telemetry: detect idle -> uploading transition (auth completed).
+  // Telemetry: detect idle -> uploading or verifying -> uploading transition (auth completed).
   useEffect(() => {
-    if (prevShareStatusRef.current === 'idle' && reducerState.screen.status === 'uploading') {
+    if (
+      (prevShareStatusRef.current === 'idle' || prevShareStatusRef.current === 'verifying') &&
+      reducerState.screen.status === 'uploading'
+    ) {
       emitTelemetry('share-auth-completed');
     }
     prevShareStatusRef.current = reducerState.screen.status;
@@ -305,6 +177,14 @@ export const ShareSection = ({ api }: { api: API }) => {
           onBack={() => dispatch({ type: 'BACK_TO_IDLE' })}
         />
       );
+    case 'verifying':
+      return (
+        <ShareSectionVerifying
+          userCode={screen.userCode}
+          onGoToChromatic={() => window.open(screen.verificationUrl, '_blank')}
+          onBack={() => dispatch({ type: 'BACK_TO_IDLE' })}
+        />
+      );
     case 'uploading':
       return (
         <ShareSectionUploading
@@ -323,7 +203,7 @@ export const ShareSection = ({ api }: { api: API }) => {
           onCopy={() => emitTelemetry('share-url-copied')}
           onPublishAgain={() => {
             isRepeatShareRef.current = true;
-            dispatch({ type: 'PUBLISH_AGAIN', newRequestId: crypto.randomUUID() });
+            dispatch({ type: 'START_UPLOAD', newRequestId: crypto.randomUUID() });
           }}
         />
       );

--- a/src/screens/ShareSection/ShareSectionError.tsx
+++ b/src/screens/ShareSection/ShareSectionError.tsx
@@ -29,13 +29,15 @@ const ErrorMessage = styled.span(({ theme }) => ({
 }));
 
 interface ShareSectionErrorProps {
-  reason: 'upload-canceled' | 'unknown';
+  reason: 'upload-canceled' | 'cancelled' | 'expired' | 'unknown';
   message?: string;
   onRetry: () => void;
 }
 
 const reasonMessages: Record<ShareSectionErrorProps['reason'], string> = {
   'upload-canceled': 'Upload canceled',
+  cancelled: 'Sign-in canceled. Try again.',
+  expired: 'Verification code expired. Try again.',
   unknown: 'An unexpected error occurred. Please try again.',
 };
 

--- a/src/screens/ShareSection/ShareSectionPrimitives.tsx
+++ b/src/screens/ShareSection/ShareSectionPrimitives.tsx
@@ -51,6 +51,12 @@ export const ButtonStack = styled.div({
   gap: 8,
 });
 
+export const ButtonRow = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+});
+
 export const StatusRow = styled.div(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',

--- a/src/screens/ShareSection/ShareSectionVerifying.tsx
+++ b/src/screens/ShareSection/ShareSectionVerifying.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { styled } from 'storybook/theming';
+
+import { Button } from '../../components/Button';
+import {
+  ButtonRow,
+  ButtonStack,
+  ShareContainer,
+  ShareDescription,
+  ShareTextLink,
+  ShareTitle,
+  StatusRow,
+  TextBlock,
+} from './ShareSectionPrimitives';
+
+const Digits = styled.ol(({ theme }) => ({
+  display: 'inline-flex',
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  gap: 5,
+
+  'li:not(:empty)': {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: `1px dashed ${theme.input.border}`,
+    borderRadius: 4,
+    width: 28,
+    height: 32,
+    fontWeight: 'bold' as const,
+    fontSize: 14,
+  },
+}));
+
+const PulsingDot = styled.div(({ theme }) => ({
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  backgroundColor: theme.color.positive,
+  animation: 'pulse 1.5s ease-in-out infinite',
+  '@keyframes pulse': {
+    '0%, 100%': { opacity: 1 },
+    '50%': { opacity: 0.4 },
+  },
+}));
+
+interface ShareSectionVerifyingProps {
+  userCode: string;
+  onGoToChromatic: () => void;
+  onBack: () => void;
+}
+
+export const ShareSectionVerifying = ({
+  userCode,
+  onGoToChromatic,
+  onBack,
+}: ShareSectionVerifyingProps) => (
+  <ShareContainer>
+    <TextBlock>
+      <ShareTitle>Verify your account</ShareTitle>
+      <ShareDescription>
+        Enter this verification code on Chromatic to grant access to your published Storybooks.
+      </ShareDescription>
+    </TextBlock>
+    <Digits>
+      {userCode.split('').map((char, index) => (
+        <li key={`${index}-${char}`}>{char.replace(/[^A-Z0-9]/i, '')}</li>
+      ))}
+    </Digits>
+    <ButtonStack>
+      <ButtonRow>
+        <Button size="medium" variant="solid" onClick={onGoToChromatic}>
+          Go to Chromatic
+        </Button>
+        <StatusRow>
+          <PulsingDot />
+          Waiting for verification...
+        </StatusRow>
+      </ButtonRow>
+      <ShareTextLink onClick={onBack}>Back to sign in</ShareTextLink>
+    </ButtonStack>
+  </ShareContainer>
+);

--- a/src/screens/ShareSection/shareReducer.test.ts
+++ b/src/screens/ShareSection/shareReducer.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyProgress, initialShareState, shareReducer } from './shareReducer';
+import type { ShareReducerState } from './types';
+
+describe('shareReducer', () => {
+  it('VERIFICATION_STARTED transitions to verifying with userCode/verificationUrl', () => {
+    const next = shareReducer(initialShareState, {
+      type: 'VERIFICATION_STARTED',
+      userCode: 'AB12CD',
+      verificationUrl: 'https://chromatic.com/verify?code=AB12CD',
+    });
+
+    expect(next.screen).toEqual({
+      status: 'verifying',
+      userCode: 'AB12CD',
+      verificationUrl: 'https://chromatic.com/verify?code=AB12CD',
+    });
+    expect(next.shareRequestId).toBeNull();
+    expect(next.shareTriggeredId).toBeNull();
+  });
+
+  it('START_UPLOAD transitions to uploading with fresh shareRequestId', () => {
+    const verifying: ShareReducerState = {
+      screen: { status: 'verifying', userCode: 'AB12CD', verificationUrl: 'https://x' },
+      shareRequestId: null,
+      shareTriggeredId: null,
+    };
+    const next = shareReducer(verifying, {
+      type: 'START_UPLOAD',
+      newRequestId: 'req-new',
+    });
+
+    expect(next.screen).toEqual({ status: 'uploading', shareUrl: '' });
+    expect(next.shareRequestId).toBe('req-new');
+    expect(next.shareTriggeredId).toBeNull();
+  });
+
+  it('VERIFICATION_FAILED transitions to error with reason', () => {
+    const verifying: ShareReducerState = {
+      screen: { status: 'verifying', userCode: 'AB12CD', verificationUrl: 'https://x' },
+      shareRequestId: null,
+      shareTriggeredId: null,
+    };
+    const next = shareReducer(verifying, { type: 'VERIFICATION_FAILED', reason: 'expired' });
+
+    expect(next.screen).toEqual({ status: 'error', reason: 'expired' });
+    expect(next.shareRequestId).toBeNull();
+    expect(next.shareTriggeredId).toBeNull();
+  });
+});
+
+describe('applyProgress', () => {
+  it('ignores progress for a different request id', () => {
+    const uploading: ShareReducerState = {
+      screen: { status: 'uploading', shareUrl: '' },
+      shareRequestId: 'req-1',
+      shareTriggeredId: 'req-1',
+    };
+    const { next, effect } = applyProgress(
+      uploading,
+      { shareRequestId: 'req-2', status: 'uploading', shareUrl: 'https://x' } as any,
+      undefined,
+      null
+    );
+
+    expect(next).toBe(uploading);
+    expect(effect).toEqual({ kind: 'none' });
+  });
+});

--- a/src/screens/ShareSection/shareReducer.ts
+++ b/src/screens/ShareSection/shareReducer.ts
@@ -1,0 +1,130 @@
+import type { GitInfoPayload, ShareProgress } from '../../types';
+import type { ProgressEffect, ShareAction, ShareReducerState } from './types';
+
+export const initialShareState: ShareReducerState = {
+  screen: { status: 'welcome' },
+  shareRequestId: null,
+  shareTriggeredId: null,
+};
+
+export function applyProgress(
+  state: ShareReducerState,
+  progress: ShareProgress,
+  gitInfo: GitInfoPayload | undefined,
+  lastCompletedShareUrl: string | null
+): { next: ShareReducerState; effect: ProgressEffect } {
+  if (progress.shareRequestId !== state.shareRequestId) {
+    return { next: state, effect: { kind: 'none' } };
+  }
+
+  if (
+    progress.status === 'uploading' &&
+    progress.shareUrl &&
+    state.screen.status === 'uploading' &&
+    progress.shareUrl !== state.screen.shareUrl
+  ) {
+    return {
+      next: { ...state, screen: { status: 'uploading', shareUrl: progress.shareUrl } },
+      effect: { kind: 'url-received' },
+    };
+  }
+
+  if (progress.status === 'complete') {
+    const { shareUrl } = progress;
+    return {
+      next: {
+        ...state,
+        screen: { status: 'complete', shareUrl, publishedAt: Date.now() },
+        shareRequestId: null,
+        shareTriggeredId: null,
+      },
+      effect: {
+        kind: 'completed',
+        shareUrl,
+        gitInfo,
+        isNew: shareUrl !== lastCompletedShareUrl,
+      },
+    };
+  }
+
+  if (progress.status === 'error') {
+    if (progress.canceled) {
+      return {
+        next: {
+          ...state,
+          screen: { status: 'error', reason: 'upload-canceled' },
+          shareRequestId: null,
+          shareTriggeredId: null,
+        },
+        effect: { kind: 'failed' },
+      };
+    }
+    const isAuthError = /\b(401|403|unauthorized|expired)\b/i.test(progress.error);
+    if (isAuthError) {
+      return {
+        next: {
+          ...state,
+          screen: { status: 'idle' },
+          shareRequestId: null,
+          shareTriggeredId: null,
+        },
+        effect: { kind: 'auth-error' },
+      };
+    }
+    return {
+      next: {
+        ...state,
+        screen: { status: 'error', reason: 'unknown', message: progress.error || undefined },
+        shareRequestId: null,
+        shareTriggeredId: null,
+      },
+      effect: { kind: 'failed' },
+    };
+  }
+
+  return { next: state, effect: { kind: 'none' } };
+}
+
+export function shareReducer(state: ShareReducerState, action: ShareAction): ShareReducerState {
+  switch (action.type) {
+    case 'START_UPLOAD':
+      return {
+        ...state,
+        screen: { status: 'uploading', shareUrl: '' },
+        shareRequestId: action.newRequestId,
+        shareTriggeredId: null,
+      };
+    case 'GO_SUBDOMAIN':
+      return { ...state, screen: { status: 'subdomain' } };
+    case 'BACK_TO_IDLE':
+      return { ...state, screen: { status: 'idle' } };
+    case 'START_SHARE_EMITTED':
+      return {
+        ...state,
+        shareRequestId: action.id,
+        shareTriggeredId: action.id,
+      };
+    case 'APPLY_STATE':
+      return action.next;
+    case 'VERIFICATION_STARTED':
+      return {
+        ...state,
+        screen: {
+          status: 'verifying',
+          userCode: action.userCode,
+          verificationUrl: action.verificationUrl,
+        },
+        shareRequestId: null,
+        shareTriggeredId: null,
+      };
+    case 'VERIFICATION_FAILED':
+      return {
+        ...state,
+        screen: { status: 'error', reason: action.reason },
+        shareRequestId: null,
+        shareTriggeredId: null,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/screens/ShareSection/types.ts
+++ b/src/screens/ShareSection/types.ts
@@ -2,11 +2,12 @@ export type ShareState =
   | { status: 'welcome' }
   | { status: 'idle' }
   | { status: 'subdomain' }
+  | { status: 'verifying'; userCode: string; verificationUrl: string }
   | { status: 'uploading'; shareUrl: string }
   | { status: 'complete'; shareUrl: string; publishedAt: number }
   | {
       status: 'error';
-      reason: 'upload-canceled' | 'unknown';
+      reason: 'upload-canceled' | 'cancelled' | 'expired' | 'unknown';
       message?: string;
     };
 
@@ -19,14 +20,13 @@ export type ShareReducerState = {
 };
 
 export type ShareAction =
-  | { type: 'SET_SCREEN'; screen: ShareState }
-  | { type: 'PUBLISH_REQUESTED'; hasToken: boolean; newRequestId: string }
-  | { type: 'PUBLISH_AGAIN'; newRequestId: string }
+  | { type: 'START_UPLOAD'; newRequestId: string }
   | { type: 'GO_SUBDOMAIN' }
   | { type: 'BACK_TO_IDLE' }
-  | { type: 'AUTO_SKIP_TO_UPLOADING'; newRequestId: string }
   | { type: 'START_SHARE_EMITTED'; id: string }
-  | { type: 'APPLY_STATE'; next: ShareReducerState };
+  | { type: 'APPLY_STATE'; next: ShareReducerState }
+  | { type: 'VERIFICATION_STARTED'; userCode: string; verificationUrl: string }
+  | { type: 'VERIFICATION_FAILED'; reason: 'cancelled' | 'expired' | 'unknown' };
 
 export type ProgressEffect =
   | { kind: 'none' }

--- a/src/screens/ShareSection/useShareAuth.test.ts
+++ b/src/screens/ShareSection/useShareAuth.test.ts
@@ -1,16 +1,19 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// We test useShareAuth by calling it as a plain function (no DOM render needed)
-// because all hooks it depends on are mocked synchronously.
+import type { DriverSnapshot, SignInDriver } from '../../utils/signInDriver';
+
+// We test useShareAuth by invoking it as a plain function with mocked react primitives.
 
 const mocks = vi.hoisted(() => {
   const openDialog = vi.fn();
   const closeDialog = vi.fn();
   const updateToken = vi.fn();
-  const exchangeOAuthCode = vi.fn();
-  const initiateSignin = vi.fn();
-  return { openDialog, closeDialog, updateToken, exchangeOAuthCode, initiateSignin };
+  const createSignInDriver = vi.fn();
+  const setSnapshot = vi.fn();
+  return { openDialog, closeDialog, updateToken, createSignInDriver, setSnapshot };
 });
+
+const effects: Array<() => void | (() => void)> = [];
 
 vi.mock('react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react')>();
@@ -18,6 +21,9 @@ vi.mock('react', async (importOriginal) => {
     ...actual,
     useRef: (initial: unknown) => ({ current: initial }),
     useCallback: (fn: unknown) => fn,
+    useEffect: (fn: () => void | (() => void)) => {
+      effects.push(fn);
+    },
   };
 });
 
@@ -25,171 +31,275 @@ vi.mock('../../utils/graphQLClient', () => ({
   useAccessToken: () => [null, mocks.updateToken],
 }));
 
-vi.mock('../../utils/oauthGrant', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../utils/oauthGrant')>();
-  return { ...actual, exchangeOAuthCode: mocks.exchangeOAuthCode };
-});
-
-vi.mock('../../utils/requestAccessToken', () => ({
-  initiateSignin: mocks.initiateSignin,
+let snapshotValue: DriverSnapshot | null = null;
+vi.mock('../../utils/useSessionState', () => ({
+  useSessionState: () => [snapshotValue, mocks.setSnapshot] as const,
 }));
 
-// Capture the handler registered with useChromaticDialog
-let capturedHandler: ((event: any) => Promise<void>) | undefined;
+let capturedDialogHandler: ((event: any) => Promise<void>) | undefined;
 vi.mock('../../utils/useChromaticDialog', () => ({
   useChromaticDialog: (handler: (event: any) => Promise<void>) => {
-    capturedHandler = handler;
+    capturedDialogHandler = handler;
     return [mocks.openDialog, mocks.closeDialog] as const;
   },
 }));
 
+vi.mock('../../utils/signInDriver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/signInDriver')>();
+  return { ...actual, createSignInDriver: mocks.createSignInDriver };
+});
+
 const { useShareAuth } = await import('./useShareAuth');
 
-const defaultParams = {
-  clientId: 'client-id',
-  redirectUri: 'https://example.com/redirect',
-  codeVerifier: 'verifier',
-  state: 'state-abc',
-  authorizationUrl: 'https://chromatic.com/authorize',
-  tokenEndpoint: 'https://chromatic.com/token',
+const flushEffects = () => {
+  while (effects.length) {
+    const fn = effects.shift()!;
+    fn();
+  }
 };
+
+const flushMicrotasks = async () => {
+  // allow promise microtasks to drain
+  for (let i = 0; i < 5; i += 1) await Promise.resolve();
+};
+
+const makeDeviceCodeDriver = () => {
+  let resolveToken!: (token: string) => void;
+  let rejectToken!: (err: unknown) => void;
+  const tokenPromise = new Promise<string>((resolve, reject) => {
+    resolveToken = resolve;
+    rejectToken = reject;
+  });
+  // Avoid unhandled rejection
+  tokenPromise.catch(() => {});
+
+  const driver: SignInDriver = {
+    flow: 'device-code',
+    start: vi.fn(async (opts) => {
+      opts.dispatch?.({
+        type: 'VERIFICATION_STARTED',
+        userCode: 'AB12CD',
+        verificationUrl: 'https://chromatic.com/verify',
+      });
+      opts.onSnapshot?.({
+        flow: 'device-code',
+        deviceCode: 'd',
+        verifier: 'v',
+        expires: Date.now() + 60_000,
+        interval: 1000,
+        userCode: 'AB12CD',
+        verificationUrl: 'https://chromatic.com/verify',
+        tokenEndpoint: 'https://chromatic.com/token',
+      });
+      return {
+        affordance: { userCode: 'AB12CD', verificationUrl: 'https://chromatic.com/verify' },
+        token: tokenPromise,
+      };
+    }),
+    resume: vi.fn(async () => ({ token: tokenPromise })),
+    cancel: vi.fn(),
+  };
+
+  return { driver, resolveToken, rejectToken };
+};
+
+const makeAuthCodeDriver = () => {
+  let resolveToken!: (token: string) => void;
+  let rejectToken!: (err: unknown) => void;
+  const tokenPromise = new Promise<string>((resolve, reject) => {
+    resolveToken = resolve;
+    rejectToken = reject;
+  });
+  tokenPromise.catch(() => {});
+
+  const driver: SignInDriver & { handleDialogEvent: any } = {
+    flow: 'authorization-code',
+    start: vi.fn(async (opts) => {
+      opts.onSnapshot?.({
+        flow: 'authorization-code',
+        params: {
+          clientId: 'cid',
+          redirectUri: 'https://example.com/redirect',
+          codeVerifier: 'v',
+          state: 'state-abc',
+          authorizationUrl: 'https://chromatic.com/authorize',
+          tokenEndpoint: 'https://chromatic.com/token',
+        },
+      });
+      return { token: tokenPromise };
+    }),
+    cancel: vi.fn(),
+    handleDialogEvent: vi.fn(async () => ({ kind: 'code', code: 'auth' })),
+  };
+
+  return { driver, resolveToken, rejectToken };
+};
+
+beforeEach(() => {
+  effects.length = 0;
+  snapshotValue = null;
+  capturedDialogHandler = undefined;
+});
 
 afterEach(() => {
   vi.clearAllMocks();
-  capturedHandler = undefined;
 });
 
-describe('useShareAuth', () => {
-  it('successful flow: startSignIn opens dialog, grant code triggers fetchAccessToken and updateToken', async () => {
-    const setShareState = vi.fn();
-    mocks.initiateSignin.mockResolvedValueOnce(defaultParams);
-    mocks.exchangeOAuthCode.mockResolvedValueOnce('access-token-xyz');
+describe('useShareAuth (device-code flow)', () => {
+  it('start dispatches VERIFICATION_STARTED then START_UPLOAD on token resolve', async () => {
+    const { driver, resolveToken } = makeDeviceCodeDriver();
+    mocks.createSignInDriver.mockReturnValue(driver);
 
-    const { startSignIn } = useShareAuth(setShareState);
+    const dispatch = vi.fn();
+    const { startSignIn } = useShareAuth(dispatch);
+    flushEffects();
+
     await (startSignIn as () => Promise<void>)();
+    await flushMicrotasks();
 
-    expect(mocks.openDialog).toHaveBeenCalledWith(defaultParams.authorizationUrl, [
-      new URL(defaultParams.redirectUri).origin,
-    ]);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'VERIFICATION_STARTED',
+      userCode: 'AB12CD',
+      verificationUrl: 'https://chromatic.com/verify',
+    });
 
-    await capturedHandler!({ message: 'grant', code: 'auth-code', state: 'state-abc' });
+    resolveToken('access-token-xyz');
+    await flushMicrotasks();
 
-    expect(mocks.exchangeOAuthCode).toHaveBeenCalledOnce();
+    const completed = dispatch.mock.calls.find(([a]) => a.type === 'START_UPLOAD');
+    expect(completed).toBeTruthy();
+    expect(completed![0].newRequestId).toEqual(expect.any(String));
     expect(mocks.updateToken).toHaveBeenCalledWith('access-token-xyz');
-    expect(setShareState).toHaveBeenCalledWith({ status: 'uploading', shareUrl: '' });
   });
 
-  it('duplicate grant: fetchAccessToken called only once (paramsRef cleared pre-await)', async () => {
-    const setShareState = vi.fn();
-    mocks.initiateSignin.mockResolvedValueOnce(defaultParams);
+  it('token rejection dispatches VERIFICATION_FAILED with cancelled reason', async () => {
+    const { driver, rejectToken } = makeDeviceCodeDriver();
+    mocks.createSignInDriver.mockReturnValue(driver);
 
-    let resolveFetch!: (token: string) => void;
-    mocks.exchangeOAuthCode.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveFetch = resolve;
-      })
-    );
+    const dispatch = vi.fn();
+    const { startSignIn } = useShareAuth(dispatch);
+    flushEffects();
 
-    const { startSignIn } = useShareAuth(setShareState);
     await (startSignIn as () => Promise<void>)();
+    await flushMicrotasks();
 
-    // First grant — clears paramsRef, starts fetch
-    const first = capturedHandler!({ message: 'grant', code: 'auth-code', state: 'state-abc' });
-    // Second grant — paramsRef is null now, should short-circuit
-    await capturedHandler!({ message: 'grant', code: 'auth-code', state: 'state-abc' });
+    const abortErr: any = new Error('aborted');
+    abortErr.name = 'AbortError';
+    rejectToken(abortErr);
+    await flushMicrotasks();
 
-    resolveFetch('token');
-    await first;
-
-    expect(mocks.exchangeOAuthCode).toHaveBeenCalledOnce();
+    const failed = dispatch.mock.calls.find(([a]) => a.type === 'VERIFICATION_FAILED');
+    expect(failed).toBeTruthy();
+    expect(failed![0].reason).toBe('cancelled');
   });
 
-  it('error outcome: setShareState reason=unknown, closeDialog called', async () => {
-    const setShareState = vi.fn();
-    mocks.initiateSignin.mockResolvedValueOnce(defaultParams);
+  it('rejects a second concurrent startSignIn', async () => {
+    const { driver } = makeDeviceCodeDriver();
+    mocks.createSignInDriver.mockReturnValue(driver);
 
-    const { startSignIn } = useShareAuth(setShareState);
+    const dispatch = vi.fn();
+    const { startSignIn } = useShareAuth(dispatch);
+    flushEffects();
+
+    await (startSignIn as () => Promise<void>)();
     await (startSignIn as () => Promise<void>)();
 
-    await capturedHandler!({ message: 'grant', error: 'server_error', state: 'state-abc' });
-
-    expect(mocks.closeDialog).toHaveBeenCalledOnce();
-    expect(setShareState).toHaveBeenCalledWith({ status: 'error', reason: 'unknown' });
+    expect(driver.start).toHaveBeenCalledTimes(1);
   });
 
-  it('stale grant: arriving after paramsRef cleared, no state change or error surfaced', async () => {
-    const setShareState = vi.fn();
-    mocks.initiateSignin.mockResolvedValueOnce(defaultParams);
-    mocks.exchangeOAuthCode.mockResolvedValueOnce('token');
+  it('mount with matching device-code snapshot resumes', async () => {
+    const { driver } = makeDeviceCodeDriver();
+    mocks.createSignInDriver.mockReturnValue(driver);
 
-    const { startSignIn } = useShareAuth(setShareState);
-    await (startSignIn as () => Promise<void>)();
+    snapshotValue = {
+      flow: 'device-code',
+      deviceCode: 'd',
+      verifier: 'v',
+      expires: Date.now() + 60_000,
+      interval: 1000,
+      userCode: 'AB12CD',
+      verificationUrl: 'https://chromatic.com/verify',
+      tokenEndpoint: 'https://chromatic.com/token',
+    };
 
-    // Complete the flow — clears paramsRef
-    await capturedHandler!({ message: 'grant', code: 'auth-code', state: 'state-abc' });
-    setShareState.mockClear();
-    mocks.closeDialog.mockClear();
+    const dispatch = vi.fn();
+    useShareAuth(dispatch);
+    flushEffects();
+    await flushMicrotasks();
 
-    // Stale grant arrives after params cleared
-    await capturedHandler!({ message: 'grant', error: 'server_error', state: 'state-abc' });
-
-    expect(setShareState).not.toHaveBeenCalled();
-    expect(mocks.closeDialog).not.toHaveBeenCalled();
+    expect(driver.resume).toHaveBeenCalledTimes(1);
   });
 
-  it('grant with wrong state during active flow: ignored, flow stays in current state', async () => {
-    const setShareState = vi.fn();
-    mocks.initiateSignin.mockResolvedValueOnce(defaultParams);
+  it('mount with mismatched-flow snapshot drops snapshot without resume', async () => {
+    const { driver } = makeDeviceCodeDriver();
+    mocks.createSignInDriver.mockReturnValue(driver);
 
-    const { startSignIn } = useShareAuth(setShareState);
-    await (startSignIn as () => Promise<void>)();
-    setShareState.mockClear();
+    snapshotValue = {
+      flow: 'authorization-code',
+      params: {
+        clientId: 'cid',
+        redirectUri: 'https://example.com/redirect',
+        codeVerifier: 'v',
+        state: 's',
+        authorizationUrl: 'https://chromatic.com/authorize',
+        tokenEndpoint: 'https://chromatic.com/token',
+      },
+    } as DriverSnapshot;
 
-    // Grant with mismatched state — should be ignored
-    await capturedHandler!({ message: 'grant', error: 'server_error', state: 'wrong-state' });
+    const dispatch = vi.fn();
+    useShareAuth(dispatch);
+    flushEffects();
+    await flushMicrotasks();
 
-    expect(setShareState).not.toHaveBeenCalled();
-    expect(mocks.closeDialog).not.toHaveBeenCalled();
-    expect(mocks.exchangeOAuthCode).not.toHaveBeenCalled();
+    expect(driver.resume).not.toHaveBeenCalled();
+    expect(mocks.setSnapshot).toHaveBeenCalledWith(null);
   });
 
-  it('login relay: openDialog called again with authorizationUrl', async () => {
-    const setShareState = vi.fn();
-    mocks.initiateSignin.mockResolvedValueOnce(defaultParams);
+  it('cleanup effect calls driver.cancel on unmount', () => {
+    const { driver } = makeDeviceCodeDriver();
+    mocks.createSignInDriver.mockReturnValue(driver);
 
-    const { startSignIn } = useShareAuth(setShareState);
+    const dispatch = vi.fn();
+    useShareAuth(dispatch);
+
+    // First effect is mount-resume, second is cleanup. Run both and capture cleanup return.
+    const cleanupFns: Array<() => void> = [];
+    while (effects.length) {
+      const fn = effects.shift()!;
+      const ret = fn();
+      if (typeof ret === 'function') cleanupFns.push(ret);
+    }
+    cleanupFns.forEach((c) => c());
+
+    expect(driver.cancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useShareAuth (auth-code flow)', () => {
+  it('start opens dialog via onSnapshot and resolves token', async () => {
+    const { driver, resolveToken } = makeAuthCodeDriver();
+    mocks.createSignInDriver.mockReturnValue(driver);
+
+    const dispatch = vi.fn();
+    const { startSignIn } = useShareAuth(dispatch);
+    flushEffects();
+
     await (startSignIn as () => Promise<void>)();
-    mocks.openDialog.mockClear();
+    await flushMicrotasks();
 
-    await capturedHandler!({ message: 'login' });
-
-    expect(mocks.openDialog).toHaveBeenCalledWith(defaultParams.authorizationUrl, [
-      new URL(defaultParams.redirectUri).origin,
+    expect(mocks.openDialog).toHaveBeenCalledWith('https://chromatic.com/authorize', [
+      new URL('https://example.com/redirect').origin,
     ]);
-    expect(mocks.exchangeOAuthCode).not.toHaveBeenCalled();
-  });
 
-  it('fetchAccessToken throws: setShareState reason=unknown, closeDialog called', async () => {
-    const setShareState = vi.fn();
-    mocks.initiateSignin.mockResolvedValueOnce(defaultParams);
-    mocks.exchangeOAuthCode.mockRejectedValueOnce(new Error('network error'));
+    // dispatch into dialog handler should call driver.handleDialogEvent
+    await capturedDialogHandler!({ message: 'grant', code: 'auth', state: 'state-abc' });
+    expect(driver.handleDialogEvent).toHaveBeenCalled();
 
-    const { startSignIn } = useShareAuth(setShareState);
-    await (startSignIn as () => Promise<void>)();
+    resolveToken('access-token-xyz');
+    await flushMicrotasks();
 
-    await capturedHandler!({ message: 'grant', code: 'auth-code', state: 'state-abc' });
-
-    expect(mocks.closeDialog).toHaveBeenCalledOnce();
-    expect(setShareState).toHaveBeenCalledWith({ status: 'error', reason: 'unknown' });
-  });
-
-  it('initiateSignin throws in startSignIn: setShareState reason=unknown', async () => {
-    const setShareState = vi.fn();
-    mocks.initiateSignin.mockRejectedValueOnce(new Error('network error'));
-
-    const { startSignIn } = useShareAuth(setShareState);
-    await (startSignIn as () => Promise<void>)();
-
-    expect(setShareState).toHaveBeenCalledWith({ status: 'error', reason: 'unknown' });
+    const completed = dispatch.mock.calls.find(([a]) => a.type === 'START_UPLOAD');
+    expect(completed).toBeTruthy();
+    expect(mocks.updateToken).toHaveBeenCalledWith('access-token-xyz');
   });
 });

--- a/src/screens/ShareSection/useShareAuth.ts
+++ b/src/screens/ShareSection/useShareAuth.ts
@@ -1,75 +1,144 @@
-import { useCallback, useRef } from 'react';
+import { type Dispatch, useCallback, useEffect, useRef } from 'react';
 
+import type { AuthCodeDriver } from '../../utils/authCodeDriver';
+import { BetaUserDeniedError } from '../../utils/deviceCodeDriver';
 import { useAccessToken } from '../../utils/graphQLClient';
-import { exchangeOAuthCode, parseGrantPayload } from '../../utils/oauthGrant';
-import { initiateSignin, type TokenExchangeParameters } from '../../utils/requestAccessToken';
-import { type DialogHandler, useChromaticDialog } from '../../utils/useChromaticDialog';
-import type { ShareState } from './types';
+import {
+  createSignInDriver,
+  type DriverAction,
+  type DriverSnapshot,
+  type SignInDriver,
+} from '../../utils/signInDriver';
+import { useChromaticDialog } from '../../utils/useChromaticDialog';
+import { useSessionState } from '../../utils/useSessionState';
+import type { ShareAction } from './types';
 
-export function useShareAuth(setShareState: (s: ShareState) => void) {
+const errorReason = (err: unknown): 'cancelled' | 'expired' | 'unknown' => {
+  if (err instanceof BetaUserDeniedError) return 'expired';
+  const e = err as { name?: string; message?: string } | null;
+  if (!e) return 'unknown';
+  if (e.name === 'AbortError') return 'cancelled';
+  if (typeof e.message === 'string') {
+    const m = e.message.toLowerCase();
+    if (m.includes('cancel')) return 'cancelled';
+    if (m.includes('expired')) return 'expired';
+  }
+  return 'unknown';
+};
+
+export function useShareAuth(dispatch: Dispatch<ShareAction>) {
   const [, updateToken] = useAccessToken();
-  const paramsRef = useRef<TokenExchangeParameters | null>(null);
+
+  const driverRef = useRef<SignInDriver | null>(null);
+  if (driverRef.current === null) {
+    driverRef.current = createSignInDriver();
+  }
+  const driver = driverRef.current;
+
+  const startedRef = useRef(false);
+  const [snapshot, setSnapshot] = useSessionState<DriverSnapshot | null>(
+    'shareSignInSnapshot',
+    null
+  );
+  const snapshotRef = useRef(snapshot);
+  snapshotRef.current = snapshot;
+
+  const driverDispatch = useCallback((action: DriverAction) => dispatch(action), [dispatch]);
+
   const openDialogRef = useRef<(url: string, additionalOrigins?: string[]) => void>();
   const closeDialogRef = useRef<() => void>();
 
-  const handler = useCallback<DialogHandler>(
-    async (event) => {
-      const params = paramsRef.current;
-      if (!params) return;
+  const dialogHandler = useCallback(async (event: unknown) => {
+    const d = driverRef.current as AuthCodeDriver | null;
+    if (!d || d.flow !== 'authorization-code') return;
+    const outcome = await d.handleDialogEvent(
+      event as Parameters<AuthCodeDriver['handleDialogEvent']>[0]
+    );
+    if (outcome.kind === 'code' || outcome.kind === 'error') {
+      closeDialogRef.current?.();
+    }
+  }, []);
 
-      const { authorizationUrl, redirectUri, state, clientId, codeVerifier, tokenEndpoint } =
-        params;
-      const redirectOrigin = new URL(redirectUri).origin;
-      const outcome = parseGrantPayload(event, state);
-
-      if (outcome.kind === 'login') {
-        openDialogRef.current?.(authorizationUrl, [redirectOrigin]);
-        return;
-      }
-      if (outcome.kind === 'ignore') return;
-
-      if (outcome.kind === 'error') {
-        paramsRef.current = null;
-        closeDialogRef.current?.();
-        setShareState({ status: 'error', reason: 'unknown' });
-        return;
-      }
-
-      paramsRef.current = null;
-
-      try {
-        const token = await exchangeOAuthCode(
-          { clientId, codeVerifier, redirectUri, tokenEndpoint },
-          outcome.code
-        );
-
-        updateToken(token);
-        closeDialogRef.current?.();
-        setShareState({ status: 'uploading', shareUrl: '' });
-      } catch {
-        closeDialogRef.current?.();
-        setShareState({ status: 'error', reason: 'unknown' });
-      }
-    },
-    [setShareState, updateToken]
-  );
-
-  const [openDialog, closeDialog] = useChromaticDialog(handler);
+  const [openDialog, closeDialog] = useChromaticDialog(dialogHandler);
   openDialogRef.current = openDialog;
   closeDialogRef.current = closeDialog;
 
-  const startSignIn = useCallback(
-    async (subdomain?: string) => {
+  const finalizeToken = useCallback(
+    async (tokenPromise: Promise<string>) => {
       try {
-        const params = await initiateSignin(subdomain);
-        paramsRef.current = params;
-        const redirectOrigin = new URL(params.redirectUri).origin;
-        openDialogRef.current?.(params.authorizationUrl, [redirectOrigin]);
-      } catch {
-        setShareState({ status: 'error', reason: 'unknown' });
+        const token = await tokenPromise;
+        dispatch({ type: 'START_UPLOAD', newRequestId: crypto.randomUUID() });
+        updateToken(token);
+        setSnapshot(null);
+        closeDialogRef.current?.();
+      } catch (err) {
+        dispatch({ type: 'VERIFICATION_FAILED', reason: errorReason(err) });
+        setSnapshot(null);
+        closeDialogRef.current?.();
+      } finally {
+        startedRef.current = false;
       }
     },
-    [setShareState]
+    [dispatch, setSnapshot, updateToken]
+  );
+
+  // On mount: resume from snapshot when flow matches.
+  useEffect(() => {
+    const snap = snapshotRef.current;
+    if (!snap) return;
+    if (snap.flow !== driver.flow) {
+      setSnapshot(null);
+      return;
+    }
+    if (!driver.resume) return;
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    driver
+      .resume(snap, { dispatch: driverDispatch, onSnapshot: setSnapshot })
+      .then((result) => finalizeToken(result.token))
+      .catch((err) => {
+        dispatch({ type: 'VERIFICATION_FAILED', reason: errorReason(err) });
+        setSnapshot(null);
+        startedRef.current = false;
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      driver.cancel();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const startSignIn = useCallback(
+    async (subdomain?: string) => {
+      if (startedRef.current) return;
+      startedRef.current = true;
+
+      try {
+        const result = await driver.start({
+          subdomain,
+          dispatch: driverDispatch,
+          onSnapshot: (s) => {
+            setSnapshot(s);
+            if (s.flow === 'authorization-code') {
+              const redirectOrigin = new URL(s.params.redirectUri).origin;
+              openDialogRef.current?.(s.params.authorizationUrl, [redirectOrigin]);
+            }
+          },
+        });
+        // Token resolution happens later — don't block startSignIn on it.
+        finalizeToken(result.token);
+      } catch (err) {
+        dispatch({ type: 'VERIFICATION_FAILED', reason: errorReason(err) });
+        setSnapshot(null);
+        startedRef.current = false;
+      }
+    },
+    [driver, driverDispatch, dispatch, finalizeToken, setSnapshot]
   );
 
   return { startSignIn, updateToken };

--- a/src/utils/authCodeDriver.test.ts
+++ b/src/utils/authCodeDriver.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const initiateSignin = vi.fn();
+const exchangeOAuthCode = vi.fn();
+
+vi.mock('./requestAccessToken', () => ({
+  initiateSignin: (...args: unknown[]) => initiateSignin(...args),
+}));
+
+vi.mock('./oauthGrant', async () => {
+  const actual = await vi.importActual<typeof import('./oauthGrant')>('./oauthGrant');
+  return {
+    ...actual,
+    exchangeOAuthCode: (...args: unknown[]) => exchangeOAuthCode(...args),
+  };
+});
+
+const { createAuthCodeDriver } = await import('./authCodeDriver');
+
+const defaultParams = {
+  clientId: 'chromaui:addon-visual-tests',
+  redirectUri: 'https://storybook.example.com/iframe.html',
+  codeVerifier: 'verifier',
+  state: 'state-abc',
+  authorizationUrl: 'https://www.chromatic.com/authorize?...',
+  tokenEndpoint: 'https://www.chromatic.com/token',
+};
+
+afterEach(() => {
+  initiateSignin.mockReset();
+  exchangeOAuthCode.mockReset();
+});
+
+describe('authCodeDriver', () => {
+  it('reports flow=authorization-code', () => {
+    const driver = createAuthCodeDriver();
+    expect(driver.flow).toBe('authorization-code');
+  });
+
+  it('start() emits an authorization-code snapshot with TokenExchangeParameters', async () => {
+    initiateSignin.mockResolvedValueOnce(defaultParams);
+    const onSnapshot = vi.fn();
+    const driver = createAuthCodeDriver();
+    await driver.start({ subdomain: 'acme', onSnapshot });
+    expect(initiateSignin).toHaveBeenCalledWith('acme');
+    expect(onSnapshot).toHaveBeenCalledWith({
+      flow: 'authorization-code',
+      params: defaultParams,
+    });
+  });
+
+  it('handleDialogEvent({code,state}) exchanges and resolves the token promise', async () => {
+    initiateSignin.mockResolvedValueOnce(defaultParams);
+    exchangeOAuthCode.mockResolvedValueOnce('tok-from-grant');
+    const driver = createAuthCodeDriver();
+    const { token } = await driver.start({});
+    const outcome = await driver.handleDialogEvent({
+      message: 'grant',
+      code: 'auth-code-1',
+      state: 'state-abc',
+    });
+    expect(outcome).toEqual({ kind: 'code', code: 'auth-code-1' });
+    expect(exchangeOAuthCode).toHaveBeenCalledOnce();
+    await expect(token).resolves.toBe('tok-from-grant');
+  });
+
+  it('handleDialogEvent ignores duplicate grant events (params cleared on first call)', async () => {
+    initiateSignin.mockResolvedValueOnce(defaultParams);
+    exchangeOAuthCode.mockResolvedValueOnce('tok');
+    const driver = createAuthCodeDriver();
+    await driver.start({});
+
+    await driver.handleDialogEvent({
+      message: 'grant',
+      code: 'auth-code-1',
+      state: 'state-abc',
+    });
+    const second = await driver.handleDialogEvent({
+      message: 'grant',
+      code: 'auth-code-1',
+      state: 'state-abc',
+    });
+    expect(second).toEqual({ kind: 'ignore' });
+    expect(exchangeOAuthCode).toHaveBeenCalledOnce();
+  });
+
+  it('rejects token promise when grant payload carries an error', async () => {
+    initiateSignin.mockResolvedValueOnce(defaultParams);
+    const dispatch = vi.fn();
+    const driver = createAuthCodeDriver();
+    const { token } = await driver.start({ dispatch });
+    await driver.handleDialogEvent({
+      message: 'grant',
+      error: 'access_denied',
+      error_description: 'User denied',
+      state: 'state-abc',
+    });
+    await expect(token).rejects.toThrow('User denied');
+    expect(dispatch).toHaveBeenCalledWith({ type: 'VERIFICATION_FAILED', reason: 'unknown' });
+  });
+
+  it('cancel() rejects the token promise and dispatches cancelled', async () => {
+    initiateSignin.mockResolvedValueOnce(defaultParams);
+    const dispatch = vi.fn();
+    const driver = createAuthCodeDriver();
+    const { token } = await driver.start({ dispatch });
+    driver.cancel();
+    await expect(token).rejects.toThrow(/cancelled/i);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'VERIFICATION_FAILED', reason: 'cancelled' });
+  });
+
+  it('handleDialogEvent passes through login outcomes', async () => {
+    initiateSignin.mockResolvedValueOnce(defaultParams);
+    const driver = createAuthCodeDriver();
+    await driver.start({});
+    const outcome = await driver.handleDialogEvent({ message: 'login' });
+    expect(outcome).toEqual({ kind: 'login' });
+  });
+});

--- a/src/utils/authCodeDriver.ts
+++ b/src/utils/authCodeDriver.ts
@@ -1,0 +1,97 @@
+import type { GrantOutcome } from './oauthGrant';
+import { exchangeOAuthCode, parseGrantPayload } from './oauthGrant';
+import { initiateSignin, type TokenExchangeParameters } from './requestAccessToken';
+import type { DriverAction, SignInDriver, StartOpts, StartResult } from './signInDriver';
+
+// The auth-code driver delegates popup management to the existing
+// `useChromaticDialog` hook (React-tied). The driver maintains an internal
+// deferred token promise and exposes `handleDialogEvent`, which consumers
+// call from the dialog's `handler` callback. This keeps the popup hook
+// reusable while letting the driver own the OAuth state machine.
+export type AuthCodeDriver = SignInDriver & {
+  flow: 'authorization-code';
+  handleDialogEvent: (event: Parameters<typeof parseGrantPayload>[0]) => Promise<GrantOutcome>;
+};
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+export const createAuthCodeDriver = (): AuthCodeDriver => {
+  let params: TokenExchangeParameters | null = null;
+  let deferred: ReturnType<typeof createDeferred<string>> | null = null;
+  let abortController: AbortController | null = null;
+  let dispatch: ((action: DriverAction) => void) | undefined;
+  let settled = false;
+
+  const finish = (action: () => void) => {
+    if (settled) return;
+    settled = true;
+    action();
+  };
+
+  return {
+    flow: 'authorization-code',
+
+    async start(opts: StartOpts): Promise<StartResult> {
+      params = await initiateSignin(opts.subdomain);
+      deferred = createDeferred<string>();
+      abortController = new AbortController();
+      dispatch = opts.dispatch;
+      settled = false;
+
+      // Attach a noop catch so rejection (cancel/error) doesn't surface as
+      // an unhandled rejection when the caller hasn't yet awaited the token.
+      deferred.promise.catch(() => {});
+
+      opts.onSnapshot?.({ flow: 'authorization-code', params });
+
+      return { token: deferred.promise };
+    },
+
+    cancel() {
+      abortController?.abort();
+      finish(() => {
+        dispatch?.({ type: 'VERIFICATION_FAILED', reason: 'cancelled' });
+        deferred?.reject(new Error('Sign-in cancelled'));
+      });
+    },
+
+    async handleDialogEvent(event) {
+      if (!params || !deferred) return { kind: 'ignore' };
+      const outcome = parseGrantPayload(event, params.state);
+
+      if (outcome.kind === 'login' || outcome.kind === 'ignore') return outcome;
+
+      if (outcome.kind === 'error') {
+        finish(() => {
+          dispatch?.({ type: 'VERIFICATION_FAILED', reason: 'unknown' });
+          deferred!.reject(new Error(outcome.message));
+        });
+        return outcome;
+      }
+
+      // outcome.kind === 'code' — exchange and resolve.
+      const exchangeParams = params;
+      params = null; // prevent duplicate exchange on repeat events
+      try {
+        const token = await exchangeOAuthCode(exchangeParams, outcome.code);
+        finish(() => {
+          deferred!.resolve(token);
+        });
+      } catch (err) {
+        finish(() => {
+          dispatch?.({ type: 'VERIFICATION_FAILED', reason: 'unknown' });
+          deferred!.reject(err);
+        });
+      }
+      return outcome;
+    },
+  };
+};

--- a/src/utils/deviceCodeDriver.test.ts
+++ b/src/utils/deviceCodeDriver.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../env', () => ({ CHROMATIC_BASE_URL: 'https://www.chromatic.com' }));
+vi.mock('../constants', () => ({ OAUTH_CLIENT_ID: 'chromaui:addon-visual-tests' }));
+vi.mock('./sha256', () => ({ sha256: (_: string) => 'aabbccdd' }));
+
+const cryptoMock = {
+  getRandomValues: vi.fn((arr: Uint8Array) => {
+    for (let i = 0; i < arr.length; i += 1) arr[i] = (i * 7) & 0xff;
+    return arr;
+  }),
+};
+
+vi.stubGlobal('window', {
+  btoa: globalThis.btoa,
+  crypto: cryptoMock,
+  open: vi.fn(() => ({ close: vi.fn() })),
+});
+
+const { createDeviceCodeDriver, BetaUserDeniedError } = await import('./deviceCodeDriver');
+
+const makeAuthorizeResponse = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  device_code: 'device-code-123',
+  user_code: 'ABCD-1234',
+  verification_uri_complete: 'https://www.chromatic.com/device?user_code=ABCD-1234',
+  expires_in: 600,
+  interval: 5,
+  ...overrides,
+});
+
+const jsonResponse = (data: unknown) => ({ json: async () => data }) as Response;
+
+beforeEach(() => {
+  cryptoMock.getRandomValues.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('deviceCodeDriver — start()', () => {
+  it('uses crypto.getRandomValues for the PKCE verifier (not Math.random)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse(makeAuthorizeResponse()));
+    const driver = createDeviceCodeDriver();
+    await driver.start({});
+    expect(cryptoMock.getRandomValues).toHaveBeenCalled();
+    driver.cancel();
+  });
+
+  it('exposes affordance with userCode and verificationUrl', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse(makeAuthorizeResponse()));
+    const driver = createDeviceCodeDriver();
+    const result = await driver.start({});
+    expect(result.affordance).toEqual({
+      userCode: 'ABCD-1234',
+      verificationUrl: 'https://www.chromatic.com/device?user_code=ABCD-1234',
+    });
+    driver.cancel();
+  });
+
+  it('rewrites verification URL to subdomain when subdomain provided', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse(makeAuthorizeResponse()));
+    const driver = createDeviceCodeDriver();
+    const result = await driver.start({ subdomain: 'acme' });
+    expect(result.affordance?.verificationUrl).toContain('acme.chromatic.com');
+    driver.cancel();
+  });
+
+  it('dispatches VERIFICATION_STARTED', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse(makeAuthorizeResponse()));
+    const dispatch = vi.fn();
+    const driver = createDeviceCodeDriver();
+    await driver.start({ dispatch });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'VERIFICATION_STARTED',
+      userCode: 'ABCD-1234',
+      verificationUrl: 'https://www.chromatic.com/device?user_code=ABCD-1234',
+    });
+    driver.cancel();
+  });
+
+  it('emits a device-code snapshot via onSnapshot', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse(makeAuthorizeResponse()));
+    const onSnapshot = vi.fn();
+    const driver = createDeviceCodeDriver();
+    await driver.start({ onSnapshot });
+    expect(onSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: 'device-code',
+        deviceCode: 'device-code-123',
+        userCode: 'ABCD-1234',
+      })
+    );
+    driver.cancel();
+  });
+
+  it('reports flow=device-code', () => {
+    const driver = createDeviceCodeDriver();
+    expect(driver.flow).toBe('device-code');
+  });
+});
+
+describe('deviceCodeDriver — polling and lifecycle', () => {
+  it('continues polling on authorization_pending and resolves on access_token', async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeAuthorizeResponse()));
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ error: 'authorization_pending' }));
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ access_token: 'tok-final' }));
+
+    const driver = createDeviceCodeDriver();
+    const { token } = await driver.start({});
+
+    await vi.advanceTimersByTimeAsync(5000); // first poll → pending
+    await vi.advanceTimersByTimeAsync(5000); // second poll → token
+    await expect(token).resolves.toBe('tok-final');
+  });
+
+  it('throws BetaUserDeniedError when error_description is "Not OAuth beta user"', async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeAuthorizeResponse()));
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ error: 'access_denied', error_description: 'Not OAuth beta user' })
+    );
+
+    const driver = createDeviceCodeDriver();
+    const { token } = await driver.start({});
+    await vi.advanceTimersByTimeAsync(5000);
+    await expect(token).rejects.toBeInstanceOf(BetaUserDeniedError);
+  });
+
+  it('rejects with expiry message when expires has elapsed before next poll', async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeAuthorizeResponse({ expires_in: 1 })));
+
+    const dispatch = vi.fn();
+    const driver = createDeviceCodeDriver();
+    const { token } = await driver.start({ dispatch });
+
+    // Advance past the 1s expiry, then trigger poll (interval = 5s clamped).
+    vi.setSystemTime(Date.now() + 2000);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(token).rejects.toThrow(/expired/i);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'VERIFICATION_FAILED', reason: 'expired' });
+  });
+
+  it('clamps a NaN/zero interval to 1000ms', async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeAuthorizeResponse({ interval: Number.NaN })));
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ access_token: 'tok-after-nan' }));
+
+    const driver = createDeviceCodeDriver();
+    const { token } = await driver.start({});
+
+    await vi.advanceTimersByTimeAsync(1000); // poll fires after clamped 1s
+    await expect(token).resolves.toBe('tok-after-nan');
+  });
+
+  it('cancel() aborts in-flight fetch and clears pending poll timer', async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockResolvedValueOnce(jsonResponse(makeAuthorizeResponse()));
+
+    const dispatch = vi.fn();
+    const driver = createDeviceCodeDriver();
+    const { token } = await driver.start({ dispatch });
+
+    driver.cancel();
+    await expect(token).rejects.toThrow(/cancelled/i);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'VERIFICATION_FAILED', reason: 'cancelled' });
+
+    // After cancel, advancing time must not trigger any further fetch calls.
+    fetchSpy.mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('deviceCodeDriver — resume()', () => {
+  it('continues polling from a stored snapshot without re-requesting /authorize', async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ access_token: 'tok-resumed' }));
+
+    const driver = createDeviceCodeDriver();
+    const snapshot = {
+      flow: 'device-code' as const,
+      deviceCode: 'device-code-resumed',
+      verifier: 'verifier-resumed',
+      expires: Date.now() + 60_000,
+      interval: 1000,
+      userCode: 'WXYZ-9999',
+      verificationUrl: 'https://www.chromatic.com/device?user_code=WXYZ-9999',
+      tokenEndpoint: 'https://www.chromatic.com/token',
+    };
+
+    const { token } = await driver.resume!(snapshot, {});
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(token).resolves.toBe('tok-resumed');
+
+    // Only one fetch call (the /token poll), no /authorize roundtrip.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0]?.[0] as string) ?? '').toContain('/token');
+  });
+});

--- a/src/utils/deviceCodeDriver.ts
+++ b/src/utils/deviceCodeDriver.ts
@@ -1,0 +1,289 @@
+import { OAUTH_CLIENT_ID } from '../constants';
+import { CHROMATIC_BASE_URL } from '../env';
+// @ts-expect-error File is in plain JS
+import { sha256 } from './sha256';
+import type {
+  DriverAction,
+  DriverSnapshot,
+  SignInDriver,
+  StartOpts,
+  StartResult,
+} from './signInDriver';
+
+export class BetaUserDeniedError extends Error {
+  constructor(message = 'You must be a beta user to use this addon at this time.') {
+    super(message);
+    this.name = 'BetaUserDeniedError';
+  }
+}
+
+const bytes = (buf: number[]) =>
+  new Uint8Array(buf).reduce((acc, val) => acc + String.fromCharCode(val), '');
+
+const base64 = (val: string | number[]) => window.btoa(Array.isArray(val) ? bytes(val) : val);
+
+const base64URLEncode = (val: string | number[]) =>
+  base64(val).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+
+const hexStringToBytes = (str: string) =>
+  Array.from(str.match(/.{1,2}/g) ?? [], (byte) => parseInt(byte, 16));
+
+const randomBase64Url = (byteLength: number) => {
+  const randomValues = new Uint8Array(byteLength);
+  window.crypto.getRandomValues(randomValues);
+  return base64URLEncode(Array.from(randomValues));
+};
+
+const encodeParams = (params: Record<string, string | number | boolean>) =>
+  Object.entries(params)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+
+const resolveChromaticHost = (subdomain?: string) => {
+  if (!subdomain) return CHROMATIC_BASE_URL;
+  const base = new URL(CHROMATIC_BASE_URL);
+  if (base.hostname.startsWith('www.')) {
+    base.hostname = `${subdomain}.${base.hostname.slice(4)}`;
+  }
+  return base.origin;
+};
+
+type DeviceCodeSession = {
+  deviceCode: string;
+  verifier: string;
+  expires: number;
+  interval: number;
+  userCode: string;
+  verificationUrl: string;
+  tokenEndpoint: string;
+};
+
+const clampInterval = (raw: number) => {
+  const ms = Number(raw);
+  return Number.isFinite(ms) && ms >= 1000 ? ms : 1000;
+};
+
+export const createDeviceCodeDriver = (): SignInDriver => {
+  let abortController: AbortController | null = null;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let popup: Window | null = null;
+  let dispatch: ((action: DriverAction) => void) | undefined;
+  let activeDeferred: { resolve: (v: string) => void; reject: (e: unknown) => void } | null = null;
+  let settled = false;
+
+  const clearTimer = () => {
+    if (pollTimer !== null) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+  };
+
+  const finishOnce = (action: () => void) => {
+    if (settled) return;
+    settled = true;
+    clearTimer();
+    action();
+  };
+
+  const closePopup = () => {
+    try {
+      popup?.close();
+    } catch {
+      // popup may already be closed
+    }
+    popup = null;
+  };
+
+  const pollOnce = async (
+    session: DeviceCodeSession,
+    deferred: { resolve: (v: string) => void; reject: (e: unknown) => void }
+  ): Promise<void> => {
+    if (settled) return;
+
+    if (Date.now() >= session.expires) {
+      finishOnce(() => {
+        dispatch?.({ type: 'VERIFICATION_FAILED', reason: 'expired' });
+        deferred.reject(new Error('Token exchange expired, please restart sign in.'));
+      });
+      return;
+    }
+
+    try {
+      const res = await fetch(session.tokenEndpoint, {
+        method: 'POST',
+        signal: abortController?.signal,
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+        body: encodeParams({
+          client_id: OAUTH_CLIENT_ID,
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          device_code: session.deviceCode,
+          code_verifier: session.verifier,
+          scope: 'user:read account:read project:read project:write',
+        }),
+      });
+      const data = await res.json();
+
+      if (data.access_token) {
+        finishOnce(() => {
+          closePopup();
+          deferred.resolve(data.access_token as string);
+        });
+        return;
+      }
+
+      if (data.error === 'authorization_pending') {
+        pollTimer = setTimeout(() => pollOnce(session, deferred), session.interval);
+        return;
+      }
+
+      if (data.error_description === 'Not OAuth beta user') {
+        finishOnce(() => {
+          dispatch?.({ type: 'VERIFICATION_FAILED', reason: 'unknown' });
+          deferred.reject(new BetaUserDeniedError());
+        });
+        return;
+      }
+
+      finishOnce(() => {
+        dispatch?.({ type: 'VERIFICATION_FAILED', reason: 'unknown' });
+        deferred.reject(new Error(data.error_description || data.error || 'Token exchange failed'));
+      });
+    } catch (err) {
+      if ((err as { name?: string }).name === 'AbortError') return;
+      finishOnce(() => {
+        dispatch?.({ type: 'VERIFICATION_FAILED', reason: 'unknown' });
+        deferred.reject(err);
+      });
+    }
+  };
+
+  const beginPolling = (
+    session: DeviceCodeSession,
+    deferred: { resolve: (v: string) => void; reject: (e: unknown) => void }
+  ) => {
+    pollTimer = setTimeout(() => pollOnce(session, deferred), session.interval);
+  };
+
+  const requestDeviceCode = async (
+    subdomain: string | undefined,
+    signal: AbortSignal
+  ): Promise<DeviceCodeSession> => {
+    const verifier = randomBase64Url(64);
+    const challenge = base64URLEncode(hexStringToBytes(sha256(verifier)));
+    const chromaticBaseUrl = resolveChromaticHost(subdomain);
+
+    const res = await fetch(`${chromaticBaseUrl}/authorize`, {
+      method: 'POST',
+      signal,
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+      body: encodeParams({
+        client_id: OAUTH_CLIENT_ID,
+        code_challenge: challenge,
+      }),
+    });
+
+    const {
+      device_code: deviceCode,
+      user_code: userCode,
+      verification_uri_complete,
+      expires_in,
+      interval,
+    } = await res.json();
+
+    const verificationUrl = subdomain
+      ? String(verification_uri_complete).replace('https://www', `https://${subdomain}`)
+      : (verification_uri_complete as string);
+
+    return {
+      deviceCode,
+      verifier,
+      userCode,
+      verificationUrl,
+      expires: Date.now() + Number(expires_in) * 1000,
+      interval: clampInterval(Number(interval) * 1000),
+      tokenEndpoint: `${chromaticBaseUrl}/token`,
+    };
+  };
+
+  const beginStart = (session: DeviceCodeSession, opts: StartOpts): StartResult => {
+    dispatch = opts.dispatch;
+    settled = false;
+
+    opts.onSnapshot?.({
+      flow: 'device-code',
+      deviceCode: session.deviceCode,
+      verifier: session.verifier,
+      expires: session.expires,
+      interval: session.interval,
+      userCode: session.userCode,
+      verificationUrl: session.verificationUrl,
+      tokenEndpoint: session.tokenEndpoint,
+    });
+
+    dispatch?.({
+      type: 'VERIFICATION_STARTED',
+      userCode: session.userCode,
+      verificationUrl: session.verificationUrl,
+    });
+
+    popup = window.open(session.verificationUrl, '_blank');
+
+    let resolve!: (v: string) => void;
+    let reject!: (e: unknown) => void;
+    const tokenPromise = new Promise<string>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    // Attach a noop catch so a rejected token (cancel/expired/error) doesn't
+    // surface as an unhandled rejection if the consumer never awaits it.
+    tokenPromise.catch(() => {});
+    activeDeferred = { resolve, reject };
+
+    beginPolling(session, activeDeferred);
+
+    return {
+      affordance: {
+        userCode: session.userCode,
+        verificationUrl: session.verificationUrl,
+      },
+      token: tokenPromise,
+    };
+  };
+
+  return {
+    flow: 'device-code',
+
+    async start(opts: StartOpts): Promise<StartResult> {
+      abortController = new AbortController();
+      const session = await requestDeviceCode(opts.subdomain, abortController.signal);
+      return beginStart(session, opts);
+    },
+
+    async resume(snapshot: DriverSnapshot, opts: StartOpts): Promise<StartResult> {
+      if (snapshot.flow !== 'device-code') {
+        throw new Error('Cannot resume non-device-code snapshot');
+      }
+      abortController = new AbortController();
+      const session: DeviceCodeSession = {
+        deviceCode: snapshot.deviceCode,
+        verifier: snapshot.verifier,
+        expires: snapshot.expires,
+        interval: clampInterval(snapshot.interval),
+        userCode: snapshot.userCode,
+        verificationUrl: snapshot.verificationUrl,
+        tokenEndpoint: snapshot.tokenEndpoint,
+      };
+      return beginStart(session, opts);
+    },
+
+    cancel() {
+      abortController?.abort();
+      finishOnce(() => {
+        dispatch?.({ type: 'VERIFICATION_FAILED', reason: 'cancelled' });
+        closePopup();
+        activeDeferred?.reject(new Error('Sign-in cancelled'));
+        activeDeferred = null;
+      });
+    },
+  };
+};

--- a/src/utils/oauthGrant.ts
+++ b/src/utils/oauthGrant.ts
@@ -1,3 +1,5 @@
+// Authorization-code flow only. The device-code flow does NOT call this
+// module — it polls /token directly via deviceCodeDriver.
 import { fetchAccessToken, type TokenExchangeParameters } from './requestAccessToken';
 import type { DialogHandler } from './useChromaticDialog';
 

--- a/src/utils/signInDriver.test.ts
+++ b/src/utils/signInDriver.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSignInDriver, handlesOAuthRedirect, OAUTH_FLOW } from './signInDriver';
+
+describe('signInDriver', () => {
+  it('exports OAUTH_FLOW as one of the OAuthFlow literals', () => {
+    expect(['authorization-code', 'device-code']).toContain(OAUTH_FLOW);
+  });
+
+  it('createSignInDriver returns a driver matching the configured flow', () => {
+    expect(createSignInDriver().flow).toBe(OAUTH_FLOW);
+  });
+
+  it('handlesOAuthRedirect mirrors authorization-code selection', () => {
+    expect(handlesOAuthRedirect).toBe(OAUTH_FLOW === 'authorization-code');
+  });
+});

--- a/src/utils/signInDriver.ts
+++ b/src/utils/signInDriver.ts
@@ -1,0 +1,54 @@
+import { createAuthCodeDriver } from './authCodeDriver';
+import { createDeviceCodeDriver } from './deviceCodeDriver';
+
+export type OAuthFlow = 'authorization-code' | 'device-code';
+
+// Single switch for the OAuth flow used across the addon. The explicit
+// OAuthFlow annotation widens the literal type so both branches in
+// createSignInDriver remain reachable to type-checkers and bundlers.
+export const OAUTH_FLOW: OAuthFlow = 'device-code';
+
+// True when the configured flow round-trips through this window (the addon
+// page is opened as the OAuth redirect target). Lets manager.tsx decide
+// whether to install the redirect handler without instantiating a driver.
+export const handlesOAuthRedirect: boolean = OAUTH_FLOW === 'authorization-code';
+
+export type SignInAffordance = { userCode: string; verificationUrl: string };
+
+export type DriverSnapshot =
+  | { flow: 'authorization-code'; params: import('./requestAccessToken').TokenExchangeParameters }
+  | {
+      flow: 'device-code';
+      deviceCode: string;
+      verifier: string;
+      expires: number;
+      interval: number;
+      userCode: string;
+      verificationUrl: string;
+      tokenEndpoint: string;
+    };
+
+export type DriverAction =
+  | { type: 'VERIFICATION_STARTED'; userCode: string; verificationUrl: string }
+  | { type: 'VERIFICATION_FAILED'; reason: 'cancelled' | 'expired' | 'unknown' };
+
+export type StartOpts = {
+  subdomain?: string;
+  dispatch?: (action: DriverAction) => void;
+  onSnapshot?: (snapshot: DriverSnapshot) => void;
+};
+
+export type StartResult = {
+  affordance?: SignInAffordance;
+  token: Promise<string>;
+};
+
+export interface SignInDriver {
+  flow: OAuthFlow;
+  start(opts: StartOpts): Promise<StartResult>;
+  resume?(snapshot: DriverSnapshot, opts: StartOpts): Promise<StartResult>;
+  cancel(): void;
+}
+
+export const createSignInDriver = (): SignInDriver =>
+  OAUTH_FLOW === 'device-code' ? createDeviceCodeDriver() : createAuthCodeDriver();


### PR DESCRIPTION
## Summary

Refactors the share popover's authentication flow so the UI state and the OAuth state machine no longer share a single tangled component. The popover now drives a typed reducer for screen transitions, and OAuth itself lives behind a small pluggable driver interface with two implementations: **device-code** (verification code in a new tab + polled token) and **authorization-code** (popup with redirect back to the addon).

The driver-level split means the rest of the addon never sees the difference — the popover, manager redirect handler, and Authentication screen all consume the same `SignInDriver` interface and resume from the same snapshot shape across remounts. This makes it cheap to switch flows for experiments or rollback without touching call sites.

## What changed

- New typed reducer (`shareReducer`) owns the popover screen + share-request lifecycle, with a single `START_UPLOAD` action covering all four ways an upload can begin (initial publish, repeat publish, post-auth, and signed-in auto-skip).
- New `SignInDriver` interface with two implementations:
  - **device-code** — open verification URL in a new tab, poll the token endpoint, no popup window.
  - **authorization-code** — open a popup, accept the OAuth redirect on this window, exchange the code for a token.
- `useShareAuth` hook owns the driver lifecycle (start, resume, cancel, snapshot persistence) and translates driver outcomes into reducer actions.
- The OAuth redirect handler in `manager` no longer instantiates a driver at module load — it's gated by an exported boolean constant that mirrors the configured flow.
- Adds a dedicated **Verifying** screen for the device-code flow showing the user code as digit chips with a pulsing "waiting for verification…" indicator.
- Snapshot-based resume: if the addon remounts mid-sign-in (panel close/reopen, manager reload), the driver picks up where it left off as long as the persisted snapshot's flow still matches the configured one.
- Test coverage for both drivers, the reducer, the hook, the redirect handler, and the Authentication / Verify screens.

## Toggling the OAuth flow

There is a single switch that controls which OAuth flow the addon uses. To change it, edit the constant in `src/utils/signInDriver.ts`:

```ts
export const OAUTH_FLOW: OAuthFlow = 'device-code';
```

Set it to either:

- `'device-code'` — current default. The addon opens the verification URL in a new browser tab, the user signs in on Chromatic, and the addon polls the token endpoint until a token is issued or the device code expires. No popup, no redirect, no special manager handling.
- `'authorization-code'` — the addon opens a popup window pointed at Chromatic's authorization URL, Chromatic redirects back to the addon's manager URL with a `code` + `state`, the manager forwards the grant to the popover via `postMessage`, and the driver exchanges the code for a token.

The same constant also drives `handlesOAuthRedirect`, an exported boolean the manager checks before installing its OAuth redirect listener — so flipping the switch automatically wires up (or removes) the redirect handler without any further code changes. Snapshots stored in session storage from a previous flow are dropped on mount when they don't match the active flow, so a switch never strands a user mid-sign-in.

## Test plan

- [ ] Verify share popover sign-in works end-to-end with `OAUTH_FLOW = 'device-code'`: verification screen renders with the digit chips, opens the correct URL in a new tab, polls and completes upload after the user authorizes on Chromatic.
- [ ] Verify share popover sign-in works end-to-end with `OAUTH_FLOW = 'authorization-code'`: popup opens, redirect lands back on the manager, popover transitions to uploading after `postMessage`.
- [ ] Close the popover mid-verification and reopen it — the verifying screen should resume against the same device code (device-code flow only; auth-code popup cannot resume after the popup closes).
- [ ] Trigger the auth-error path (expired token from the API): popover should drop back to the sign-in screen and clear the access token without showing a generic error.
- [ ] Cancel an in-flight upload from the uploading screen — share is canceled, telemetry fires `share-canceled`.
- [ ] Sign in via the standalone Authentication screen (project setup flow), not just the share popover — verification screen, popup handling, and project-creation handoff should all still work for both flows.
- [ ] Run `yarn vitest run`, `yarn lint`, and `tsc --noEmit` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)