### PR TITLE
Show share expiry based on `daysToExpire` from CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@neoconfetti/react": "^1.0.0",
-    "chromatic": "16.0.1--canary.1262.23788470989.0",
+    "chromatic": "16.10.0--canary.1284.25486644217.0",
     "filesize": "^10.0.12",
     "jsonfile": "^6.1.0",
     "strip-ansi": "^7.1.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,6 +61,4 @@ export const CONFIG_OVERRIDES = {
   storybookBuildDir: undefined,
 };
 
-export const SHARE_EXPIRY_DAYS = 7;
-
 export const DOCS_URL = 'https://www.chromatic.com/docs/visual-tests-addon';

--- a/src/preset.share.test.ts
+++ b/src/preset.share.test.ts
@@ -121,7 +121,7 @@ describe('preset START_SHARE handler', () => {
     emitStartShare({ accessToken: 'token', shareRequestId: 'req-1' });
     emitStartShare({ accessToken: 'token', shareRequestId: 'req-2' });
 
-    resolveShare({ shareUrl: 'https://share.example.com/1' });
+    resolveShare({ shareUrl: 'https://share.example.com/1', daysToExpire: 7 });
 
     // Give promises time to flush
     await new Promise((r) => setTimeout(r, 0));
@@ -150,7 +150,7 @@ describe('preset START_SHARE handler', () => {
 
     mocks.shareMock.mockImplementationOnce(async ({ onError }: { onError: (e: Error) => void }) => {
       onError(new Error('upload failed'));
-      return { shareUrl: 'https://share.example.com/sb' };
+      return { shareUrl: 'https://share.example.com/sb', daysToExpire: 7 };
     });
 
     await emitStartShare({ accessToken: 'token', shareRequestId: 'req-1' });
@@ -187,7 +187,10 @@ describe('preset START_SHARE handler', () => {
     });
 
     // After abort, shareInFlight should be released — a new share with a different id must run
-    mocks.shareMock.mockResolvedValueOnce({ shareUrl: 'https://share.example.com/2' });
+    mocks.shareMock.mockResolvedValueOnce({
+      shareUrl: 'https://share.example.com/2',
+      daysToExpire: 7,
+    });
     await emitStartShare({ accessToken: 'token', shareRequestId: 'req-2' });
     expect(mocks.shareMock).toHaveBeenCalledTimes(2);
   });
@@ -211,7 +214,7 @@ describe('preset START_SHARE handler', () => {
     mocks.shareMock.mockImplementationOnce(
       async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
         if (abortSignal) captured.push(abortSignal);
-        return { shareUrl: 'https://share.example.com/2' };
+        return { shareUrl: 'https://share.example.com/2', daysToExpire: 7 };
       }
     );
     await emitStartShare({ accessToken: 'token', shareRequestId: 'req-2' });
@@ -224,7 +227,10 @@ describe('preset START_SHARE handler', () => {
   it('duplicate START_SHARE with the id of the last completed share is ignored', async () => {
     await loadPreset();
 
-    mocks.shareMock.mockResolvedValueOnce({ shareUrl: 'https://share.example.com/sb' });
+    mocks.shareMock.mockResolvedValueOnce({
+      shareUrl: 'https://share.example.com/sb',
+      daysToExpire: 7,
+    });
     await emitStartShare({ accessToken: 'token', shareRequestId: 'req-done' });
     expect(mocks.shareProgressState.value).toMatchObject({ status: 'complete' });
     expect(mocks.shareMock).toHaveBeenCalledTimes(1);

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -303,6 +303,7 @@ async function serverChannel(channel: Channel, options: Options & { configFile?:
           shareProgressState.value = {
             status: 'complete',
             shareUrl: result.shareUrl,
+            daysToExpire: result.daysToExpire,
             shareRequestId: requestId,
           };
           lastCompletedShareRequestId = requestId;

--- a/src/screens/ShareSection/ShareSection.stories.tsx
+++ b/src/screens/ShareSection/ShareSection.stories.tsx
@@ -83,6 +83,21 @@ export const CompleteJustPublished: CompleteStory = {
   args: {
     shareUrl: 'https://64e2e5e6ad08a7e515c54b37-abcdefghij.chromatic.com',
     publishedAt: Date.now(),
+    daysToExpire: 7,
+    isOutdated: false,
+    onPublishAgain: fn().mockName('onPublishAgain'),
+    onCopy: fn().mockName('onCopy'),
+    onDelete: fn().mockName('onDelete'),
+  },
+};
+
+// --- Complete (without expiry info) ---
+
+export const CompleteWithoutExpiry: CompleteStory = {
+  render: (args) => <ShareSectionComplete {...args} />,
+  args: {
+    shareUrl: 'https://64e2e5e6ad08a7e515c54b37-abcdefghij.chromatic.com',
+    publishedAt: Date.now() - 2 * 60 * 60 * 1000, // 2 hours ago
     isOutdated: false,
     onPublishAgain: fn().mockName('onPublishAgain'),
     onCopy: fn().mockName('onCopy'),
@@ -97,6 +112,7 @@ export const CompleteWithChanges: CompleteStory = {
   args: {
     shareUrl: 'https://64e2e5e6ad08a7e515c54b37-abcdefghij.chromatic.com',
     publishedAt: Date.now() - 2 * 60 * 60 * 1000, // 2 hours ago
+    daysToExpire: 7,
     isOutdated: true,
     onPublishAgain: fn().mockName('onPublishAgain'),
     onCopy: fn().mockName('onCopy'),

--- a/src/screens/ShareSection/ShareSection.test.tsx
+++ b/src/screens/ShareSection/ShareSection.test.tsx
@@ -213,6 +213,7 @@ describe('ShareSection', () => {
       shareProgressValue = {
         status: 'complete',
         shareUrl: 'https://share.example.com/sb',
+        daysToExpire: 7,
         shareRequestId: 'req-1',
       };
 
@@ -251,6 +252,7 @@ describe('ShareSection', () => {
       shareProgressValue = {
         status: 'complete',
         shareUrl: 'https://share.example.com/sb',
+        daysToExpire: 7,
         shareRequestId: 'req-1',
       };
 
@@ -321,6 +323,7 @@ describe('ShareSection', () => {
           status: 'complete',
           shareUrl: 'https://share.example.com/sb',
           publishedAt: Date.now(),
+          daysToExpire: 7,
         },
       });
 

--- a/src/screens/ShareSection/ShareSection.tsx
+++ b/src/screens/ShareSection/ShareSection.tsx
@@ -46,11 +46,11 @@ function applyProgress(
   }
 
   if (progress.status === 'complete') {
-    const { shareUrl } = progress;
+    const { shareUrl, daysToExpire } = progress;
     return {
       next: {
         ...state,
-        screen: { status: 'complete', shareUrl, publishedAt: Date.now() },
+        screen: { status: 'complete', shareUrl, publishedAt: Date.now(), daysToExpire },
         shareRequestId: null,
         shareTriggeredId: null,
       },
@@ -319,6 +319,7 @@ export const ShareSection = ({ api }: { api: API }) => {
         <ShareSectionComplete
           shareUrl={screen.shareUrl}
           publishedAt={screen.publishedAt}
+          daysToExpire={screen.daysToExpire}
           isOutdated={checkOutdated(lastCompletedGitInfo, gitInfo)}
           onCopy={() => emitTelemetry('share-url-copied')}
           onPublishAgain={() => {

--- a/src/screens/ShareSection/ShareSectionComplete.tsx
+++ b/src/screens/ShareSection/ShareSectionComplete.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react';
 import { styled } from 'storybook/theming';
 
 import { Button } from '../../components/Button';
-import { SHARE_EXPIRY_DAYS } from '../../constants';
 import { formatDate } from '../../utils/formatDate';
 import {
   ButtonStack,
@@ -64,6 +63,7 @@ const InfoBannerText = styled.span(({ theme }) => ({
 interface ShareSectionCompleteProps {
   shareUrl: string;
   publishedAt: number;
+  daysToExpire?: number;
   isOutdated: boolean;
   onPublishAgain: () => void;
   onCopy?: () => void;
@@ -74,6 +74,7 @@ const CELEBRATION_DURATION_MS = 5000;
 export const ShareSectionComplete = ({
   shareUrl,
   publishedAt,
+  daysToExpire,
   isOutdated,
   onPublishAgain,
   onCopy,
@@ -112,12 +113,14 @@ export const ShareSectionComplete = ({
           <TimestampRow>
             <span style={{ fontSize: 12, flexShrink: 0 }}>⏳</span>
             <TimestampText>
-              Published {formatDate(publishedAt)} – expires in{' '}
-              {(() => {
-                const msRemaining = addDays(publishedAt, SHARE_EXPIRY_DAYS).getTime() - Date.now();
-                const daysRemaining = Math.max(0, Math.ceil(msRemaining / 86_400_000));
-                return `${daysRemaining} ${daysRemaining === 1 ? 'day' : 'days'}`;
-              })()}
+              Published {formatDate(publishedAt)}
+              {daysToExpire !== undefined
+                ? (() => {
+                    const msRemaining = addDays(publishedAt, daysToExpire).getTime() - Date.now();
+                    const daysRemaining = Math.max(0, Math.ceil(msRemaining / 86_400_000));
+                    return ` – expires in ${daysRemaining} ${daysRemaining === 1 ? 'day' : 'days'}`;
+                  })()
+                : ''}
             </TimestampText>
           </TimestampRow>
         )}

--- a/src/screens/ShareSection/types.ts
+++ b/src/screens/ShareSection/types.ts
@@ -3,7 +3,7 @@ export type ShareState =
   | { status: 'idle' }
   | { status: 'subdomain' }
   | { status: 'uploading'; shareUrl: string }
-  | { status: 'complete'; shareUrl: string; publishedAt: number }
+  | { status: 'complete'; shareUrl: string; publishedAt: number; daysToExpire?: number }
   | {
       status: 'error';
       reason: 'upload-canceled' | 'unknown';

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,7 +225,7 @@ export type LocalBuildProgress = {
 export type ShareProgress =
   | { status: 'pending'; shareRequestId: string }
   | { status: 'uploading'; shareUrl?: string; shareRequestId: string }
-  | { status: 'complete'; shareUrl: string; shareRequestId: string }
+  | { status: 'complete'; shareUrl: string; shareRequestId: string; daysToExpire?: number }
   | {
       status: 'error';
       error: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,7 +467,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^3.0.8"
     auto: "npm:^11.0.5"
     boxen: "npm:^5.0.1"
-    chromatic: "npm:16.0.1--canary.1262.23788470989.0"
+    chromatic: "npm:16.10.0--canary.1284.25486644217.0"
     date-fns: "npm:^2.30.0"
     dedent: "npm:^0.7.0"
     eslint: "npm:^9.21.0"
@@ -4263,22 +4263,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromatic@npm:16.0.1--canary.1262.23788470989.0":
-  version: 16.0.1--canary.1262.23788470989.0
-  resolution: "chromatic@npm:16.0.1--canary.1262.23788470989.0"
+"chromatic@npm:16.10.0--canary.1284.25486644217.0":
+  version: 16.10.0--canary.1284.25486644217.0
+  resolution: "chromatic@npm:16.10.0--canary.1284.25486644217.0"
+  dependencies:
+    semver: "npm:^7.3.5"
   peerDependencies:
     "@chromatic-com/cypress": ^0.*.* || ^1.0.0
     "@chromatic-com/playwright": ^0.*.* || ^1.0.0
+    "@chromatic-com/vitest": ^0.*.* || ^1.0.0
   peerDependenciesMeta:
     "@chromatic-com/cypress":
       optional: true
     "@chromatic-com/playwright":
       optional: true
+    "@chromatic-com/vitest":
+      optional: true
   bin:
-    chroma: dist/bin.js
-    chromatic: dist/bin.js
-    chromatic-cli: dist/bin.js
-  checksum: 10c0/c0069f6fc0bf13b39a6a0dc1c70a8f4e512761cd30dbc7a996a4ec3c14ae677655ad3d5aeda5ef51d6b899e593c749dc2692d2ea0dce160c2b3a5789aae56400
+    chroma: dist/bin.cjs
+    chromatic: dist/bin.cjs
+    chromatic-cli: dist/bin.cjs
+  checksum: 10c0/95075a4ed04238e52ff429c5036c9673c196a52d9e5fcf7797255ff5e359c0988f0c9305581eafe5871cc2671fc085f6999f133f662620e553a6e60de9d7f286
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces the hardcoded 7-day expiry with whatever value is returned by the CLI when using the `share` API.