### PR TITLE
Update Codecov to fix GPG issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
         run: yarn test
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov started failing with a GPG verification issue. This was updated in the later versions of their Action. 

Issue for reference: [https://github.com/codecov/codecov-action/issues/1956](https://github.com/codecov/codecov-action/issues/1956)