### PR TITLE
Fix OAuth authorization_code flow

### DIFF
--- a/src/screens/ShareSection/useShareAuth.test.ts
+++ b/src/screens/ShareSection/useShareAuth.test.ts
@@ -153,7 +153,7 @@ describe('useShareAuth', () => {
     expect(mocks.exchangeOAuthCode).not.toHaveBeenCalled();
   });
 
-  it('login relay: openDialog called again with authorizationUrl', async () => {
+  it('login relay: ignored so current popup tracking is preserved', async () => {
     const setShareState = vi.fn();
     mocks.initiateSignin.mockResolvedValueOnce(defaultParams);
 
@@ -163,9 +163,7 @@ describe('useShareAuth', () => {
 
     await capturedHandler!({ message: 'login' });
 
-    expect(mocks.openDialog).toHaveBeenCalledWith(defaultParams.authorizationUrl, [
-      new URL(defaultParams.redirectUri).origin,
-    ]);
+    expect(mocks.openDialog).not.toHaveBeenCalled();
     expect(mocks.exchangeOAuthCode).not.toHaveBeenCalled();
   });
 

--- a/src/screens/ShareSection/useShareAuth.ts
+++ b/src/screens/ShareSection/useShareAuth.ts
@@ -17,16 +17,12 @@ export function useShareAuth(setShareState: (s: ShareState) => void) {
       const params = paramsRef.current;
       if (!params) return;
 
-      const { authorizationUrl, redirectUri, state, clientId, codeVerifier, tokenEndpoint } =
-        params;
-      const redirectOrigin = new URL(redirectUri).origin;
+      const { redirectUri, state, clientId, codeVerifier, tokenEndpoint } = params;
       const outcome = parseGrantPayload(event, state);
 
-      if (outcome.kind === 'login') {
-        openDialogRef.current?.(authorizationUrl, [redirectOrigin]);
+      if (outcome.kind === 'login' || outcome.kind === 'ignore') {
         return;
       }
-      if (outcome.kind === 'ignore') return;
 
       if (outcome.kind === 'error') {
         paramsRef.current = null;


### PR DESCRIPTION
Avoid reopening the auth dialog when receiving a login message, which could replace the tracked window and drop the subsequent grant/code message.