### PR TITLE
Consolidate auth state into a single AuthStore

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,7 +108,7 @@ export default [
         },
         {
           selector:
-            "CallExpression[callee.name=/^(setTimeout|setInterval)$/][arguments.0.type=/^(Literal|TemplateLiteral)$/]",
+            'CallExpression[callee.name=/^(setTimeout|setInterval)$/][arguments.0.type=/^(Literal|TemplateLiteral)$/]',
           message: 'String/template-form setTimeout/setInterval is banned',
         },
         {

--- a/src/utils/authStore.ts
+++ b/src/utils/authStore.ts
@@ -1,0 +1,177 @@
+import { v4 as uuid } from 'uuid';
+
+import { ADDON_ID } from '../constants';
+import { ACCESS_TOKEN_KEY } from '../env';
+import { type AuthSession, AuthSessionSchema, refreshAccessToken } from './requestAccessToken';
+
+const REFRESH_TIMEOUT_MS = 10_000;
+const SESSION_EXPIRED_EVENT = `${ADDON_ID}/session-expired`;
+
+const setBrowserTimeout = (...args: Parameters<typeof globalThis.setTimeout>) =>
+  (typeof window !== 'undefined' ? window : globalThis).setTimeout(...args);
+const clearBrowserTimeout = (...args: Parameters<typeof globalThis.clearTimeout>) =>
+  (typeof window !== 'undefined' ? window : globalThis).clearTimeout(...args);
+
+type Subscriber = (token: string | null) => void;
+
+const parseStoredAuth = (rawAuth: string): AuthSession | null => {
+  // Legacy format used to persist only a raw JWT string.
+  if (!rawAuth.trim().startsWith('{')) {
+    return null;
+  }
+  const parsed = AuthSessionSchema.safeParse(JSON.parse(rawAuth));
+  return parsed.success ? parsed.data : null;
+};
+
+class AuthStore {
+  private auth: AuthSession | null = null;
+  private generation = 0;
+  private refreshing: Promise<void> | null = null;
+  private refreshAbort: AbortController | null = null;
+  private readonly subscribers = new Set<Subscriber>();
+  private readonly fallbackSessionId = uuid();
+
+  constructor() {
+    this.loadFromStorage();
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', this.handleStorageEvent);
+    }
+  }
+
+  private get storage(): Storage | null {
+    return typeof localStorage === 'undefined' ? null : localStorage;
+  }
+
+  private notifySubscribers() {
+    const token = this.getToken();
+    this.subscribers.forEach((cb) => cb(token));
+  }
+
+  private notifySessionExpired() {
+    if (typeof window === 'undefined') return;
+    window.dispatchEvent(new window.CustomEvent(SESSION_EXPIRED_EVENT));
+  }
+
+  private persist() {
+    const storage = this.storage;
+    if (!storage) return;
+    if (this.auth) storage.setItem(ACCESS_TOKEN_KEY, JSON.stringify(this.auth));
+    else storage.removeItem(ACCESS_TOKEN_KEY);
+  }
+
+  private applyParsedAuth(rawAuth: string | null) {
+    if (!rawAuth) {
+      this.setAuth(null, { persist: false });
+      return;
+    }
+    try {
+      const parsed = parseStoredAuth(rawAuth);
+      if (!parsed) {
+        this.storage?.removeItem(ACCESS_TOKEN_KEY);
+        this.setAuth(null, { persist: false });
+        return;
+      }
+      this.setAuth(parsed, { persist: false });
+    } catch {
+      this.storage?.removeItem(ACCESS_TOKEN_KEY);
+      this.setAuth(null, { persist: false });
+    }
+  }
+
+  private loadFromStorage() {
+    this.applyParsedAuth(this.storage?.getItem(ACCESS_TOKEN_KEY) ?? null);
+  }
+
+  private handleStorageEvent = (event: StorageEvent) => {
+    if (event.key !== ACCESS_TOKEN_KEY) return;
+    this.applyParsedAuth(event.newValue);
+  };
+
+  private async attemptRefresh() {
+    const auth = this.auth;
+    if (!auth) {
+      throw new Error('Token refresh failed (401)');
+    }
+    const generation = this.generation;
+    const abortController = new AbortController();
+    this.refreshAbort = abortController;
+    const timeoutId = setBrowserTimeout(() => abortController.abort(), REFRESH_TIMEOUT_MS);
+    try {
+      const nextAuth = await refreshAccessToken({
+        subdomain: auth.subdomain,
+        refreshToken: auth.refreshToken,
+        sessionId: auth.sessionId,
+        signal: abortController.signal,
+      });
+      if (generation !== this.generation) return;
+      this.setAuth(nextAuth);
+    } finally {
+      clearBrowserTimeout(timeoutId);
+      this.refreshAbort = null;
+    }
+  }
+
+  getAuth() {
+    return this.auth;
+  }
+
+  getToken() {
+    return this.auth?.accessToken ?? null;
+  }
+
+  getSessionId() {
+    return this.auth?.sessionId || this.fallbackSessionId;
+  }
+
+  setAuth(auth: AuthSession | null, { persist = true }: { persist?: boolean } = {}) {
+    this.auth = auth;
+    if (persist) this.persist();
+    this.notifySubscribers();
+  }
+
+  setToken(token: string | null) {
+    if (!token) {
+      this.clear();
+      return;
+    }
+    if (this.auth) this.setAuth({ ...this.auth, accessToken: token });
+  }
+
+  clear() {
+    this.generation += 1;
+    this.refreshAbort?.abort();
+    this.refreshAbort = null;
+    this.refreshing = null;
+    this.setAuth(null);
+  }
+
+  subscribe(cb: Subscriber) {
+    this.subscribers.add(cb);
+    return () => {
+      this.subscribers.delete(cb);
+    };
+  }
+
+  async refresh() {
+    if (!this.auth) {
+      this.clear();
+      return;
+    }
+    if (!this.refreshing) {
+      this.refreshing = this.attemptRefresh()
+        .catch((error) => {
+          console.warn('Session expired. Please sign in again.');
+          this.clear();
+          this.notifySessionExpired();
+          throw error;
+        })
+        .finally(() => {
+          this.refreshing = null;
+        });
+    }
+    await this.refreshing;
+  }
+}
+
+export const authStore = new AuthStore();
+export const SESSION_EXPIRED_EVENT_NAME = SESSION_EXPIRED_EVENT;

--- a/src/utils/graphQLClient.tsx
+++ b/src/utils/graphQLClient.tsx
@@ -2,156 +2,27 @@ import { authExchange } from '@urql/exchange-auth';
 import React from 'react';
 import { useAddonState } from 'storybook/manager-api';
 import { Client, type ClientOptions, fetchExchange, mapExchange, Provider } from 'urql';
-import { v4 as uuid } from 'uuid';
 
 import { ADDON_ID } from '../constants';
-import { ACCESS_TOKEN_KEY, CHROMATIC_API_URL } from '../env';
-import { type AuthSession, AuthSessionSchema, refreshAccessToken } from './requestAccessToken';
+import { CHROMATIC_API_URL } from '../env';
+import { authStore, SESSION_EXPIRED_EVENT_NAME } from './authStore';
+import type { AuthSession } from './requestAccessToken';
 
-const REFRESH_TIMEOUT_MS = 10_000;
-const getStorage = () => (typeof localStorage === 'undefined' ? null : localStorage);
-const SESSION_EXPIRED_EVENT = `${ADDON_ID}/session-expired`;
-const setBrowserTimeout = (...args: Parameters<typeof globalThis.setTimeout>) =>
-  (typeof window !== 'undefined' ? window : globalThis).setTimeout(...args);
-const clearBrowserTimeout = (...args: Parameters<typeof globalThis.clearTimeout>) =>
-  (typeof window !== 'undefined' ? window : globalThis).clearTimeout(...args);
-
-let currentAuth: AuthSession | null = null;
-let currentToken: string | null = null;
-let refreshPromise: Promise<void> | null = null;
-let refreshAbortController: AbortController | null = null;
-let authGeneration = 0;
-const tokenSubscribers = new Set<(token: string | null) => void>();
-const fallbackSessionId = uuid();
-
-const notifyTokenSubscribers = () => {
-  tokenSubscribers.forEach((subscriber) => {
-    subscriber(currentToken);
-  });
-};
-
-const subscribeToTokenUpdates = (subscriber: (token: string | null) => void) => {
-  tokenSubscribers.add(subscriber);
-  return () => {
-    tokenSubscribers.delete(subscriber);
-  };
-};
-
-const notifySessionExpired = () => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  window.dispatchEvent(new window.CustomEvent(SESSION_EXPIRED_EVENT));
-};
-
-const persistCurrentAuth = () => {
-  const storage = getStorage();
-  if (!storage) {
-    return;
-  }
-  if (currentAuth) {
-    storage.setItem(ACCESS_TOKEN_KEY, JSON.stringify(currentAuth));
-  } else {
-    storage.removeItem(ACCESS_TOKEN_KEY);
-  }
-};
-
-const setCurrentAuth = (auth: AuthSession | null) => {
-  currentAuth = auth;
-  currentToken = auth?.accessToken ?? null;
-
-  persistCurrentAuth();
-  notifyTokenSubscribers();
-};
-
-const clearCurrentAuth = () => {
-  authGeneration += 1;
-  refreshAbortController?.abort();
-  refreshAbortController = null;
-  refreshPromise = null;
-  setCurrentAuth(null);
-};
-
-const setCurrentToken = (token: string | null) => {
-  if (!token) {
-    clearCurrentAuth();
-    return;
-  }
-  if (currentAuth) {
-    setCurrentAuth({ ...currentAuth, accessToken: token });
-  }
-};
-
-const parseStoredAuth = (rawAuth: string): AuthSession | null => {
-  // Legacy format used to persist only a raw JWT string.
-  if (!rawAuth.trim().startsWith('{')) {
-    return null;
-  }
-  const parsed = AuthSessionSchema.safeParse(JSON.parse(rawAuth));
-  return parsed.success ? parsed.data : null;
-};
-
-const initializeCurrentAuthFromStorage = () => {
-  const storage = getStorage();
-  const storedAuth = storage?.getItem(ACCESS_TOKEN_KEY);
-  if (!storedAuth) {
-    setCurrentAuth(null);
-    return;
-  }
-  try {
-    const parsed = parseStoredAuth(storedAuth);
-    if (!parsed) {
-      storage?.removeItem(ACCESS_TOKEN_KEY);
-      setCurrentAuth(null);
-      return;
-    }
-    setCurrentAuth(parsed);
-  } catch {
-    storage?.removeItem(ACCESS_TOKEN_KEY);
-    setCurrentAuth(null);
-  }
-};
-
-initializeCurrentAuthFromStorage();
-if (typeof window !== 'undefined') {
-  window.addEventListener('storage', (event) => {
-    if (event.key !== ACCESS_TOKEN_KEY) {
-      return;
-    }
-    if (!event.newValue) {
-      setCurrentAuth(null);
-      return;
-    }
-    try {
-      const parsed = parseStoredAuth(event.newValue);
-      if (!parsed) {
-        getStorage()?.removeItem(ACCESS_TOKEN_KEY);
-        setCurrentAuth(null);
-        return;
-      }
-      setCurrentAuth(parsed);
-    } catch {
-      getStorage()?.removeItem(ACCESS_TOKEN_KEY);
-      setCurrentAuth(null);
-    }
-  });
-}
-
-export const setAuthenticatedSession = (auth: AuthSession) => setCurrentAuth(auth);
+export const setAuthenticatedSession = (auth: AuthSession) => authStore.setAuth(auth);
 
 export const useAccessToken = () => {
   // We use an object rather than a straight boolean here due to https://github.com/storybookjs/storybook/pull/23991
   const [{ token }, setTokenState] = useAddonState<{ token: string | null }>(
     `${ADDON_ID}/accessToken`,
-    { token: currentToken }
+    { token: authStore.getToken() }
   );
 
   const updateToken = React.useCallback((newToken: string | null) => {
-    setCurrentToken(newToken);
+    authStore.setToken(newToken);
   }, []);
 
   React.useEffect(
-    () => subscribeToTokenUpdates((nextToken) => setTokenState({ token: nextToken })),
+    () => authStore.subscribe((nextToken) => setTokenState({ token: nextToken })),
     [setTokenState]
   );
 
@@ -162,58 +33,9 @@ export const getFetchOptions = (token?: string, sessionId?: string) => ({
   headers: {
     Accept: '*/*',
     ...(token && { Authorization: `Bearer ${token}` }),
-    'X-Chromatic-Session-ID': sessionId || currentAuth?.sessionId || fallbackSessionId,
+    'X-Chromatic-Session-ID': sessionId || authStore.getSessionId(),
   },
 });
-
-const attemptTokenRefresh = async () => {
-  const auth = currentAuth;
-  if (!auth) {
-    throw new Error('Token refresh failed (401)');
-  }
-
-  const generation = authGeneration;
-  const abortController = new AbortController();
-  refreshAbortController = abortController;
-  const timeoutId = setBrowserTimeout(() => abortController.abort(), REFRESH_TIMEOUT_MS);
-  try {
-    const nextAuth = await refreshAccessToken({
-      subdomain: auth.subdomain,
-      refreshToken: auth.refreshToken,
-      sessionId: auth.sessionId,
-      signal: abortController.signal,
-    });
-    if (generation !== authGeneration) {
-      return;
-    }
-    setCurrentAuth(nextAuth);
-  } finally {
-    clearBrowserTimeout(timeoutId);
-    refreshAbortController = null;
-  }
-};
-
-const refreshCurrentSession = async () => {
-  if (!currentAuth) {
-    clearCurrentAuth();
-    return;
-  }
-
-  if (!refreshPromise) {
-    refreshPromise = attemptTokenRefresh()
-      .catch((error) => {
-        console.warn('Session expired. Please sign in again.');
-        clearCurrentAuth();
-        notifySessionExpired();
-        throw error;
-      })
-      .finally(() => {
-        refreshPromise = null;
-      });
-  }
-
-  await refreshPromise;
-};
 
 export const createClient = (options?: Partial<ClientOptions>) =>
   new Client({
@@ -224,14 +46,15 @@ export const createClient = (options?: Partial<ClientOptions>) =>
         onResult(result) {
           // Not all queries contain the `viewer` field, in which case it will be `undefined`.
           // When we do retrieve the field but the token is invalid, it will be `null`.
-          if (result.data?.viewer === null) setCurrentToken(null);
+          if (result.data?.viewer === null) authStore.setToken(null);
         },
       }),
       authExchange(async (utils) => {
         return {
           addAuthToOperation(operation) {
-            if (!currentToken) return operation;
-            return utils.appendHeaders(operation, { Authorization: `Bearer ${currentToken}` });
+            const token = authStore.getToken();
+            if (!token) return operation;
+            return utils.appendHeaders(operation, { Authorization: `Bearer ${token}` });
           },
 
           // Determine if the current error is an authentication error.
@@ -241,12 +64,12 @@ export const createClient = (options?: Partial<ClientOptions>) =>
 
           // Refresh access token on demand after auth failures.
           async refreshAuth() {
-            await refreshCurrentSession();
+            await authStore.refresh();
           },
 
           // Reactive auth: only refresh after auth failures, not pre-emptively by token expiry.
           willAuthError() {
-            return !currentToken;
+            return !authStore.getToken();
           },
         };
       }),
@@ -257,13 +80,13 @@ export const createClient = (options?: Partial<ClientOptions>) =>
   });
 
 export const __testUtils = {
-  getCurrentAuth: () => currentAuth,
-  clearCurrentAuth,
-  subscribeToTokenUpdates,
-  refreshCurrentSession,
+  getCurrentAuth: () => authStore.getAuth(),
+  clearCurrentAuth: () => authStore.clear(),
+  subscribeToTokenUpdates: (cb: (token: string | null) => void) => authStore.subscribe(cb),
+  refreshCurrentSession: () => authStore.refresh(),
 };
 
-export const sessionExpiredEventName = SESSION_EXPIRED_EVENT;
+export const sessionExpiredEventName = SESSION_EXPIRED_EVENT_NAME;
 
 export const GraphQLClientProvider = ({
   children,


### PR DESCRIPTION
## Summary
- Extract `currentAuth`, `currentToken`, `refreshPromise`, `refreshAbortController`, `authGeneration`, and the token-subscriber set out of `graphQLClient.tsx` into a single `AuthStore` class in `src/utils/authStore.ts`. The store also owns initial `localStorage` load, the cross-tab `storage` listener, the session-expired event, and the in-flight refresh / single-flight logic.
- Reduce `graphQLClient.tsx` to a thin wrapper that maps Storybook/urql concerns onto the store. Public API (`setAuthenticatedSession`, `useAccessToken`, `getFetchOptions`, `sessionExpiredEventName`, `__testUtils`, `createClient`, `GraphQLClientProvider`) is unchanged.
- No behaviour change intended; the existing `graphQLClient.test.ts` and `useShareAuth.test.ts` suites pass against the new store via the same `__testUtils` surface.

## Why
PR #425 ended up with six free module variables in `graphQLClient.tsx`, each mutated by a different helper. The refresh/clear race depended on reading them in the right order, and any new caller had to know which helper to reach for. The CCG review (codex + gemini) flagged this as the main remaining clean-up. Encapsulating them removes the implicit coupling and makes the refresh/clear ordering local to one class.

Stacked on top of #425 (`refresh-token`); review and merge after that PR.

## Test plan
- [x] `yarn lint`
- [x] `yarn tsc --noEmit` (no new errors on touched files; pre-existing storybook decl noise unchanged)
- [x] `yarn vitest run` — 121/121 pass, including `graphQLClient.test.ts` and `useShareAuth.test.ts`
- [ ] Manual smoke: sign in, sign out, expire-and-refresh paths in addon panel