### PR TITLE
Refresh auth preemptively before token expiry

### DIFF
--- a/src/utils/graphQLClient.test.ts
+++ b/src/utils/graphQLClient.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AuthSession } from '../auth/requestAccessToken';
 import { ACCESS_TOKEN_KEY } from '../env';
-import { __testUtils, setAuthenticatedSession } from './graphQLClient';
+import { __testUtils, createClient, setAuthenticatedSession } from './graphQLClient';
 
 const createAuth = (overrides: Partial<AuthSession> = {}): AuthSession => ({
   version: 2,
@@ -12,6 +12,16 @@ const createAuth = (overrides: Partial<AuthSession> = {}): AuthSession => ({
   ...overrides,
 });
 
+const createJwtWithExp = (exp: number) => {
+  const encodeSegment = (value: object) =>
+    globalThis
+      .btoa(JSON.stringify(value))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
+
+  return `${encodeSegment({ alg: 'HS256', typ: 'JWT' })}.${encodeSegment({ exp })}.signature`;
+};
 const ensureLocalStorage = () => {
   if (globalThis.localStorage) {
     return;
@@ -165,5 +175,83 @@ describe('graphQLClient refresh auth', () => {
 
     expect(__testUtils.getCurrentAuth()).toBeNull();
     expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
+  });
+
+  it('does not clear auth when viewer is null without an auth error', async () => {
+    setAuthenticatedSession(createAuth());
+    const client = createClient();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            viewer: null,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const result = await client.query('{ viewer { __typename } }', {}).toPromise();
+
+    expect(result.error).toBeUndefined();
+    expect(__testUtils.getCurrentAuth()).toMatchObject({
+      accessToken: 'access-token-1',
+      refreshToken: 'refresh-token-1',
+    });
+  });
+
+  it('refreshes session before query when token is near expiry', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const soonToExpireToken = createJwtWithExp(nowSeconds + 30);
+    const refreshedToken = createJwtWithExp(nowSeconds + 3600);
+    setAuthenticatedSession(
+      createAuth({
+        accessToken: soonToExpireToken,
+      })
+    );
+
+    const client = createClient();
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: refreshedToken,
+            refresh_token: 'refresh-token-2',
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              viewer: null,
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      );
+
+    await client.query('{ viewer { __typename } }', {}).toPromise();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/\/token$/),
+      expect.objectContaining({
+        method: 'POST',
+      })
+    );
+    expect(__testUtils.getCurrentAuth()).toMatchObject({
+      accessToken: refreshedToken,
+      refreshToken: 'refresh-token-2',
+    });
   });
 });

--- a/src/utils/graphQLClient.tsx
+++ b/src/utils/graphQLClient.tsx
@@ -1,13 +1,14 @@
 import { authExchange } from '@urql/exchange-auth';
 import React from 'react';
 import { useAddonState } from 'storybook/manager-api';
-import { Client, type ClientOptions, fetchExchange, mapExchange, Provider } from 'urql';
+import { Client, type ClientOptions, fetchExchange, Provider } from 'urql';
 
 import { authStore, SESSION_EXPIRED_EVENT_NAME } from '../auth/authStore';
 import type { AuthSession } from '../auth/requestAccessToken';
 import { ADDON_ID } from '../constants';
 import { CHROMATIC_API_URL } from '../env';
 
+const PREEMPTIVE_REFRESH_WINDOW_SECONDS = 60;
 export const setAuthenticatedSession = (auth: AuthSession) => authStore.setAuth(auth);
 
 export const useAccessToken = () => {
@@ -37,18 +38,40 @@ export const getFetchOptions = (token?: string, sessionId?: string) => ({
   },
 });
 
+const decodeJwtExpiration = (token: string): number | null => {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) return null;
+
+    // JWT payload is base64url-encoded; convert to base64 and restore required padding for atob().
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = '='.repeat((4 - (normalized.length % 4)) % 4);
+    const parsed = JSON.parse(globalThis.atob(`${normalized}${padding}`)) as { exp?: unknown };
+    return typeof parsed.exp === 'number' ? parsed.exp : null;
+  } catch {
+    return null;
+  }
+};
+
+const shouldPreemptivelyRefreshSession = () => {
+  const token = authStore.getToken();
+  if (!token) {
+    return false;
+  }
+
+  const expiration = decodeJwtExpiration(token);
+  if (!expiration) {
+    return false;
+  }
+
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+  return expiration <= nowInSeconds + PREEMPTIVE_REFRESH_WINDOW_SECONDS;
+};
+
 export const createClient = (options?: Partial<ClientOptions>) =>
   new Client({
     url: CHROMATIC_API_URL,
     exchanges: [
-      // We don't use cacheExchange, because it would inadvertently share data between stories.
-      mapExchange({
-        onResult(result) {
-          // Not all queries contain the `viewer` field, in which case it will be `undefined`.
-          // When we do retrieve the field but the token is invalid, it will be `null`.
-          if (result.data?.viewer === null) authStore.setToken(null);
-        },
-      }),
       authExchange(async (utils) => {
         return {
           addAuthToOperation(operation) {
@@ -67,9 +90,9 @@ export const createClient = (options?: Partial<ClientOptions>) =>
             await authStore.refresh();
           },
 
-          // Reactive auth: only refresh after auth failures, not pre-emptively by token expiry.
+          // Refresh when missing token or when token is about to expire.
           willAuthError() {
-            return !authStore.getToken();
+            return !authStore.getToken() || shouldPreemptivelyRefreshSession();
           },
         };
       }),


### PR DESCRIPTION
Instead of forcing a logout whenever GraphQL returns `viewer: null`, add proactive token refresh based on the JWT `exp` claim. Trigger a token refresh when the access token is about to expire within 60 seconds.

This is necessary because the forced logout means lazy token refreshing (afterwards) doesn't work. By not forcing the logout on `viewer: null` but only a `401` response, this should already fix it, but it's even better to refresh preemtively.