### PR TITLE
Add view telemetry for top-of-funnel share screens

### DIFF
--- a/src/screens/SharePopup/SharePopup.test.tsx
+++ b/src/screens/SharePopup/SharePopup.test.tsx
@@ -19,12 +19,22 @@ let reducerState: ShareReducerState = {
   shareTriggeredId: null,
 };
 let shareProgressValue: ShareProgress | undefined = undefined;
+let tokenValue: string | null = 'token-123';
+
+// Refs persist across invocations (keyed by hook call order) so that calling
+// the component repeatedly behaves like re-rendering the same mount.
+const refStore: { current: unknown }[] = [];
+let refIndex = 0;
 
 vi.mock('react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react')>();
   return {
     ...actual,
-    useRef: (initial: unknown) => ({ current: initial }),
+    useRef: (initial: unknown) => {
+      const ref = (refStore[refIndex] ??= { current: initial });
+      refIndex += 1;
+      return ref;
+    },
     useCallback: (fn: unknown) => fn,
     // useEffect: run synchronously so effects fire during the "render" call
     useEffect: (fn: () => (() => void) | void) => {
@@ -41,7 +51,7 @@ vi.mock('storybook/manager-api', () => ({
 }));
 
 vi.mock('../../utils/graphQLClient', () => ({
-  useAccessToken: () => ['token-123', mocks.updateToken],
+  useAccessToken: () => [tokenValue, mocks.updateToken],
 }));
 
 vi.mock('../../auth/authStore', () => ({
@@ -88,6 +98,7 @@ function makeApi() {
 
 // Call the component as a plain function to trigger all useEffect calls
 function invokeSharePopup() {
+  refIndex = 0;
   (SharePopup as any)({ api: makeApi() });
 }
 
@@ -108,7 +119,13 @@ afterEach(() => {
     shareTriggeredId: null,
   };
   shareProgressValue = undefined;
+  tokenValue = 'token-123';
+  refStore.length = 0;
 });
+
+function viewEmits(action: string) {
+  return mocks.channel.emit.mock.calls.filter(([, payload]) => payload?.action === action);
+}
 
 describe('SharePopup', () => {
   describe('stale shareProgress filtering by shareRequestId', () => {
@@ -320,6 +337,62 @@ describe('SharePopup', () => {
         ([action]) => action?.type === 'AUTO_SKIP_TO_UPLOADING'
       );
       expect(autoSkipDispatches).toHaveLength(0);
+    });
+  });
+
+  describe('top-of-funnel view telemetry', () => {
+    it('emits share-welcome-viewed when the welcome screen is shown signed out', () => {
+      tokenValue = null;
+      setReducer({ screen: { status: 'welcome' } });
+
+      invokeSharePopup();
+
+      expect(viewEmits('share-welcome-viewed')).toHaveLength(1);
+    });
+
+    it('does not re-emit the view event on re-render of the same screen', () => {
+      tokenValue = null;
+      setReducer({ screen: { status: 'welcome' } });
+
+      invokeSharePopup();
+      invokeSharePopup();
+
+      expect(viewEmits('share-welcome-viewed')).toHaveLength(1);
+    });
+
+    it('emits once per screen entry and re-fires when returning to a screen', () => {
+      tokenValue = null;
+
+      setReducer({ screen: { status: 'idle' } });
+      invokeSharePopup();
+      setReducer({ screen: { status: 'subdomain' } });
+      invokeSharePopup();
+      setReducer({ screen: { status: 'idle' } });
+      invokeSharePopup();
+
+      expect(viewEmits('share-signin-viewed')).toHaveLength(2);
+      expect(viewEmits('share-sso-viewed')).toHaveLength(1);
+    });
+
+    it('does not emit view events when signed in, since those screens auto-skip', () => {
+      setReducer({ screen: { status: 'welcome' } });
+
+      invokeSharePopup();
+
+      expect(viewEmits('share-welcome-viewed')).toHaveLength(0);
+      expect(viewEmits('share-signin-viewed')).toHaveLength(0);
+      expect(viewEmits('share-sso-viewed')).toHaveLength(0);
+    });
+
+    it('does not emit view events for screens outside the funnel entry', () => {
+      tokenValue = null;
+      setReducer({ screen: { status: 'uploading', shareUrl: '' } });
+
+      invokeSharePopup();
+
+      expect(viewEmits('share-welcome-viewed')).toHaveLength(0);
+      expect(viewEmits('share-signin-viewed')).toHaveLength(0);
+      expect(viewEmits('share-sso-viewed')).toHaveLength(0);
     });
   });
 

--- a/src/screens/SharePopup/SharePopup.test.tsx
+++ b/src/screens/SharePopup/SharePopup.test.tsx
@@ -124,7 +124,10 @@ afterEach(() => {
 });
 
 function viewEmits(action: string) {
-  return mocks.channel.emit.mock.calls.filter(([, payload]) => payload?.action === action);
+  return mocks.channel.emit.mock.calls.filter(
+    ([eventName, payload]) =>
+      eventName === 'chromaui/addon-visual-tests/telemetry' && payload?.action === action
+  );
 }
 
 describe('SharePopup', () => {

--- a/src/screens/SharePopup/useShareExecution.ts
+++ b/src/screens/SharePopup/useShareExecution.ts
@@ -5,7 +5,16 @@ import { authStore } from '../../auth/authStore';
 import { CANCEL_SHARE, START_SHARE, TELEMETRY } from '../../constants';
 import type { GitInfoPayload, ShareProgress } from '../../types';
 import { applyProgress } from './shareMachine';
-import type { ShareAction, ShareReducerState } from './types';
+import type { ShareAction, ShareReducerState, ShareState } from './types';
+
+// Top-of-funnel screens report a view event so we can measure drop-off before
+// publish/auth. They only actually render when signed out; with a token they
+// auto-skip straight to uploading.
+const VIEW_TELEMETRY_ACTIONS: Partial<Record<ShareState['status'], string>> = {
+  welcome: 'share-welcome-viewed',
+  idle: 'share-signin-viewed',
+  subdomain: 'share-sso-viewed',
+};
 
 type Params = {
   api: API;
@@ -92,6 +101,17 @@ export function useShareExecution({
     }
     prevShareStatusRef.current = reducerState.screen.status;
   }, [emitTelemetry, reducerState.screen.status]);
+
+  // One view event per screen entry: the ref suppresses re-renders of the same
+  // screen, while leaving and returning (e.g. subdomain → back → idle) fires again.
+  const lastViewedScreenRef = useRef<string | null>(null);
+  useEffect(() => {
+    const viewAction = VIEW_TELEMETRY_ACTIONS[screenStatus];
+    if (viewAction && !token && lastViewedScreenRef.current !== screenStatus) {
+      emitTelemetry(viewAction);
+    }
+    lastViewedScreenRef.current = screenStatus;
+  }, [emitTelemetry, screenStatus, token]);
 
   const progressCtxRef = useRef({
     reducerState,

--- a/src/screens/SharePopup/useShareExecution.ts
+++ b/src/screens/SharePopup/useShareExecution.ts
@@ -104,7 +104,7 @@ export function useShareExecution({
 
   // One view event per screen entry: the ref suppresses re-renders of the same
   // screen, while leaving and returning (e.g. subdomain → back → idle) fires again.
-  const lastViewedScreenRef = useRef<string | null>(null);
+  const lastViewedScreenRef = useRef<ShareState['status'] | null>(null);
   useEffect(() => {
     const viewAction = VIEW_TELEMETRY_ACTIONS[screenStatus];
     if (viewAction && !token && lastViewedScreenRef.current !== screenStatus) {


### PR DESCRIPTION
## What

The share flow reported telemetry from the `uploading` step onward, but the top of the funnel was dark: the welcome, sign-in, and SSO subdomain screens emitted nothing, so we couldn't measure drop-off before publish/auth.

This adds three view events, emitted via the existing `emitTelemetry` channel in `useShareExecution`:

| Screen | Telemetry before | Telemetry after |
|---|---|---|
| `welcome` | ❌ none | ✅ `share-welcome-viewed` |
| `idle` (sign-in) | ❌ none | ✅ `share-signin-viewed` |
| `subdomain` (SAML SSO) | ❌ none | ✅ `share-sso-viewed` |
| `uploading` | ✅ `share-initiated`, `share-url-received`, `share-url-copied`, `share-canceled` | unchanged |
| `complete` | ✅ `share-upload-completed`, `share-url-copied` | unchanged |
| `error` | ✅ `share-failed`, `share-auth-retry`, `share-auth-completed` | unchanged |

Semantics:
- One event per screen **entry** — a ref suppresses re-renders of the same screen, and leaving/returning (e.g. subdomain → back → idle) fires again.
- Skipped when a token is present, since welcome/idle/subdomain auto-skip straight to uploading and are never actually shown.
- Payload follows the existing `share-*` shape (`{ action, entryPoint: 'toolbar' }`).

## Manual QA

Ran the addon's own Storybook (`yarn storybook`, addon loaded from source) signed out, with a listener on the `chromaui/addon-visual-tests/telemetry` channel event, and walked: open Share popover → Publish & copy link → Connect with SAML SSO → Back. Captured event sequence (each exactly once per view):

```
share-welcome-viewed   (popover opened on welcome)
share-signin-viewed    (clicked "Publish & copy link" while signed out)
share-sso-viewed       (clicked "Connect with SAML SSO")
share-signin-viewed    (clicked "Back" — re-entry fires again)
```

All four also arrived at the Node-side `TELEMETRY` preset handler (logged as `eventType: addon-visual-tests` with `addonVersion` enrichment via `STORYBOOK_TELEMETRY_DEBUG`). Re-rendering the open popover produced no duplicate events. The post-auth events (`share-initiated` etc.) are not reachable in this signed-out QA pass; their code paths are untouched and remain covered by the existing unit tests.

## Tests

- 5 new tests in `SharePopup.test.tsx`: fires on entry, no double-fire on re-render, once per entry with re-fire on return, suppressed when signed in, and no view events for non-funnel screens.
- Test harness now persists `useRef` values across invocations (keyed by hook call order) so repeated calls behave like re-renders; existing 12 tests unchanged and passing.
- `yarn typecheck`, `yarn lint`, `yarn vitest run` (21 files, 176 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)