### PR TITLE
Scope access token by per-Storybook identifier

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -6,4 +6,12 @@ export const {
   CHROMATIC_API_URL = `${CHROMATIC_BASE_URL}/api`,
 } = process.env;
 
-export const ACCESS_TOKEN_KEY = `${ADDON_ID}/access-token/${CHROMATIC_BASE_URL}`;
+// Per-Storybook identifier injected by the addon's `managerHead` preset hook.
+// Falls back to 'unscoped' when missing (e.g. preset didn't run, no git remote).
+const STORYBOOK_ID =
+  (typeof window !== 'undefined' &&
+    (window as { __CHROMATIC_STORYBOOK_ID__?: string }).__CHROMATIC_STORYBOOK_ID__) ||
+  'unscoped';
+
+export const ACCESS_TOKEN_KEY_LEGACY = `${ADDON_ID}/access-token/${CHROMATIC_BASE_URL}`;
+export const ACCESS_TOKEN_KEY = `${ACCESS_TOKEN_KEY_LEGACY}/${STORYBOOK_ID}`;

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -45,6 +45,7 @@ import type {
   ShareProgress,
 } from './types.ts';
 import { ChannelFetch } from './utils/ChannelFetch.ts';
+import { getStorybookId } from './utils/getStorybookId.ts';
 import { SharedState } from './utils/SharedState.ts';
 import { updateChromaticConfig } from './utils/updateChromaticConfig.ts';
 
@@ -370,8 +371,20 @@ async function serverChannel(channel: Channel, options: Options & { configFile?:
   return channel;
 }
 
+// Inject the Storybook installation identifier into the manager so the
+// addon can scope its localStorage keys per Storybook. Without this, two
+// different Storybooks served on the same dev port (different projects,
+// different Chromatic accounts) would silently share the cached access
+// token, since localStorage is scoped to origin only.
+async function managerHead(head: string) {
+  const storybookId = await getStorybookId();
+  if (!storybookId) return head;
+  return `${head}\n<script>window.__CHROMATIC_STORYBOOK_ID__ = ${JSON.stringify(storybookId)};</script>`;
+}
+
 const config = {
   managerEntries,
+  managerHead,
   previewAnnotations,
   experimental_serverChannel: serverChannel,
   staticDirs: async (inputDirs: string[]) => [

--- a/src/utils/getStorybookId.test.ts
+++ b/src/utils/getStorybookId.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeStorybookId, normalizeGitUrl } from './getStorybookId';
+
+describe('normalizeGitUrl', () => {
+  it('normalizes https and ssh URLs to the same shape', () => {
+    expect(normalizeGitUrl('git@github.com:owner/repo.git')).toBe(
+      normalizeGitUrl('https://github.com/owner/repo.git')
+    );
+  });
+
+  it('appends .git when missing', () => {
+    expect(normalizeGitUrl('https://github.com/owner/repo')).toMatch(/\.git$/);
+  });
+
+  it('strips trailing fragments', () => {
+    expect(normalizeGitUrl('https://github.com/owner/repo.git#main')).toBe(
+      'github.com/owner/repo.git'
+    );
+  });
+});
+
+describe('computeStorybookId', () => {
+  it('returns a stable sha256 hex string for a given remote + path', () => {
+    const a = computeStorybookId('git@github.com:owner/repo.git', 'packages/storybook');
+    const b = computeStorybookId('git@github.com:owner/repo.git', 'packages/storybook');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('produces different ids for the same repo at different sub-paths (monorepo)', () => {
+    const a = computeStorybookId('git@github.com:owner/repo.git', 'packages/sb-a');
+    const b = computeStorybookId('git@github.com:owner/repo.git', 'packages/sb-b');
+    expect(a).not.toBe(b);
+  });
+
+  it('produces different ids for different remotes at the same path', () => {
+    const a = computeStorybookId('git@github.com:owner/one.git', '');
+    const b = computeStorybookId('git@github.com:owner/two.git', '');
+    expect(a).not.toBe(b);
+  });
+
+  it('returns null for null/empty remote', () => {
+    expect(computeStorybookId(null, 'x')).toBeNull();
+    expect(computeStorybookId(undefined, 'x')).toBeNull();
+    expect(computeStorybookId('', 'x')).toBeNull();
+  });
+
+  it('treats https and ssh URLs to the same repo as the same id', () => {
+    const ssh = computeStorybookId('git@github.com:owner/repo.git', '');
+    const https = computeStorybookId('https://github.com/owner/repo.git', '');
+    expect(ssh).toBe(https);
+  });
+
+  it('normalizes Windows backslashes in project root path', () => {
+    const win = computeStorybookId('git@github.com:owner/repo.git', 'packages\\storybook');
+    const posix = computeStorybookId('git@github.com:owner/repo.git', 'packages/storybook');
+    expect(win).toBe(posix);
+  });
+});

--- a/src/utils/getStorybookId.ts
+++ b/src/utils/getStorybookId.ts
@@ -1,0 +1,45 @@
+import { createHash } from 'node:crypto';
+import { relative } from 'node:path';
+
+export const normalizeGitUrl = (rawUrl: string) => {
+  const urlWithoutHash = rawUrl.trim().replace(/#.*$/, '');
+  const urlWithoutUser = urlWithoutHash.replace(/^.*@/, '');
+  const urlWithoutScheme = urlWithoutUser.replace(/^.*\/\//, '');
+  const urlWithExtension = urlWithoutScheme.endsWith('.git')
+    ? urlWithoutScheme
+    : `${urlWithoutScheme}.git`;
+  return urlWithExtension.replace(':', '/');
+};
+
+const toForwardSlashes = (p: string) => p.replace(/\\/g, '/');
+
+// Stable identifier from a git remote URL + project-root-relative path. Pure
+// function so it's trivially testable without mocking Storybook internals.
+// Returns null when the remote URL is empty/missing.
+export const computeStorybookId = (
+  remoteUrl: string | null | undefined,
+  projectRootPath: string
+): string | null => {
+  if (!remoteUrl) return null;
+  const payload = `${normalizeGitUrl(remoteUrl)}${toForwardSlashes(projectRootPath)}`;
+  return createHash('sha256').update('chromatic-storybook-id-salt').update(payload).digest('hex');
+};
+
+// IO wrapper. Pulls the git remote + project root from Storybook's common
+// utilities, then delegates to computeStorybookId. Same structural shape as
+// Storybook's telemetry anonymousId (git remote + relative project root),
+// salted independently so we never accidentally surface the telemetry id.
+export const getStorybookId = async (): Promise<string | null> => {
+  try {
+    const { executeCommandSync, getProjectRoot } = await import('storybook/internal/common');
+    const projectRootPath = relative(getProjectRoot(), process.cwd());
+    const remoteUrl = executeCommandSync({
+      command: 'git',
+      args: ['config', '--get', 'remote.origin.url'],
+      timeout: 1000,
+    });
+    return computeStorybookId(remoteUrl, projectRootPath);
+  } catch {
+    return null;
+  }
+};

--- a/src/utils/graphQLClient.tsx
+++ b/src/utils/graphQLClient.tsx
@@ -5,7 +5,7 @@ import { Client, ClientOptions, fetchExchange, mapExchange, Provider } from 'urq
 import { v4 as uuid } from 'uuid';
 
 import { ADDON_ID } from '../constants';
-import { ACCESS_TOKEN_KEY, CHROMATIC_API_URL } from '../env';
+import { ACCESS_TOKEN_KEY, ACCESS_TOKEN_KEY_LEGACY, CHROMATIC_API_URL } from '../env';
 
 let currentToken: string | null;
 let currentTokenExpiration: number | null;
@@ -24,6 +24,17 @@ const setCurrentToken = (token: string | null) => {
     localStorage.removeItem(ACCESS_TOKEN_KEY);
   }
 };
+
+// One-time migration: previous releases stored the token at the legacy
+// (un-scoped) key. If the new scoped key is empty but the legacy key still
+// holds a token, adopt it under the scoped key so users don't get logged
+// out by the upgrade. The legacy key is left in place — clearing it would
+// log out any other Storybook on the same origin still using the old
+// addon version.
+if (ACCESS_TOKEN_KEY !== ACCESS_TOKEN_KEY_LEGACY && !localStorage.getItem(ACCESS_TOKEN_KEY)) {
+  const legacyToken = localStorage.getItem(ACCESS_TOKEN_KEY_LEGACY);
+  if (legacyToken) localStorage.setItem(ACCESS_TOKEN_KEY, legacyToken);
+}
 
 setCurrentToken(localStorage.getItem(ACCESS_TOKEN_KEY));
 


### PR DESCRIPTION
## Summary

Today the addon stores the Chromatic access token in localStorage under a key that includes only `CHROMATIC_BASE_URL`:

```
chromatic/access-token/<CHROMATIC_BASE_URL>
```

localStorage is scoped to browser origin (host + port), so two Storybooks served on the same dev port (or one Storybook closed and another opened on the same port later) share the same store. When those Storybooks belong to different Chromatic accounts on the same Chromatic instance, the second one silently inherits the first one's token. Any subsequent API call (upload, share, GraphQL query) runs against the wrong account, with no UI signal that the user is signed in as someone else.

This PR adds a per-Storybook identifier to the token key so different Storybooks no longer share a token, even on the same origin.

## How the identifier is computed

The shape mirrors Storybook's own telemetry `anonymousId`: `sha256(salt + normalizedGitRemoteUrl + relativeProjectRootPath)`. We use a different salt so the id we compute is independent of the telemetry hash and cannot accidentally surface it.

- `git remote.origin.url` (read once at preset boot via Storybook's `executeCommandSync`) gets normalized so https/ssh URLs to the same repo collapse to a single id.
- `relative(getProjectRoot(), process.cwd())` separates monorepo Storybooks rooted at different sub-paths.
- When git is unavailable (no remote, no commits, repo not initialized, etc.) the id resolves to `null` and the manager falls back to a literal `'unscoped'` segment. Behavior in that case is unchanged from before.

## How it reaches the browser

The preset's `managerHead` hook computes the id once and injects it into the manager iframe as a script:

```html
<script>window.__CHROMATIC_STORYBOOK_ID__ = "<sha256 hex>";</script>
```

`env.ts` reads `window.__CHROMATIC_STORYBOOK_ID__` synchronously at module load and folds it into `ACCESS_TOKEN_KEY`:

```
chromatic/access-token/<CHROMATIC_BASE_URL>/<storybookId | 'unscoped'>
```

This avoids any async ceremony at module load time and keeps the existing sync token bootstrap in `graphQLClient.tsx` working untouched.

## Migration

A one-time migration on the manager copies any token sitting at the legacy unscoped key over to the new scoped key the first time the new code runs. Users do not get logged out by the upgrade. The legacy key is intentionally left in place so older addon installs running against the same origin continue to work.

## Caveats

- Two physical humans using the same Storybook installation cannot be told apart by this scheme. They share the same git remote, the same project root, and therefore the same id. That case still requires an explicit "Sign out" affordance in the UI, which is out of scope for this PR.
- The id is recomputed on every Storybook boot, but the result is deterministic for the same repo + path, so the localStorage key is stable across boots.

## Test plan

- [ ] `yarn vitest run` (16 files, 124 tests passing locally).
- [ ] `yarn lint` (no new errors; the two pre-existing warnings in `preset.share.test.ts` are unrelated).
- [ ] Open Storybook A on `:6006`, sign in to Chromatic. Stop. Run Storybook B on `:6006` from a different repo. Confirm the panel shows "signed out" rather than picking up A's token.
- [ ] Same repo + same path on `:6006` and `:6007`: still isolated by browser origin. No regression.
- [ ] Repo with no git remote: token still persists across reloads (falls back to the `'unscoped'` segment).
- [ ] Upgrade path: install the new addon over an existing one with a token at the legacy key. Reload Storybook. Confirm still signed in (migration ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)